### PR TITLE
feat: implement hooks system for pre/post scaffold commands (Epic 6: #11)

### DIFF
--- a/internal/scaffold/errors.go
+++ b/internal/scaffold/errors.go
@@ -94,3 +94,40 @@ func (e *TemplateError) Unwrap() error {
 func NewTemplateError(file, message string, err error) *TemplateError {
 	return &TemplateError{File: file, Message: message, Err: err}
 }
+
+// ErrHookFailed is returned when a hook command fails.
+var ErrHookFailed = errors.New("hook command failed")
+
+// HookError represents an error during hook execution.
+type HookError struct {
+	Phase    HookPhase // pre_scaffold or post_scaffold
+	Command  string    // The command that failed
+	Output   string    // Combined stdout/stderr output
+	ExitCode int       // Exit code of the command
+	Err      error     // Underlying error
+}
+
+func (e *HookError) Error() string {
+	if e.ExitCode != 0 {
+		return fmt.Sprintf("%s hook failed: command %q exited with code %d", e.Phase, e.Command, e.ExitCode)
+	}
+	if e.Err != nil {
+		return fmt.Sprintf("%s hook failed: command %q: %v", e.Phase, e.Command, e.Err)
+	}
+	return fmt.Sprintf("%s hook failed: command %q", e.Phase, e.Command)
+}
+
+func (e *HookError) Unwrap() error {
+	return e.Err
+}
+
+// NewHookError creates a new hook error.
+func NewHookError(phase HookPhase, command, output string, exitCode int, err error) *HookError {
+	return &HookError{
+		Phase:    phase,
+		Command:  command,
+		Output:   output,
+		ExitCode: exitCode,
+		Err:      err,
+	}
+}

--- a/internal/scaffold/hooks.go
+++ b/internal/scaffold/hooks.go
@@ -1,0 +1,309 @@
+package scaffold
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+	"unicode"
+)
+
+const (
+	// DefaultHookTimeout is the maximum time a single hook command can run.
+	DefaultHookTimeout = 5 * time.Minute
+
+	// MaxHookOutputSize is the maximum size of combined stdout/stderr output to capture.
+	// Output beyond this limit is truncated.
+	MaxHookOutputSize = 1024 * 1024 // 1MB
+)
+
+// HookPhase indicates when a hook runs in the scaffold lifecycle.
+type HookPhase string
+
+const (
+	// HookPhasePre runs before file generation (working dir: template directory).
+	HookPhasePre HookPhase = "pre_scaffold"
+	// HookPhasePost runs after file generation (working dir: output directory).
+	HookPhasePost HookPhase = "post_scaffold"
+)
+
+// HookResult contains the result of executing a single hook command.
+type HookResult struct {
+	Command  string // The command that was executed
+	Output   string // Combined stdout and stderr output
+	ExitCode int    // Exit code (0 = success)
+	Err      error  // Error if execution failed
+}
+
+// HookRunner executes hook commands.
+type HookRunner interface {
+	// Run executes a list of commands sequentially.
+	// Returns results for each command executed (may be partial on failure).
+	// Returns error if any command fails.
+	Run(phase HookPhase, commands []string, workDir string, env []string) ([]HookResult, error)
+}
+
+// ShellHookRunner executes hooks via the system shell.
+type ShellHookRunner struct{}
+
+// NewHookRunner creates a new hook runner using the system shell.
+func NewHookRunner() HookRunner {
+	return &ShellHookRunner{}
+}
+
+// Run executes commands sequentially via the system shell.
+// On Unix: /bin/sh -c "command"
+// On Windows: cmd.exe /C "command"
+func (r *ShellHookRunner) Run(phase HookPhase, commands []string, workDir string, env []string) ([]HookResult, error) {
+	if len(commands) == 0 {
+		return nil, nil
+	}
+
+	results := make([]HookResult, 0, len(commands))
+
+	for _, cmdStr := range commands {
+		result := r.executeCommand(cmdStr, workDir, env)
+		results = append(results, result)
+
+		if result.Err != nil {
+			return results, NewHookError(phase, cmdStr, result.Output, result.ExitCode, result.Err)
+		}
+	}
+
+	return results, nil
+}
+
+// executeCommand runs a single command via the system shell with timeout.
+func (r *ShellHookRunner) executeCommand(cmdStr, workDir string, env []string) HookResult {
+	result := HookResult{
+		Command: cmdStr,
+	}
+
+	// Create context with timeout
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultHookTimeout)
+	defer cancel()
+
+	// Build the shell command based on OS
+	var cmd *exec.Cmd
+	if runtime.GOOS == "windows" {
+		cmd = exec.CommandContext(ctx, "cmd.exe", "/C", cmdStr)
+	} else {
+		cmd = exec.CommandContext(ctx, "/bin/sh", "-c", cmdStr)
+	}
+
+	// Set working directory
+	cmd.Dir = workDir
+
+	// Set environment - ensure we always have a valid environment with PATH
+	if len(env) == 0 {
+		cmd.Env = os.Environ()
+	} else {
+		cmd.Env = env
+	}
+
+	// Capture stdout and stderr together with size limit
+	output := &limitedBuffer{max: MaxHookOutputSize}
+	cmd.Stdout = output
+	cmd.Stderr = output
+
+	// Execute the command
+	err := cmd.Run()
+	result.Output = output.String()
+
+	if err != nil {
+		result.Err = err
+		// Check for context timeout/cancellation
+		if ctx.Err() == context.DeadlineExceeded {
+			result.Err = fmt.Errorf("hook timed out after %v: %w", DefaultHookTimeout, err)
+			result.ExitCode = -1 // Special code for timeout
+		} else if exitErr, ok := err.(*exec.ExitError); ok {
+			// Extract exit code from ExitError
+			result.ExitCode = exitErr.ExitCode()
+		} else {
+			result.ExitCode = 1 // Default to 1 for non-exit errors
+		}
+	}
+
+	return result
+}
+
+// limitedBuffer is a bytes.Buffer that stops accepting writes after reaching max size.
+type limitedBuffer struct {
+	buf       bytes.Buffer
+	max       int
+	truncated bool
+}
+
+func (l *limitedBuffer) Write(p []byte) (n int, err error) {
+	if l.truncated {
+		return len(p), nil // Discard but report success
+	}
+
+	remaining := l.max - l.buf.Len()
+	if remaining <= 0 {
+		l.truncated = true
+		l.buf.WriteString("\n... output truncated (exceeded 1MB limit) ...\n")
+		return len(p), nil
+	}
+
+	if len(p) > remaining {
+		l.buf.Write(p[:remaining])
+		l.truncated = true
+		l.buf.WriteString("\n... output truncated (exceeded 1MB limit) ...\n")
+		return len(p), nil
+	}
+
+	return l.buf.Write(p)
+}
+
+func (l *limitedBuffer) String() string {
+	return l.buf.String()
+}
+
+// Ensure limitedBuffer implements io.Writer
+var _ io.Writer = (*limitedBuffer)(nil)
+
+// BuildHookEnv creates environment variables for hook execution.
+// It merges the current environment with TAG-specific variables.
+func BuildHookEnv(vars map[string]any, templateDir, outputDir string) []string {
+	// Start with current environment
+	env := os.Environ()
+
+	// Add TAG-specific variables
+	env = append(env, fmt.Sprintf("TAG_TEMPLATE_DIR=%s", templateDir))
+	env = append(env, fmt.Sprintf("TAG_OUTPUT_DIR=%s", outputDir))
+
+	// Add project_name as a special variable
+	if projectName, ok := vars["project_name"]; ok {
+		env = append(env, fmt.Sprintf("TAG_PROJECT_NAME=%s", stringifyValue(projectName)))
+	}
+
+	// Add all user variables with TAG_VAR_ prefix
+	for name, value := range vars {
+		envKey := formatEnvKey(name)
+		envValue := stringifyValue(value)
+		env = append(env, fmt.Sprintf("%s=%s", envKey, envValue))
+	}
+
+	return env
+}
+
+// formatEnvKey converts a variable name to an environment variable key.
+// Example: "project_name" -> "TAG_VAR_PROJECT_NAME"
+// Example: "use-docker" -> "TAG_VAR_USE_DOCKER"
+func formatEnvKey(name string) string {
+	// Convert to uppercase and replace non-alphanumeric with underscores
+	var result strings.Builder
+	result.WriteString("TAG_VAR_")
+
+	for _, r := range name {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			result.WriteRune(unicode.ToUpper(r))
+		} else {
+			result.WriteRune('_')
+		}
+	}
+
+	return result.String()
+}
+
+// stringifyValue converts a variable value to a string for environment variables.
+func stringifyValue(value any) string {
+	switch v := value.(type) {
+	case string:
+		return v
+	case bool:
+		if v {
+			return "true"
+		}
+		return "false"
+	case float64:
+		// Check if it's an integer
+		if v == float64(int64(v)) {
+			return fmt.Sprintf("%d", int64(v))
+		}
+		return fmt.Sprintf("%g", v)
+	case int:
+		return fmt.Sprintf("%d", v)
+	case int64:
+		return fmt.Sprintf("%d", v)
+	case []any, map[string]any:
+		// JSON encode complex types
+		data, err := json.Marshal(v)
+		if err != nil {
+			return fmt.Sprintf("%v", v)
+		}
+		return string(data)
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}
+
+// RunPreScaffoldHooks executes pre-scaffold hooks and returns an error if any fail.
+// Pre-scaffold hooks run in the template directory before any files are created.
+func RunPreScaffoldHooks(runner HookRunner, hooks *HooksConfig, templateDir string, env []string) error {
+	if hooks == nil || len(hooks.PreScaffold) == 0 {
+		return nil
+	}
+
+	fmt.Printf("Running pre-scaffold hooks...\n")
+
+	results, err := runner.Run(HookPhasePre, hooks.PreScaffold, templateDir, env)
+	if err != nil {
+		// Print output from failed command
+		if len(results) > 0 {
+			lastResult := results[len(results)-1]
+			if lastResult.Output != "" {
+				fmt.Printf("Hook output:\n%s\n", lastResult.Output)
+			}
+		}
+		return err
+	}
+
+	// Print success output if any
+	for _, result := range results {
+		if result.Output != "" {
+			fmt.Print(result.Output)
+			if !strings.HasSuffix(result.Output, "\n") {
+				fmt.Println()
+			}
+		}
+	}
+
+	return nil
+}
+
+// RunPostScaffoldHooks executes post-scaffold hooks.
+// Post-scaffold hooks run in the output directory after all files are created.
+// Failures are logged as warnings but don't stop the scaffold process.
+func RunPostScaffoldHooks(runner HookRunner, hooks *HooksConfig, outputDir string, env []string) {
+	if hooks == nil || len(hooks.PostScaffold) == 0 {
+		return
+	}
+
+	fmt.Printf("Running post-scaffold hooks...\n")
+
+	results, err := runner.Run(HookPhasePost, hooks.PostScaffold, outputDir, env)
+
+	// Print output from all executed commands
+	for _, result := range results {
+		if result.Output != "" {
+			fmt.Print(result.Output)
+			if !strings.HasSuffix(result.Output, "\n") {
+				fmt.Println()
+			}
+		}
+	}
+
+	if err != nil {
+		// Post-scaffold failures are warnings, not errors
+		fmt.Printf("Warning: post-scaffold hook failed: %v\n", err)
+		fmt.Printf("Note: Scaffold completed successfully, but some post-scaffold tasks may not have run.\n")
+	}
+}

--- a/internal/scaffold/hooks_test.go
+++ b/internal/scaffold/hooks_test.go
@@ -1,0 +1,837 @@
+package scaffold
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// MockHookRunner is a mock implementation of HookRunner for testing.
+type MockHookRunner struct {
+	RunFunc func(phase HookPhase, commands []string, workDir string, env []string) ([]HookResult, error)
+	Calls   []MockHookCall
+}
+
+type MockHookCall struct {
+	Phase    HookPhase
+	Commands []string
+	WorkDir  string
+	Env      []string
+}
+
+func (m *MockHookRunner) Run(phase HookPhase, commands []string, workDir string, env []string) ([]HookResult, error) {
+	m.Calls = append(m.Calls, MockHookCall{
+		Phase:    phase,
+		Commands: commands,
+		WorkDir:  workDir,
+		Env:      env,
+	})
+	if m.RunFunc != nil {
+		return m.RunFunc(phase, commands, workDir, env)
+	}
+	// Default: return success for all commands
+	results := make([]HookResult, len(commands))
+	for i, cmd := range commands {
+		results[i] = HookResult{Command: cmd, ExitCode: 0}
+	}
+	return results, nil
+}
+
+// --- Unit Tests for BuildHookEnv ---
+
+func TestUT_BuildHookEnv_BasicVariables(t *testing.T) {
+	vars := map[string]any{
+		"project_name": "my_project",
+		"author":       "John Doe",
+	}
+
+	env := BuildHookEnv(vars, "/template", "/output")
+
+	// Check TAG-specific variables
+	assertEnvContains(t, env, "TAG_TEMPLATE_DIR=/template")
+	assertEnvContains(t, env, "TAG_OUTPUT_DIR=/output")
+	assertEnvContains(t, env, "TAG_PROJECT_NAME=my_project")
+	assertEnvContains(t, env, "TAG_VAR_PROJECT_NAME=my_project")
+	assertEnvContains(t, env, "TAG_VAR_AUTHOR=John Doe")
+}
+
+func TestUT_BuildHookEnv_BooleanVariables(t *testing.T) {
+	vars := map[string]any{
+		"use_docker": true,
+		"use_ci":     false,
+	}
+
+	env := BuildHookEnv(vars, "/template", "/output")
+
+	assertEnvContains(t, env, "TAG_VAR_USE_DOCKER=true")
+	assertEnvContains(t, env, "TAG_VAR_USE_CI=false")
+}
+
+func TestUT_BuildHookEnv_NumberVariables(t *testing.T) {
+	vars := map[string]any{
+		"port":    float64(8080),
+		"version": float64(1.5),
+	}
+
+	env := BuildHookEnv(vars, "/template", "/output")
+
+	assertEnvContains(t, env, "TAG_VAR_PORT=8080")
+	assertEnvContains(t, env, "TAG_VAR_VERSION=1.5")
+}
+
+func TestUT_BuildHookEnv_ComplexVariables(t *testing.T) {
+	vars := map[string]any{
+		"features": []any{"auth", "logging", "metrics"},
+		"config": map[string]any{
+			"key": "value",
+		},
+	}
+
+	env := BuildHookEnv(vars, "/template", "/output")
+
+	// Complex types should be JSON encoded
+	assertEnvContainsPrefix(t, env, "TAG_VAR_FEATURES=")
+	assertEnvContainsPrefix(t, env, "TAG_VAR_CONFIG=")
+
+	// Verify JSON encoding
+	for _, e := range env {
+		if strings.HasPrefix(e, "TAG_VAR_FEATURES=") {
+			value := strings.TrimPrefix(e, "TAG_VAR_FEATURES=")
+			var arr []string
+			err := json.Unmarshal([]byte(value), &arr)
+			require.NoError(t, err)
+			assert.Equal(t, []string{"auth", "logging", "metrics"}, arr)
+		}
+	}
+}
+
+func TestUT_BuildHookEnv_SpecialCharactersInNames(t *testing.T) {
+	vars := map[string]any{
+		"project-name":  "test",
+		"use_docker":    true,
+		"CamelCaseVar":  "value",
+		"with.dots":     "dotted",
+		"with spaces":   "spaced",
+		"with@special!": "special",
+	}
+
+	env := BuildHookEnv(vars, "/template", "/output")
+
+	// All should be converted to uppercase with underscores
+	assertEnvContains(t, env, "TAG_VAR_PROJECT_NAME=test")
+	assertEnvContains(t, env, "TAG_VAR_USE_DOCKER=true")
+	assertEnvContains(t, env, "TAG_VAR_CAMELCASEVAR=value")
+	assertEnvContains(t, env, "TAG_VAR_WITH_DOTS=dotted")
+	assertEnvContains(t, env, "TAG_VAR_WITH_SPACES=spaced")
+	assertEnvContains(t, env, "TAG_VAR_WITH_SPECIAL_=special")
+}
+
+func TestUT_BuildHookEnv_EmptyVars(t *testing.T) {
+	vars := map[string]any{}
+
+	env := BuildHookEnv(vars, "/template", "/output")
+
+	// Should still have TAG_TEMPLATE_DIR and TAG_OUTPUT_DIR
+	assertEnvContains(t, env, "TAG_TEMPLATE_DIR=/template")
+	assertEnvContains(t, env, "TAG_OUTPUT_DIR=/output")
+	// Should not have TAG_PROJECT_NAME if not in vars
+	assertEnvNotContainsPrefix(t, env, "TAG_PROJECT_NAME=")
+}
+
+func TestUT_BuildHookEnv_IncludesSystemEnv(t *testing.T) {
+	vars := map[string]any{}
+
+	env := BuildHookEnv(vars, "/template", "/output")
+
+	// Should include PATH from system environment
+	hasPath := false
+	for _, e := range env {
+		if strings.HasPrefix(e, "PATH=") || strings.HasPrefix(e, "Path=") {
+			hasPath = true
+			break
+		}
+	}
+	assert.True(t, hasPath, "should include system PATH")
+}
+
+// --- Unit Tests for formatEnvKey ---
+
+func TestUT_FormatEnvKey(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"project_name", "TAG_VAR_PROJECT_NAME"},
+		{"projectName", "TAG_VAR_PROJECTNAME"},
+		{"project-name", "TAG_VAR_PROJECT_NAME"},
+		{"use.docker", "TAG_VAR_USE_DOCKER"},
+		{"CamelCase", "TAG_VAR_CAMELCASE"},
+		{"ALREADY_UPPER", "TAG_VAR_ALREADY_UPPER"},
+		{"123numeric", "TAG_VAR_123NUMERIC"},
+		{"with spaces", "TAG_VAR_WITH_SPACES"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := formatEnvKey(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// --- Unit Tests for stringifyValue ---
+
+func TestUT_StringifyValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    any
+		expected string
+	}{
+		{"string", "hello", "hello"},
+		{"bool true", true, "true"},
+		{"bool false", false, "false"},
+		{"integer float", float64(42), "42"},
+		{"decimal float", float64(3.14), "3.14"},
+		{"int", int(100), "100"},
+		{"int64", int64(999), "999"},
+		{"slice", []any{"a", "b"}, `["a","b"]`},
+		{"map", map[string]any{"k": "v"}, `{"k":"v"}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := stringifyValue(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// --- Unit Tests for ShellHookRunner ---
+
+func TestUT_ShellHookRunner_SuccessfulCommand(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific test")
+	}
+
+	runner := &ShellHookRunner{}
+	dir := t.TempDir()
+
+	results, err := runner.Run(HookPhasePre, []string{"echo hello"}, dir, os.Environ())
+
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "echo hello", results[0].Command)
+	assert.Equal(t, 0, results[0].ExitCode)
+	assert.Contains(t, results[0].Output, "hello")
+}
+
+func TestUT_ShellHookRunner_MultipleCommands(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific test")
+	}
+
+	runner := &ShellHookRunner{}
+	dir := t.TempDir()
+
+	results, err := runner.Run(HookPhasePre, []string{"echo first", "echo second"}, dir, os.Environ())
+
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	assert.Contains(t, results[0].Output, "first")
+	assert.Contains(t, results[1].Output, "second")
+}
+
+func TestUT_ShellHookRunner_FirstCommandFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific test")
+	}
+
+	runner := &ShellHookRunner{}
+	dir := t.TempDir()
+
+	results, err := runner.Run(HookPhasePre, []string{"exit 1", "echo should not run"}, dir, os.Environ())
+
+	require.Error(t, err)
+	require.Len(t, results, 1) // Only first command was executed
+	assert.Equal(t, 1, results[0].ExitCode)
+
+	// Verify it's a HookError
+	hookErr, ok := err.(*HookError)
+	require.True(t, ok)
+	assert.Equal(t, HookPhasePre, hookErr.Phase)
+	assert.Equal(t, "exit 1", hookErr.Command)
+}
+
+func TestUT_ShellHookRunner_MiddleCommandFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific test")
+	}
+
+	runner := &ShellHookRunner{}
+	dir := t.TempDir()
+
+	results, err := runner.Run(HookPhasePre, []string{"echo first", "exit 2", "echo third"}, dir, os.Environ())
+
+	require.Error(t, err)
+	require.Len(t, results, 2) // First two commands were executed
+	assert.Equal(t, 0, results[0].ExitCode)
+	assert.Equal(t, 2, results[1].ExitCode)
+}
+
+func TestUT_ShellHookRunner_EmptyCommands(t *testing.T) {
+	runner := &ShellHookRunner{}
+	dir := t.TempDir()
+
+	results, err := runner.Run(HookPhasePre, []string{}, dir, os.Environ())
+
+	require.NoError(t, err)
+	assert.Empty(t, results)
+}
+
+func TestUT_ShellHookRunner_NilCommands(t *testing.T) {
+	runner := &ShellHookRunner{}
+	dir := t.TempDir()
+
+	results, err := runner.Run(HookPhasePre, nil, dir, os.Environ())
+
+	require.NoError(t, err)
+	assert.Empty(t, results)
+}
+
+func TestUT_ShellHookRunner_WorkingDirectory(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific test")
+	}
+
+	runner := &ShellHookRunner{}
+	dir := t.TempDir()
+
+	results, err := runner.Run(HookPhasePre, []string{"pwd"}, dir, os.Environ())
+
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Contains(t, results[0].Output, dir)
+}
+
+func TestUT_ShellHookRunner_EnvironmentVariables(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific test")
+	}
+
+	runner := &ShellHookRunner{}
+	dir := t.TempDir()
+	env := append(os.Environ(), "TAG_TEST_VAR=test_value")
+
+	results, err := runner.Run(HookPhasePre, []string{"echo $TAG_TEST_VAR"}, dir, env)
+
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Contains(t, results[0].Output, "test_value")
+}
+
+func TestUT_ShellHookRunner_CapturesStderr(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific test")
+	}
+
+	runner := &ShellHookRunner{}
+	dir := t.TempDir()
+
+	results, err := runner.Run(HookPhasePre, []string{"echo error >&2"}, dir, os.Environ())
+
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Contains(t, results[0].Output, "error")
+}
+
+func TestUT_ShellHookRunner_EmptyEnvUsesSystemEnv(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific test")
+	}
+
+	runner := &ShellHookRunner{}
+	dir := t.TempDir()
+
+	// With nil/empty env, should still work (uses os.Environ internally)
+	results, err := runner.Run(HookPhasePre, []string{"echo $PATH"}, dir, nil)
+
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	// PATH should exist and have some content
+	assert.NotEmpty(t, strings.TrimSpace(results[0].Output))
+}
+
+func TestUT_LimitedBuffer_TruncatesLargeOutput(t *testing.T) {
+	buf := &limitedBuffer{max: 100}
+
+	// Write 50 bytes - should succeed
+	n, err := buf.Write([]byte(strings.Repeat("a", 50)))
+	assert.NoError(t, err)
+	assert.Equal(t, 50, n)
+	assert.Len(t, buf.String(), 50)
+
+	// Write 60 more bytes - should be truncated
+	n, err = buf.Write([]byte(strings.Repeat("b", 60)))
+	assert.NoError(t, err)
+	assert.Equal(t, 60, n) // Reports full write but truncates internally
+
+	output := buf.String()
+	assert.Contains(t, output, "truncated")
+	assert.True(t, len(output) < 200) // Much less than 110 + message
+}
+
+func TestUT_LimitedBuffer_HandlesExactLimit(t *testing.T) {
+	buf := &limitedBuffer{max: 10}
+
+	// Write exactly 10 bytes
+	n, err := buf.Write([]byte("1234567890"))
+	assert.NoError(t, err)
+	assert.Equal(t, 10, n)
+	assert.Equal(t, "1234567890", buf.String())
+
+	// Next write should trigger truncation
+	n, err = buf.Write([]byte("X"))
+	assert.NoError(t, err)
+	assert.Equal(t, 1, n)
+	assert.Contains(t, buf.String(), "truncated")
+}
+
+func TestUT_LimitedBuffer_DiscardsAfterTruncation(t *testing.T) {
+	buf := &limitedBuffer{max: 5}
+
+	// Fill the buffer and trigger truncation
+	_, _ = buf.Write([]byte("12345"))
+	_, _ = buf.Write([]byte("overflow"))
+
+	snapshot := buf.String()
+
+	// Additional writes should be discarded
+	_, _ = buf.Write([]byte("more data"))
+	_, _ = buf.Write([]byte("even more"))
+
+	// Output shouldn't grow beyond the truncation message
+	assert.Equal(t, snapshot, buf.String())
+}
+
+// --- Integration Tests for Scaffold with Hooks ---
+
+func TestIT_Scaffold_PreHookSuccess(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific test")
+	}
+
+	// Create template with pre-scaffold hook
+	templateDir := t.TempDir()
+	outputDir := filepath.Join(t.TempDir(), "output")
+
+	config := map[string]any{
+		"vars": map[string]any{
+			"project_name": "test_project",
+		},
+		"hooks": map[string]any{
+			"pre_scaffold": []string{"echo pre-hook executed"},
+		},
+	}
+	configData, err := json.MarshalIndent(config, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(templateDir, "tag.template.json"), configData, 0o644))
+
+	// Create a simple template file
+	require.NoError(t, os.WriteFile(filepath.Join(templateDir, "test.txt"), []byte("content"), 0o644))
+
+	opts := Options{
+		TemplateDir: templateDir,
+		OutputDir:   outputDir,
+		NoInput:     true,
+	}
+
+	s, err := NewScaffold(opts)
+	require.NoError(t, err)
+
+	err = s.Run(opts)
+	require.NoError(t, err)
+
+	// Verify output was created
+	assert.DirExists(t, outputDir)
+	assert.FileExists(t, filepath.Join(outputDir, "test.txt"))
+}
+
+func TestIT_Scaffold_PreHookFailure_NoOutputCreated(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific test")
+	}
+
+	// Create template with failing pre-scaffold hook
+	templateDir := t.TempDir()
+	outputDir := filepath.Join(t.TempDir(), "output")
+
+	config := map[string]any{
+		"vars": map[string]any{
+			"project_name": "test_project",
+		},
+		"hooks": map[string]any{
+			"pre_scaffold": []string{"exit 1"},
+		},
+	}
+	configData, err := json.MarshalIndent(config, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(templateDir, "tag.template.json"), configData, 0o644))
+
+	require.NoError(t, os.WriteFile(filepath.Join(templateDir, "test.txt"), []byte("content"), 0o644))
+
+	opts := Options{
+		TemplateDir: templateDir,
+		OutputDir:   outputDir,
+		NoInput:     true,
+	}
+
+	s, err := NewScaffold(opts)
+	require.NoError(t, err)
+
+	err = s.Run(opts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pre-scaffold hook failed")
+
+	// Verify output was NOT created
+	assert.NoDirExists(t, outputDir)
+}
+
+func TestIT_Scaffold_PostHookSuccess(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific test")
+	}
+
+	// Create template with post-scaffold hook that creates a marker file
+	templateDir := t.TempDir()
+	outputDir := filepath.Join(t.TempDir(), "output")
+
+	config := map[string]any{
+		"vars": map[string]any{
+			"project_name": "test_project",
+		},
+		"hooks": map[string]any{
+			"post_scaffold": []string{"touch post_hook_marker.txt"},
+		},
+	}
+	configData, err := json.MarshalIndent(config, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(templateDir, "tag.template.json"), configData, 0o644))
+
+	require.NoError(t, os.WriteFile(filepath.Join(templateDir, "test.txt"), []byte("content"), 0o644))
+
+	opts := Options{
+		TemplateDir: templateDir,
+		OutputDir:   outputDir,
+		NoInput:     true,
+	}
+
+	s, err := NewScaffold(opts)
+	require.NoError(t, err)
+
+	err = s.Run(opts)
+	require.NoError(t, err)
+
+	// Verify output and marker file were created
+	assert.DirExists(t, outputDir)
+	assert.FileExists(t, filepath.Join(outputDir, "test.txt"))
+	assert.FileExists(t, filepath.Join(outputDir, "post_hook_marker.txt"))
+}
+
+func TestIT_Scaffold_PostHookFailure_OutputPreserved(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific test")
+	}
+
+	// Create template with failing post-scaffold hook
+	templateDir := t.TempDir()
+	outputDir := filepath.Join(t.TempDir(), "output")
+
+	config := map[string]any{
+		"vars": map[string]any{
+			"project_name": "test_project",
+		},
+		"hooks": map[string]any{
+			"post_scaffold": []string{"exit 1"},
+		},
+	}
+	configData, err := json.MarshalIndent(config, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(templateDir, "tag.template.json"), configData, 0o644))
+
+	require.NoError(t, os.WriteFile(filepath.Join(templateDir, "test.txt"), []byte("content"), 0o644))
+
+	opts := Options{
+		TemplateDir: templateDir,
+		OutputDir:   outputDir,
+		NoInput:     true,
+	}
+
+	s, err := NewScaffold(opts)
+	require.NoError(t, err)
+
+	// Post-hook failures should NOT cause scaffold to fail
+	err = s.Run(opts)
+	require.NoError(t, err)
+
+	// Verify output was still created despite hook failure
+	assert.DirExists(t, outputDir)
+	assert.FileExists(t, filepath.Join(outputDir, "test.txt"))
+}
+
+func TestIT_Scaffold_HooksReceiveEnvironmentVariables(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific test")
+	}
+
+	// Create template that writes env vars to a file
+	templateDir := t.TempDir()
+	outputDir := filepath.Join(t.TempDir(), "output")
+
+	config := map[string]any{
+		"vars": map[string]any{
+			"project_name": "env_test_project",
+			"author":       "Test Author",
+		},
+		"hooks": map[string]any{
+			"post_scaffold": []string{
+				"echo TAG_PROJECT_NAME=$TAG_PROJECT_NAME > env_check.txt",
+				"echo TAG_VAR_PROJECT_NAME=$TAG_VAR_PROJECT_NAME >> env_check.txt",
+				"echo TAG_VAR_AUTHOR=$TAG_VAR_AUTHOR >> env_check.txt",
+				"echo TAG_OUTPUT_DIR=$TAG_OUTPUT_DIR >> env_check.txt",
+			},
+		},
+	}
+	configData, err := json.MarshalIndent(config, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(templateDir, "tag.template.json"), configData, 0o644))
+
+	opts := Options{
+		TemplateDir: templateDir,
+		OutputDir:   outputDir,
+		NoInput:     true,
+	}
+
+	s, err := NewScaffold(opts)
+	require.NoError(t, err)
+
+	err = s.Run(opts)
+	require.NoError(t, err)
+
+	// Read and verify env check file
+	envContent, err := os.ReadFile(filepath.Join(outputDir, "env_check.txt"))
+	require.NoError(t, err)
+
+	content := string(envContent)
+	assert.Contains(t, content, "TAG_PROJECT_NAME=env_test_project")
+	assert.Contains(t, content, "TAG_VAR_PROJECT_NAME=env_test_project")
+	assert.Contains(t, content, "TAG_VAR_AUTHOR=Test Author")
+	assert.Contains(t, content, "TAG_OUTPUT_DIR="+outputDir)
+}
+
+func TestIT_Scaffold_PreHooksRunInTemplateDirectory(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific test")
+	}
+
+	// Create template with pre-hook that writes pwd to a marker file
+	templateDir := t.TempDir()
+	outputDir := filepath.Join(t.TempDir(), "output")
+
+	config := map[string]any{
+		"vars": map[string]any{
+			"project_name": "test_project",
+		},
+		"hooks": map[string]any{
+			"pre_scaffold": []string{"pwd > pre_hook_pwd.txt"},
+		},
+	}
+	configData, err := json.MarshalIndent(config, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(templateDir, "tag.template.json"), configData, 0o644))
+
+	opts := Options{
+		TemplateDir: templateDir,
+		OutputDir:   outputDir,
+		NoInput:     true,
+	}
+
+	s, err := NewScaffold(opts)
+	require.NoError(t, err)
+
+	err = s.Run(opts)
+	require.NoError(t, err)
+
+	// Read the marker file created in template directory
+	pwdContent, err := os.ReadFile(filepath.Join(templateDir, "pre_hook_pwd.txt"))
+	require.NoError(t, err)
+	assert.Contains(t, string(pwdContent), templateDir)
+}
+
+func TestIT_Scaffold_PostHooksRunInOutputDirectory(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific test")
+	}
+
+	// Create template with post-hook that writes pwd to a marker file
+	templateDir := t.TempDir()
+	outputDir := filepath.Join(t.TempDir(), "output")
+
+	config := map[string]any{
+		"vars": map[string]any{
+			"project_name": "test_project",
+		},
+		"hooks": map[string]any{
+			"post_scaffold": []string{"pwd > post_hook_pwd.txt"},
+		},
+	}
+	configData, err := json.MarshalIndent(config, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(templateDir, "tag.template.json"), configData, 0o644))
+
+	opts := Options{
+		TemplateDir: templateDir,
+		OutputDir:   outputDir,
+		NoInput:     true,
+	}
+
+	s, err := NewScaffold(opts)
+	require.NoError(t, err)
+
+	err = s.Run(opts)
+	require.NoError(t, err)
+
+	// Read the marker file created in output directory
+	pwdContent, err := os.ReadFile(filepath.Join(outputDir, "post_hook_pwd.txt"))
+	require.NoError(t, err)
+	assert.Contains(t, string(pwdContent), outputDir)
+}
+
+func TestIT_Scaffold_MultipleHooksExecuteInOrder(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific test")
+	}
+
+	// Create template with multiple hooks that append to a file
+	templateDir := t.TempDir()
+	outputDir := filepath.Join(t.TempDir(), "output")
+
+	config := map[string]any{
+		"vars": map[string]any{
+			"project_name": "test_project",
+		},
+		"hooks": map[string]any{
+			"post_scaffold": []string{
+				"echo first > order.txt",
+				"echo second >> order.txt",
+				"echo third >> order.txt",
+			},
+		},
+	}
+	configData, err := json.MarshalIndent(config, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(templateDir, "tag.template.json"), configData, 0o644))
+
+	opts := Options{
+		TemplateDir: templateDir,
+		OutputDir:   outputDir,
+		NoInput:     true,
+	}
+
+	s, err := NewScaffold(opts)
+	require.NoError(t, err)
+
+	err = s.Run(opts)
+	require.NoError(t, err)
+
+	// Verify hooks ran in order
+	orderContent, err := os.ReadFile(filepath.Join(outputDir, "order.txt"))
+	require.NoError(t, err)
+
+	lines := strings.Split(strings.TrimSpace(string(orderContent)), "\n")
+	require.Len(t, lines, 3)
+	assert.Equal(t, "first", lines[0])
+	assert.Equal(t, "second", lines[1])
+	assert.Equal(t, "third", lines[2])
+}
+
+func TestIT_Scaffold_NoHooksConfigured(t *testing.T) {
+	// Create template without hooks
+	templateDir := t.TempDir()
+	outputDir := filepath.Join(t.TempDir(), "output")
+
+	config := map[string]any{
+		"vars": map[string]any{
+			"project_name": "test_project",
+		},
+	}
+	configData, err := json.MarshalIndent(config, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(templateDir, "tag.template.json"), configData, 0o644))
+
+	require.NoError(t, os.WriteFile(filepath.Join(templateDir, "test.txt"), []byte("content"), 0o644))
+
+	opts := Options{
+		TemplateDir: templateDir,
+		OutputDir:   outputDir,
+		NoInput:     true,
+	}
+
+	s, err := NewScaffold(opts)
+	require.NoError(t, err)
+
+	err = s.Run(opts)
+	require.NoError(t, err)
+
+	// Verify output was created successfully
+	assert.DirExists(t, outputDir)
+	assert.FileExists(t, filepath.Join(outputDir, "test.txt"))
+}
+
+// --- Helper functions ---
+
+func assertEnvContains(t *testing.T, env []string, expected string) {
+	t.Helper()
+	for _, e := range env {
+		if e == expected {
+			return
+		}
+	}
+	t.Errorf("expected env to contain %q, but it didn't.\nEnv: %v", expected, filterTagEnv(env))
+}
+
+func assertEnvContainsPrefix(t *testing.T, env []string, prefix string) {
+	t.Helper()
+	for _, e := range env {
+		if strings.HasPrefix(e, prefix) {
+			return
+		}
+	}
+	t.Errorf("expected env to contain entry with prefix %q, but it didn't.\nEnv: %v", prefix, filterTagEnv(env))
+}
+
+func assertEnvNotContainsPrefix(t *testing.T, env []string, prefix string) {
+	t.Helper()
+	for _, e := range env {
+		if strings.HasPrefix(e, prefix) {
+			t.Errorf("expected env NOT to contain entry with prefix %q, but found %q", prefix, e)
+			return
+		}
+	}
+}
+
+// filterTagEnv returns only TAG_ prefixed env vars for easier debugging
+func filterTagEnv(env []string) []string {
+	var result []string
+	for _, e := range env {
+		if strings.HasPrefix(e, "TAG_") {
+			result = append(result, e)
+		}
+	}
+	return result
+}

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -19,6 +19,7 @@ type Scaffold struct {
 	Writer      OutputWriter
 	Engine      *template.Engine
 	Prompter    Prompter
+	HookRunner  HookRunner // Executes pre/post scaffold hooks
 	DryRun      bool
 	Verbose     bool
 	ProjectName string // Override for project_name variable
@@ -53,6 +54,7 @@ func NewScaffold(opts Options) (*Scaffold, error) {
 		Writer:      writer,
 		Engine:      engine,
 		Prompter:    prompter,
+		HookRunner:  NewHookRunner(),
 		ProjectName: opts.ProjectName,
 	}, nil
 }
@@ -131,31 +133,52 @@ func (s *Scaffold) Run(opts Options) error {
 		}
 	}
 
-	// Step 6: Create output directory (renumbered after safety check)
+	// Make template directory absolute for hooks
+	templateDirAbs := opts.TemplateDir
+	if !filepath.IsAbs(templateDirAbs) {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("failed to get working directory: %w", err)
+		}
+		templateDirAbs = filepath.Join(cwd, templateDirAbs)
+	}
+
+	// Step 6: Build hook environment
+	hookEnv := BuildHookEnv(vars, templateDirAbs, outputDir)
+
+	// Step 7: Run pre-scaffold hooks (before creating output directory)
+	if err := RunPreScaffoldHooks(s.HookRunner, config.Hooks, templateDirAbs, hookEnv); err != nil {
+		return fmt.Errorf("pre-scaffold hook failed: %w", err)
+	}
+
+	// Step 8: Create output directory
 	if err := os.MkdirAll(outputDir, 0o755); err != nil {
 		return fmt.Errorf("failed to create output directory: %w", err)
 	}
 
-	// Step 7: Process template files
+	// Step 9: Process template files
 	if err := s.Writer.Write(opts.TemplateDir, outputDir, vars); err != nil {
 		// Clean up on error
 		_ = os.RemoveAll(outputDir)
 		return fmt.Errorf("failed to process template: %w", err)
 	}
 
-	// Step 8: Copy _generators to _templates
+	// Step 10: Copy _generators to _templates
 	if err := CopyGenerators(opts.TemplateDir, outputDir); err != nil {
 		// Clean up on error
 		_ = os.RemoveAll(outputDir)
 		return fmt.Errorf("failed to copy generators: %w", err)
 	}
 
-	// Step 9: Generate .tagconfig.json
+	// Step 11: Generate .tagconfig.json
 	if err := GenerateTagConfig(outputDir); err != nil {
 		return fmt.Errorf("failed to generate tagconfig: %w", err)
 	}
 
-	// Step 10: Save replay data (unless --no-save)
+	// Step 12: Run post-scaffold hooks (failures are warnings, not errors)
+	RunPostScaffoldHooks(s.HookRunner, config.Hooks, outputDir, hookEnv)
+
+	// Step 13: Save replay data (unless --no-save)
 	if !opts.NoSave && opts.TemplateRef != "" {
 		// Build secrets map from variable definitions
 		secrets := make(map[string]bool)
@@ -172,7 +195,7 @@ func (s *Scaffold) Run(opts Options) error {
 		}
 	}
 
-	// Step 11: Display summary
+	// Step 14: Display summary
 	s.displaySummary(outputDir, vars)
 
 	return nil


### PR DESCRIPTION
## Summary

Implements **Epic 6: Hooks System (Pre/Post Scaffold Commands)** - pre-scaffold and post-scaffold hook execution for template authors to run validation, setup, and initialization commands.

### Changes
- Add `HookRunner` interface and `ShellHookRunner` implementation in `internal/scaffold/hooks.go`
- Add `HookError` error type in `internal/scaffold/errors.go`
- Wire hooks into scaffold flow in `internal/scaffold/scaffold.go`
- Comprehensive test coverage in `internal/scaffold/hooks_test.go`

### Features
- Execute commands before scaffolding (validation, env checks)
- Execute commands after scaffolding (git init, deps install, formatting)
- Pass variables as environment variables (`TAG_VAR_*`, `TAG_PROJECT_NAME`, `TAG_OUTPUT_DIR`, `TAG_TEMPLATE_DIR`)
- Pre-scaffold hook failure: abort cleanly, nothing created
- Post-scaffold hook failure: keep output, display warning
- Timeout support (5 min default) to prevent hanging hooks
- Output size limit (1MB) to prevent OOM from verbose hooks
- Cross-platform shell support (`/bin/sh` on Unix, `cmd.exe` on Windows)

### Hook Configuration Example
```json
{
  "hooks": {
    "pre_scaffold": [
      "echo 'Validating environment...'",
      "which go || (echo 'Go not installed' && exit 1)"
    ],
    "post_scaffold": [
      "git init",
      "go mod tidy",
      "echo 'Project ready!'"
    ]
  }
}
```

### Environment Variables Available in Hooks
| Variable | Description |
|----------|-------------|
| `TAG_PROJECT_NAME` | Value of project_name variable |
| `TAG_OUTPUT_DIR` | Absolute path to output directory |
| `TAG_TEMPLATE_DIR` | Absolute path to template directory |
| `TAG_VAR_*` | All user-defined variables (uppercase, underscores) |

## Test plan
- [x] Unit tests for `BuildHookEnv` (environment variable generation)
- [x] Unit tests for `ShellHookRunner` (command execution)
- [x] Unit tests for `limitedBuffer` (output truncation)
- [x] Integration tests for pre-scaffold hook success/failure
- [x] Integration tests for post-scaffold hook success/failure
- [x] Integration tests for environment variable availability
- [x] Integration tests for working directory correctness
- [x] All tests pass (`go test ./...`)
- [x] Linting passes for new code

Closes #11

🤖 Generated with [Claude Code](https://claude.ai/code)