### PR TITLE
feat: add config validation and fix silenced errors

### DIFF
--- a/docs/tickets/3-error-handling-config-validation-pr-review.md
+++ b/docs/tickets/3-error-handling-config-validation-pr-review.md
@@ -1,0 +1,166 @@
+# PR Review: Phase 3 - Error Handling Improvements & Config Validation
+
+**Ticket:** #3
+**Date:** 2026-02-05
+**Reviewers:** Claude, Gemini (gemini-2.5-pro), Codex (gpt-5.2-codex)
+
+---
+
+## Summary
+
+The implementation adds config validation and fixes a silenced error in the lexer. While the overall code quality is good, **critical issues were identified** that must be fixed before merging.
+
+---
+
+## Consensus Decision: REQUEST CHANGES
+
+All three reviewers agree changes are needed before approval.
+
+---
+
+## Issues Found
+
+### 🔴 CRITICAL: PATH Command Validation vs Execution Mismatch
+
+**Severity:** Critical
+**File:** `internal/config/validate.go` (validation) + `internal/commands/generate.go:163` (execution)
+**Identified by:** Codex
+
+**Problem:**
+- Validation allows PATH-resolved commands (e.g., `echo`, `git`) via `exec.LookPath`
+- However, `runCommand()` executes hooks using `filepath.Join(dir, hook[0])`
+- This means `echo` becomes `/current/dir/echo` which doesn't exist
+- **Result:** Validation passes, runtime fails
+
+**Fix Required:**
+Either:
+1. Change `runCommand()` to use `exec.Command(hook[0], hook[1:]...)` directly (let OS resolve PATH)
+2. Or change validation to reject bare commands without path separators
+
+**Recommendation:** Option 1 - Fix `runCommand()` to match validation behavior.
+
+---
+
+### 🟡 HIGH: Missing Executable Permission Check
+
+**Severity:** High
+**File:** `internal/config/validate.go:89-96`
+**Identified by:** Gemini, Codex
+
+**Problem:**
+- `validateHooks` uses `os.Stat` to check if hook file exists
+- Does not verify the file has execute permissions
+- Does not verify the path is not a directory
+- **Result:** Validation passes for non-executable files, runtime fails with "permission denied"
+
+**Fix Required:**
+Add checks in `validateHooks` for path-based hooks:
+1. Verify file is not a directory (`info.IsDir()`)
+2. Verify file has execute permission (`info.Mode()&0111 != 0` on POSIX)
+
+---
+
+### 🟡 MEDIUM: Whitespace Normalization Inconsistency
+
+**Severity:** Medium
+**File:** `internal/config/validate.go:81`
+**Identified by:** Codex
+
+**Problem:**
+- Validation trims whitespace: `cmd := strings.TrimSpace(hook[0])`
+- Execution uses original value: `hook[0]`
+- A hook like `["  echo"]` passes validation but fails execution
+
+**Fix Required:**
+Validation should reject commands with leading/trailing whitespace rather than silently trimming, OR the trimmed value should be used consistently.
+
+---
+
+### 🟢 LOW: Test Platform Dependency
+
+**Severity:** Low
+**File:** `internal/config/validate_test.go:94-104`
+**Identified by:** Codex
+
+**Problem:**
+- `TestUT_Validate_ValidHookInPath` assumes `echo` is in PATH
+- On Windows, `echo` is a shell builtin and `exec.LookPath("echo")` may fail
+- Test is platform-flaky
+
+**Fix Suggested:**
+Use a more portable command or skip test on Windows.
+
+---
+
+### 🟢 LOW: Shared Template Parse Failure Handling
+
+**Severity:** Low (design decision)
+**File:** `internal/parser/lexer.go:82-87`
+**Identified by:** Codex
+
+**Problem:**
+- Shared template parse failures are logged but ignored
+- Execution continues with partially loaded templates
+- Could lead to confusing downstream errors
+
+**Note:** This matches the ticket specification (warn, don't fail). No change required unless design changes.
+
+---
+
+## Security Concerns (Informational)
+
+Both Gemini and Codex noted:
+
+1. **Arbitrary Command Execution:** Hooks allow execution of any command from config. This is by design for a developer tool but should be documented as a security consideration.
+
+2. **TOCTOU Race Condition:** Theoretical race between validation and execution. Acceptable for CLI tools.
+
+**No code changes required** - recommend adding security note to documentation.
+
+---
+
+## Missing Edge Cases
+
+| Edge Case | Status | Action |
+|-----------|--------|--------|
+| Non-executable hook files | Not tested | Add validation check |
+| Hook path is directory | Not tested | Add validation check |
+| PATH commands in hooks | Broken | Fix `runCommand()` |
+| Whitespace in hook commands | Inconsistent | Normalize or reject |
+| Symlink hooks | Not explicitly handled | Document behavior |
+| Shell builtins (`cd`, `source`) | Won't work | Document limitation |
+
+---
+
+## Required Fixes Before Approval
+
+1. ✅ **`internal/commands/generate.go:163`** - Fix `runCommand()` to not prepend working directory for all commands - **FIXED**
+2. ✅ **`internal/config/validate.go:89-96`** - Add directory check and executable permission check for path-based hooks - **FIXED**
+3. ✅ **`internal/config/validate.go:81`** - Either reject whitespace-padded commands or document trimming behavior - **FIXED** (rejects whitespace)
+
+---
+
+## Recommended Fixes (Non-Blocking)
+
+1. **`internal/config/validate_test.go`** - Use cross-platform command for PATH test
+2. **Documentation** - Add security note about hook command execution
+
+---
+
+## Files Requiring Changes
+
+| File | Changes Needed |
+|------|----------------|
+| `internal/commands/generate.go` | Fix `runCommand()` to handle PATH commands |
+| `internal/config/validate.go` | Add executable/directory checks, handle whitespace |
+| `internal/config/validate_test.go` | Add tests for new validation, fix platform-specific test |
+
+---
+
+## Review Sign-off
+
+| Reviewer | Decision | Notes |
+|----------|----------|-------|
+| Claude | Request Changes | Critical PATH/execution mismatch must be fixed |
+| Gemini | Request Changes | Executable permission check needed |
+| Codex | Request Changes | Multiple issues identified, PATH mismatch is critical |

--- a/internal/commands/bundle.go
+++ b/internal/commands/bundle.go
@@ -37,6 +37,9 @@ func bundleAction(c *cli.Context, cfg *config.Config) error {
 	if err := config.CheckConfig(cfg); err != nil {
 		return err
 	}
+	if err := cfg.Validate(); err != nil {
+		return app.Errorf("configuration error: %w", err)
+	}
 
 	if c.Args().Len() == 0 {
 		return app.Errorf("please provide the bundle name")

--- a/internal/commands/generate.go
+++ b/internal/commands/generate.go
@@ -61,6 +61,9 @@ func generateAction(c *cli.Context, cfg *config.Config) error {
 	if err := config.CheckConfig(cfg); err != nil {
 		return err
 	}
+	if err := cfg.Validate(); err != nil {
+		return app.Errorf("configuration error: %w", err)
+	}
 
 	if c.Args().Len() < 2 {
 		return app.Errorf("please provide the generator/bundle and the name")
@@ -157,7 +160,16 @@ func runCommand(hook []string) error {
 	if err != nil {
 		return err
 	}
-	cmd := exec.Command(filepath.Join(dir, hook[0]), hook[1:]...)
+
+	// Determine the command path:
+	// - If it contains a path separator, resolve relative to working directory
+	// - Otherwise, let the OS resolve it via PATH
+	cmdPath := hook[0]
+	if strings.ContainsAny(cmdPath, "/\\") && !filepath.IsAbs(cmdPath) {
+		cmdPath = filepath.Join(dir, cmdPath)
+	}
+
+	cmd := exec.Command(cmdPath, hook[1:]...)
 	cmd.Dir = dir
 	output, err := cmd.CombinedOutput()
 	if output != nil {

--- a/internal/commands/generate_test.go
+++ b/internal/commands/generate_test.go
@@ -33,7 +33,8 @@ func TestUT_GenerateAction_MissingArguments(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg := createTestConfig(t, "_templates")
+			tmpDir := setupTempDir(t)
+			cfg := createTestConfig(t, tmpDir)
 			ctx := createTestCLIContext(t, tt.args, nil)
 
 			err := generateAction(ctx, cfg)
@@ -396,7 +397,8 @@ func TestUT_RunHooks_ValidHook(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = os.Chdir(oldDir) })
 
-	err = runHooks([][]string{{"test-hook.sh"}})
+	// Use relative path with ./ prefix to indicate it's a local file
+	err = runHooks([][]string{{"./test-hook.sh"}})
 	require.NoError(t, err)
 }
 
@@ -414,7 +416,8 @@ func TestUT_RunHooks_FailingHook(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = os.Chdir(oldDir) })
 
-	err = runHooks([][]string{{"failing-hook.sh"}})
+	// Use relative path with ./ prefix to indicate it's a local file
+	err = runHooks([][]string{{"./failing-hook.sh"}})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to run hook")
 }
@@ -439,7 +442,8 @@ func TestUT_RunHooks_StopsOnFailure(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = os.Chdir(oldDir) })
 
-	err = runHooks([][]string{{"hook1.sh"}, {"hook2.sh"}})
+	// Use relative paths with ./ prefix to indicate they are local files
+	err = runHooks([][]string{{"./hook1.sh"}, {"./hook2.sh"}})
 	require.Error(t, err)
 
 	// Verify second hook didn't run
@@ -458,4 +462,29 @@ func TestUT_RunCommand_NonexistentCommand(t *testing.T) {
 
 	err = runCommand([]string{"nonexistent-command-xyz"})
 	require.Error(t, err)
+}
+
+func TestUT_RunCommand_PathCommand(t *testing.T) {
+	// Test that PATH commands work (e.g., "echo" should be found in PATH)
+	err := runCommand([]string{"echo", "hello"})
+	require.NoError(t, err)
+}
+
+func TestUT_RunCommand_RelativePathCommand(t *testing.T) {
+	tmpDir := setupTempDir(t)
+
+	// Create a script
+	scriptPath := filepath.Join(tmpDir, "myscript.sh")
+	err := os.WriteFile(scriptPath, []byte("#!/bin/bash\nexit 0"), 0o755)
+	require.NoError(t, err)
+
+	oldDir, err := os.Getwd()
+	require.NoError(t, err)
+	err = os.Chdir(tmpDir)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Chdir(oldDir) })
+
+	// Relative path should resolve from working directory
+	err = runCommand([]string{"./myscript.sh"})
+	require.NoError(t, err)
 }

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -1,0 +1,143 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// ValidationError represents a configuration validation failure.
+type ValidationError struct {
+	Field   string
+	Message string
+}
+
+func (e *ValidationError) Error() string {
+	return fmt.Sprintf("%s: %s", e.Field, e.Message)
+}
+
+// Validate checks the configuration for errors before execution.
+// Returns the first validation error encountered (fail-fast).
+func (c *Config) Validate() error {
+	if c == nil {
+		return &ValidationError{Field: "config", Message: "configuration is nil"}
+	}
+
+	// Validate template path exists (if specified)
+	if c.Env.Path != "" {
+		if err := validateDirectory("env.TAG_PATH", c.Env.Path); err != nil {
+			return err
+		}
+	}
+
+	// Validate pre-hooks
+	if err := validateHooks("hooks.pre", c.Hooks.Pre); err != nil {
+		return err
+	}
+
+	// Validate post-hooks
+	if err := validateHooks("hooks.post", c.Hooks.Post); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateDirectory(field, path string) error {
+	info, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return &ValidationError{
+			Field:   field,
+			Message: fmt.Sprintf("path does not exist: %s", path),
+		}
+	}
+	if err != nil {
+		return &ValidationError{
+			Field:   field,
+			Message: fmt.Sprintf("cannot access path: %s", err),
+		}
+	}
+	if !info.IsDir() {
+		return &ValidationError{
+			Field:   field,
+			Message: fmt.Sprintf("path is not a directory: %s", path),
+		}
+	}
+	return nil
+}
+
+func validateHooks(hookType string, hooks [][]string) error {
+	for i, hook := range hooks {
+		field := fmt.Sprintf("%s[%d]", hookType, i)
+
+		if len(hook) == 0 {
+			return &ValidationError{
+				Field:   field,
+				Message: "hook command is empty",
+			}
+		}
+
+		cmd := hook[0]
+		if cmd == "" {
+			return &ValidationError{
+				Field:   field,
+				Message: "hook command is empty",
+			}
+		}
+
+		// Reject commands with leading/trailing whitespace
+		if strings.TrimSpace(cmd) != cmd {
+			return &ValidationError{
+				Field:   field,
+				Message: fmt.Sprintf("hook command has leading/trailing whitespace: %q", cmd),
+			}
+		}
+
+		// If path contains separator, check file exists and is executable; otherwise look in PATH
+		if strings.ContainsAny(cmd, "/\\") {
+			if err := validateHookExecutable(field, cmd); err != nil {
+				return err
+			}
+		} else {
+			if _, err := exec.LookPath(cmd); err != nil {
+				return &ValidationError{
+					Field:   field,
+					Message: fmt.Sprintf("hook command not found in PATH: %s", cmd),
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func validateHookExecutable(field, path string) error {
+	info, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return &ValidationError{
+			Field:   field,
+			Message: fmt.Sprintf("hook executable not found: %s", path),
+		}
+	}
+	if err != nil {
+		return &ValidationError{
+			Field:   field,
+			Message: fmt.Sprintf("cannot access hook path: %s", err),
+		}
+	}
+	if info.IsDir() {
+		return &ValidationError{
+			Field:   field,
+			Message: fmt.Sprintf("hook path is a directory, not an executable: %s", path),
+		}
+	}
+	// Check for execute permission (on POSIX systems)
+	// On Windows, this check is less meaningful but won't cause false negatives
+	if info.Mode()&0o111 == 0 {
+		return &ValidationError{
+			Field:   field,
+			Message: fmt.Sprintf("hook file is not executable: %s", path),
+		}
+	}
+	return nil
+}

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -1,0 +1,367 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUT_Validate_NilConfig(t *testing.T) {
+	var cfg *Config
+	err := cfg.Validate()
+
+	require.Error(t, err)
+	var valErr *ValidationError
+	require.ErrorAs(t, err, &valErr)
+	assert.Equal(t, "config", valErr.Field)
+	assert.Contains(t, valErr.Message, "nil")
+}
+
+func TestUT_Validate_EmptyConfig(t *testing.T) {
+	cfg := &Config{}
+	err := cfg.Validate()
+
+	require.NoError(t, err)
+}
+
+func TestUT_Validate_ValidPath(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	cfg := &Config{
+		Env: Env{
+			Path: tmpDir,
+		},
+	}
+	err := cfg.Validate()
+
+	require.NoError(t, err)
+}
+
+func TestUT_Validate_InvalidPath(t *testing.T) {
+	cfg := &Config{
+		Env: Env{
+			Path: "/nonexistent/path/that/does/not/exist",
+		},
+	}
+	err := cfg.Validate()
+
+	require.Error(t, err)
+	var valErr *ValidationError
+	require.ErrorAs(t, err, &valErr)
+	assert.Equal(t, "env.TAG_PATH", valErr.Field)
+	assert.Contains(t, valErr.Message, "does not exist")
+}
+
+func TestUT_Validate_PathIsFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "file.txt")
+	err := os.WriteFile(tmpFile, []byte("content"), 0o644)
+	require.NoError(t, err)
+
+	cfg := &Config{
+		Env: Env{
+			Path: tmpFile,
+		},
+	}
+	err = cfg.Validate()
+
+	require.Error(t, err)
+	var valErr *ValidationError
+	require.ErrorAs(t, err, &valErr)
+	assert.Equal(t, "env.TAG_PATH", valErr.Field)
+	assert.Contains(t, valErr.Message, "not a directory")
+}
+
+func TestUT_Validate_ValidHookFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	hookPath := filepath.Join(tmpDir, "hook.sh")
+	err := os.WriteFile(hookPath, []byte("#!/bin/bash\nexit 0"), 0o755)
+	require.NoError(t, err)
+
+	cfg := &Config{
+		Hooks: Hooks{
+			Pre: [][]string{{hookPath}},
+		},
+	}
+	err = cfg.Validate()
+
+	require.NoError(t, err)
+}
+
+func TestUT_Validate_ValidHookInPath(t *testing.T) {
+	// "echo" should be available in PATH on all systems
+	cfg := &Config{
+		Hooks: Hooks{
+			Pre: [][]string{{"echo", "hello"}},
+		},
+	}
+	err := cfg.Validate()
+
+	require.NoError(t, err)
+}
+
+func TestUT_Validate_InvalidHookPath(t *testing.T) {
+	cfg := &Config{
+		Hooks: Hooks{
+			Pre: [][]string{{"/nonexistent/hook/script.sh"}},
+		},
+	}
+	err := cfg.Validate()
+
+	require.Error(t, err)
+	var valErr *ValidationError
+	require.ErrorAs(t, err, &valErr)
+	assert.Equal(t, "hooks.pre[0]", valErr.Field)
+	assert.Contains(t, valErr.Message, "not found")
+}
+
+func TestUT_Validate_InvalidHookCommand(t *testing.T) {
+	cfg := &Config{
+		Hooks: Hooks{
+			Pre: [][]string{{"nonexistent_command_xyz_123"}},
+		},
+	}
+	err := cfg.Validate()
+
+	require.Error(t, err)
+	var valErr *ValidationError
+	require.ErrorAs(t, err, &valErr)
+	assert.Equal(t, "hooks.pre[0]", valErr.Field)
+	assert.Contains(t, valErr.Message, "not found in PATH")
+}
+
+func TestUT_Validate_EmptyHookEntry(t *testing.T) {
+	cfg := &Config{
+		Hooks: Hooks{
+			Pre: [][]string{{}},
+		},
+	}
+	err := cfg.Validate()
+
+	require.Error(t, err)
+	var valErr *ValidationError
+	require.ErrorAs(t, err, &valErr)
+	assert.Equal(t, "hooks.pre[0]", valErr.Field)
+	assert.Contains(t, valErr.Message, "empty")
+}
+
+func TestUT_Validate_EmptyHookCommand(t *testing.T) {
+	cfg := &Config{
+		Hooks: Hooks{
+			Pre: [][]string{{""}},
+		},
+	}
+	err := cfg.Validate()
+
+	require.Error(t, err)
+	var valErr *ValidationError
+	require.ErrorAs(t, err, &valErr)
+	assert.Equal(t, "hooks.pre[0]", valErr.Field)
+	assert.Contains(t, valErr.Message, "empty")
+}
+
+func TestUT_Validate_WhitespaceOnlyHookCommand(t *testing.T) {
+	cfg := &Config{
+		Hooks: Hooks{
+			Pre: [][]string{{"   "}},
+		},
+	}
+	err := cfg.Validate()
+
+	require.Error(t, err)
+	var valErr *ValidationError
+	require.ErrorAs(t, err, &valErr)
+	assert.Equal(t, "hooks.pre[0]", valErr.Field)
+	assert.Contains(t, valErr.Message, "whitespace")
+}
+
+func TestUT_Validate_LeadingWhitespaceHookCommand(t *testing.T) {
+	cfg := &Config{
+		Hooks: Hooks{
+			Pre: [][]string{{"  echo"}},
+		},
+	}
+	err := cfg.Validate()
+
+	require.Error(t, err)
+	var valErr *ValidationError
+	require.ErrorAs(t, err, &valErr)
+	assert.Equal(t, "hooks.pre[0]", valErr.Field)
+	assert.Contains(t, valErr.Message, "whitespace")
+}
+
+func TestUT_Validate_TrailingWhitespaceHookCommand(t *testing.T) {
+	cfg := &Config{
+		Hooks: Hooks{
+			Pre: [][]string{{"echo  "}},
+		},
+	}
+	err := cfg.Validate()
+
+	require.Error(t, err)
+	var valErr *ValidationError
+	require.ErrorAs(t, err, &valErr)
+	assert.Equal(t, "hooks.pre[0]", valErr.Field)
+	assert.Contains(t, valErr.Message, "whitespace")
+}
+
+func TestUT_Validate_HookWithArgs(t *testing.T) {
+	tmpDir := t.TempDir()
+	hookPath := filepath.Join(tmpDir, "hook.sh")
+	err := os.WriteFile(hookPath, []byte("#!/bin/bash\nexit 0"), 0o755)
+	require.NoError(t, err)
+
+	cfg := &Config{
+		Hooks: Hooks{
+			Pre: [][]string{{hookPath, "arg1", "arg2"}},
+		},
+	}
+	err = cfg.Validate()
+
+	require.NoError(t, err)
+}
+
+func TestUT_Validate_NilHooksSlice(t *testing.T) {
+	cfg := &Config{
+		Hooks: Hooks{
+			Pre:  nil,
+			Post: nil,
+		},
+	}
+	err := cfg.Validate()
+
+	require.NoError(t, err)
+}
+
+func TestUT_Validate_PreHookFailsBeforePost(t *testing.T) {
+	cfg := &Config{
+		Hooks: Hooks{
+			Pre:  [][]string{{"nonexistent_pre_command_xyz"}},
+			Post: [][]string{{"nonexistent_post_command_xyz"}},
+		},
+	}
+	err := cfg.Validate()
+
+	require.Error(t, err)
+	var valErr *ValidationError
+	require.ErrorAs(t, err, &valErr)
+	// Should fail on pre hook, not post
+	assert.Equal(t, "hooks.pre[0]", valErr.Field)
+}
+
+func TestUT_Validate_RelativePathHook(t *testing.T) {
+	tmpDir := t.TempDir()
+	hookPath := filepath.Join(tmpDir, "hook.sh")
+	err := os.WriteFile(hookPath, []byte("#!/bin/bash\nexit 0"), 0o755)
+	require.NoError(t, err)
+
+	// Change to tmpDir to test relative path
+	oldDir, err := os.Getwd()
+	require.NoError(t, err)
+	err = os.Chdir(tmpDir)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Chdir(oldDir) })
+
+	cfg := &Config{
+		Hooks: Hooks{
+			Pre: [][]string{{"./hook.sh"}},
+		},
+	}
+	err = cfg.Validate()
+
+	require.NoError(t, err)
+}
+
+func TestUT_Validate_MultipleHooksFirstFails(t *testing.T) {
+	tmpDir := t.TempDir()
+	validHook := filepath.Join(tmpDir, "valid.sh")
+	err := os.WriteFile(validHook, []byte("#!/bin/bash\nexit 0"), 0o755)
+	require.NoError(t, err)
+
+	cfg := &Config{
+		Hooks: Hooks{
+			Pre: [][]string{
+				{"/nonexistent/first.sh"},
+				{validHook},
+			},
+		},
+	}
+	err = cfg.Validate()
+
+	require.Error(t, err)
+	var valErr *ValidationError
+	require.ErrorAs(t, err, &valErr)
+	assert.Equal(t, "hooks.pre[0]", valErr.Field)
+}
+
+func TestUT_Validate_MultipleHooksSecondFails(t *testing.T) {
+	tmpDir := t.TempDir()
+	validHook := filepath.Join(tmpDir, "valid.sh")
+	err := os.WriteFile(validHook, []byte("#!/bin/bash\nexit 0"), 0o755)
+	require.NoError(t, err)
+
+	cfg := &Config{
+		Hooks: Hooks{
+			Pre: [][]string{
+				{validHook},
+				{"/nonexistent/second.sh"},
+			},
+		},
+	}
+	err = cfg.Validate()
+
+	require.Error(t, err)
+	var valErr *ValidationError
+	require.ErrorAs(t, err, &valErr)
+	assert.Equal(t, "hooks.pre[1]", valErr.Field)
+}
+
+func TestUT_Validate_HookPathIsDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	cfg := &Config{
+		Hooks: Hooks{
+			Pre: [][]string{{tmpDir}},
+		},
+	}
+	err := cfg.Validate()
+
+	require.Error(t, err)
+	var valErr *ValidationError
+	require.ErrorAs(t, err, &valErr)
+	assert.Equal(t, "hooks.pre[0]", valErr.Field)
+	assert.Contains(t, valErr.Message, "directory")
+}
+
+func TestUT_Validate_HookFileNotExecutable(t *testing.T) {
+	tmpDir := t.TempDir()
+	hookPath := filepath.Join(tmpDir, "hook.sh")
+	// Create file without execute permission (0644)
+	err := os.WriteFile(hookPath, []byte("#!/bin/bash\nexit 0"), 0o644)
+	require.NoError(t, err)
+
+	cfg := &Config{
+		Hooks: Hooks{
+			Pre: [][]string{{hookPath}},
+		},
+	}
+	err = cfg.Validate()
+
+	require.Error(t, err)
+	var valErr *ValidationError
+	require.ErrorAs(t, err, &valErr)
+	assert.Equal(t, "hooks.pre[0]", valErr.Field)
+	assert.Contains(t, valErr.Message, "not executable")
+}
+
+func TestUT_ValidationError_Error(t *testing.T) {
+	err := &ValidationError{
+		Field:   "test.field",
+		Message: "test message",
+	}
+
+	assert.Equal(t, "test.field: test message", err.Error())
+}

--- a/internal/parser/lexer.go
+++ b/internal/parser/lexer.go
@@ -80,8 +80,11 @@ func generateTemplate(tmplName, tmplOutput string, data TemplateData, funcs temp
 	}
 
 	for sharedTmplName, sharedTmpl := range sharedTmpl {
-		// we don't mind if this fails
-		_, _ = tmpl.New(sharedTmplName).Funcs(funcs).Parse(sharedTmpl)
+		if _, err := tmpl.New(sharedTmplName).Funcs(funcs).Parse(sharedTmpl); err != nil {
+			slog.Warn("failed to parse shared template",
+				"template", sharedTmplName,
+				"error", err)
+		}
 	}
 
 	var buf bytes.Buffer


### PR DESCRIPTION
## Summary
- Implements Phase 3: Error Handling Improvements & Config Validation (#3)
- Adds `ValidationError` type and `Config.Validate()` method for pre-execution validation
- Fixes silenced error in lexer.go - now logs warnings for shared template parse failures
- Fixes `runCommand()` to properly handle PATH commands vs relative paths

## Changes
| File | Description |
|------|-------------|
| `internal/config/validate.go` | NEW: Validation logic with ValidationError type |
| `internal/config/validate_test.go` | NEW: 22 comprehensive tests |
| `internal/parser/lexer.go` | Log warning on shared template parse failure |
| `internal/commands/generate.go` | Add validation call + fix runCommand() |
| `internal/commands/bundle.go` | Add validation call |
| `internal/commands/generate_test.go` | Updated and new tests for hooks |

## Validation Checks
- Template path exists and is a directory
- Hook executables exist, are files (not directories), and have execute permission
- Hook commands don't have leading/trailing whitespace
- PATH commands (e.g., `echo`) now work correctly alongside relative paths (e.g., `./script.sh`)

## Test plan
- [x] All existing tests pass
- [x] 22 new validation tests covering edge cases
- [x] New tests for PATH command execution
- [x] `go vet` passes
- [x] Build succeeds

Closes #3

🤖 Generated with [Claude Code](https://claude.ai/code)