### PR TITLE
docs: add comprehensive v2 documentation (Epic 8: #13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,121 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.0.0] - 2026-02-05
+
+### Added
+
+#### Project Scaffolding (`tag scaffold`)
+- New `scaffold` command for creating complete projects from templates
+- Support for local and remote template sources
+- Interactive variable prompting with TTY detection
+- Variable types: string, boolean, number, choice
+- Computed/private variables (prefixed with `_`)
+- JSON values file support (`--values`)
+- Variable override via flags (`--meta`)
+- Non-interactive mode (`--no-input`)
+- Force overwrite (`--force`)
+
+#### Remote Template Support
+- GitHub shorthand: `gh:user/repo`, `gh:user/repo@v1.0.0`
+- GitLab shorthand: `gl:user/repo`
+- Bitbucket shorthand: `bb:user/repo`
+- Full Git URLs (HTTPS and SSH)
+- Zip file URLs
+- Local zip file extraction
+- Version/tag/branch pinning with `@version` suffix
+- Subdirectory support within repositories
+- Local caching with `--update` refresh option
+- SSH key and token authentication
+
+#### Replay System
+- Automatic saving of scaffold inputs to `~/.tag/replay/`
+- Replay previous inputs with `--replay` flag
+- Skip saving with `--no-save` flag
+- Secret variables excluded from replay files
+- Version tracking for replay compatibility
+
+#### Hooks System
+- Pre-scaffold hooks (run before file generation)
+- Post-scaffold hooks (run after file generation)
+- Environment variables for hook scripts (`TAG_VAR_*`)
+- Timeout protection (5 minutes per hook)
+- Cross-platform shell execution (Unix and Windows)
+
+#### Cookiecutter Conversion (`tag convert cookiecutter`)
+- Convert `cookiecutter.json` to `tag.template.json`
+- Path placeholder conversion (`{{ cookiecutter.var }}` → `__var__`)
+- Directory and file renaming with filter support
+- Content compatibility analysis
+- Hook migration
+- Dry-run mode for preview
+- Remote template source support
+
+#### Template Engine (Gonja/Jinja2)
+- Jinja2-compatible syntax via [Gonja](https://github.com/noirbizarre/gonja)
+- Template inheritance (`{% extends %}`, `{% block %}`)
+- Macros (`{% macro %}`)
+- Includes (`{% include %}`)
+- Aliased namespaces: `vars.*` and `cookiecutter.*`
+
+#### Built-in Filters
+- Case transformations: `snake`, `pascal`, `camel`, `kebab`, `lower`, `upper`, `title`
+- Inflections: `plural`, `singular`, `ordinalize`, `titleize`, `humanize`
+- String operations: `split`, `join`, `contains`, `hasprefix`, `hassuffix`, `replace`, `trim`, `default`, `truncate`
+- Filter aliases: `snake_case`, `pascal_case`, `camel_case`, `kebab_case`, `pluralize`, `singularize`
+
+#### Path Placeholders
+- Variable substitution in file/directory names: `__varname__`
+- Filter support in paths: `__varname | filter__`
+
+#### Configuration
+- `tag.template.json` for template configuration
+- JSON Schema validation (embedded in binary)
+- Variable definitions with prompts, defaults, and validation
+
+#### Documentation
+- Comprehensive documentation in `docs/` directory
+- Getting started guide
+- Command references
+- Template authoring guide
+- Filter reference
+- Hooks guide
+- Migration guide from v1
+
+### Changed
+
+- Template engine changed from Go `text/template` to Gonja (Jinja2-compatible)
+- Variable access syntax changed (see Migration Guide)
+- Functions are now filters with pipe syntax
+
+### Migration from v1
+
+The template syntax has changed significantly. Key changes:
+
+| v1 Syntax | v2 Syntax |
+|-----------|-----------|
+| `{{ .Name }}` | `{{ name }}` |
+| `{{ .Meta.key }}` | `{{ vars.key }}` |
+| `{{ .N.PascalCase }}` | `{{ n.pascal_case }}` |
+| `{{ caseSnake .Name }}` | `{{ name\|snake }}` |
+| `{{ if .Flag }}...{{ end }}` | `{% if flag %}...{% endif %}` |
+| `{{ range .Items }}...{{ end }}` | `{% for item in items %}...{% endfor %}` |
+
+See [Migration Guide](docs/migration/v1-to-v2.md) for complete migration instructions.
+
+### Dependencies
+
+New dependencies added:
+- `github.com/nikolalohinski/gonja/v2` - Jinja2-compatible template engine
+- `github.com/go-git/go-git/v5` - Git repository fetching
+- `github.com/xeipuuv/gojsonschema` - JSON Schema validation
+
+## [1.x.x] - Previous Releases
+
+See Git history for changes prior to v2.0.0.
+
+[2.0.0]: https://github.com/kaikenlabs/tag/releases/tag/v2.0.0

--- a/README.md
+++ b/README.md
@@ -1,299 +1,215 @@
 # TAG
 
-This is a code generator based on [Pyrotic](https://github.com/code-gorilla-au/pyrotic) but a few perks and features added.
+A powerful code generation and project scaffolding CLI for developers.
 
-## Motivation
+TAG combines the project bootstrapping capabilities of [Cookiecutter](https://cookiecutter.readthedocs.io/) with incremental code generation, supporting both full project scaffolding from templates and adding code to existing projects.
 
-Pyrotic is cool. I like it. But, it is incomplete and insufficient for the uses I need.  
-So, I took it upon myself to modify it and improve it to have a much better template generation system.
+## Features
 
-## Install
+- **Project Scaffolding** - Create complete projects from local or remote templates
+- **Incremental Generation** - Add files, append content, or inject code into existing files
+- **Remote Templates** - Fetch templates from GitHub, GitLab, Bitbucket, or any Git repository
+- **Jinja2 Syntax** - Familiar template syntax via [Gonja](https://github.com/noirbizarre/gonja)
+- **Cookiecutter Compatible** - Convert and use existing Cookiecutter templates
+- **Interactive Prompts** - Guided variable input with defaults and choices
+- **Replay System** - Save and reuse scaffold inputs for reproducibility
+- **Hooks** - Run commands before and after scaffolding
+- **Single Binary** - Pure Go, no external dependencies
 
-```
+## Quick Start
+
+### Install
+
+```bash
 go install github.com/kaikenlabs/tag@latest
 ```
 
-## Initialise the templates directory
+### Scaffold a Project
 
-The initial setup creates a `_templates` directory at the root of the project to hold the generators:
+```bash
+# From a GitHub template
+tag scaffold gh:user/awesome-template
 
+# From a local template
+tag scaffold ./my-template
+
+# With a project name
+tag scaffold gh:user/go-api my-new-api
 ```
+
+### Generate Code in Existing Projects
+
+```bash
+# Initialize TAG in your project
 tag init
+
+# Create a generator
+tag new handler
+
+# Generate code
+tag generate handler UserAuth
 ```
 
-## Work with generators
+## Documentation
 
-Now you can create your first generator:
+| Guide | Description |
+|-------|-------------|
+| [Getting Started](docs/getting-started.md) | Installation and first steps |
+| [Scaffold Command](docs/commands/scaffold.md) | Project scaffolding reference |
+| [Generate Command](docs/commands/generate.md) | Code generation reference |
+| [Convert Command](docs/commands/convert.md) | Cookiecutter migration |
+| [Template Authoring](docs/templates/authoring.md) | Creating templates |
+| [Template Syntax](docs/templates/syntax.md) | Jinja2/Gonja syntax guide |
+| [Filter Reference](docs/templates/filters.md) | Available template filters |
+| [Hooks Guide](docs/templates/hooks.md) | Pre and post hooks |
+| [Migration Guide](docs/migration/v1-to-v2.md) | Migrating from TAG v1 |
+| [tag.template.json](docs/reference/tag.template.json.md) | Configuration reference |
+| [Remote References](docs/reference/remote-refs.md) | Remote template formats |
 
-```
-tag new my_generator
-```
+## Template Sources
 
-A generator is a template or a collection of templates that can be created or added to existing files.  
-To edit your generator, go to the `_templates` directory created and edit it.  
-_TAG_ uses [Go's template language](https://pkg.go.dev/text/template#pkg-overview) so you can build your templates with
-ease.
+TAG supports multiple template sources:
 
-Go [here](#data-exposed-to-each-template) to understand what data is exposed to each template.
+| Format | Example |
+|--------|---------|
+| GitHub | `gh:user/repo`, `gh:user/repo@v1.0.0` |
+| GitLab | `gl:user/repo` |
+| Bitbucket | `bb:user/repo` |
+| Git URL | `https://github.com/user/repo.git` |
+| Zip URL | `https://example.com/template.zip` |
+| Local | `./my-template`, `/path/to/template` |
 
-## Run your generator
+## Template Syntax
 
-Default template path is `_templates` and default file extension is `.tmpl`
+TAG uses Jinja2-compatible syntax:
 
-```sh
-tag generate <name of generator> <name-to-pass-in> <args>
-```
+~~~jinja2
+# {{ vars.project_name }}
 
-As in our example:
+Author: {{ vars.author }}
 
-```sh
-tag generate my_generator myObject
-```
+{% if vars.use_docker %}
+## Docker
 
-## Hooks
+    docker build -t {{ vars.project_name|kebab }} .
 
-`tag` offers the ability of adding pre- and post- hooks for both generators and bundles.
+{% endif %}
 
-As an example, for Go it could be useful to run:
+## Features
+
+{% for feature in vars.features %}
+- {{ feature|title }}
+{% endfor %}
+~~~
+
+### Available Filters
+
+**Case transformations:** `snake`, `pascal`, `camel`, `kebab`, `lower`, `upper`, `title`
+
+**Inflections:** `plural`, `singular`, `ordinalize`, `titleize`, `humanize`
+
+**String operations:** `split`, `join`, `contains`, `hasprefix`, `hassuffix`, `replace`, `trim`, `default`, `truncate`
+
+## Template Configuration
+
+Templates are configured via `tag.template.json`:
 
 ```json
 {
-  "env":{
-    "TAG_PATH": "_templates",
-    "TAG_EXTENSION": ".tmpl",
-    "TAG_SHARED_PATH": "_shared",
-    "TAG_BUNDLE_PATH": "_bundles"
+  "name": "Go API Template",
+  "version": "1.0.0",
+  "vars": {
+    "project_name": "my-api",
+    "author": {
+      "type": "string",
+      "prompt": "Author name",
+      "default": "Your Name"
+    },
+    "license": {
+      "type": "choice",
+      "options": ["MIT", "Apache-2.0", "BSD-3"],
+      "default": "MIT"
+    },
+    "use_docker": {
+      "type": "boolean",
+      "default": true
+    }
   },
   "hooks": {
-    "pre": [],
-    "post":[
-      ["./bin/goimports","-w", "-l","."],
-      ["./bin/gofumpt", "-w", "-l", "."],
-      ["./bin/golangci-lint", "run"]
-    ]
+    "post_scaffold": ["go mod tidy", "git init"]
   }
 }
 ```
 
-**IMPORTANT**: all the hooks will run from the directory that `tag` is being called in, so make sure you add the relative path.
+## Generator Templates
 
-## Tips & Tricks
-
-### Data exposed to each template
-
-_TAG_ will expose the following data to each template:
-
-| Property | Description                                                                                            | Type                | Default | Example                           |
-|----------|--------------------------------------------------------------------------------------------------------|---------------------|---------|-----------------------------------|
-| Name     | The name you passed in the command line                                                                | `string`            | ""      | `my_generator`                    |
-| Args     | The arguments you passed in the command line. It is free form so you can manipulate it in the template | `string`            | nil     | `age:int,name:string`             |
-| Meta     | Additional arguments you can pass from the command line with the `--meta` flag                         | `map[string]string` | nil     | `map[string]string{"foo": "bar"}` |
-
-A quick example:
-
-`tag -d generante myGenerator myName name:string,age:int`
-
-with the following template:
+For incremental code generation, create templates in `_templates/`:
 
 ```
-My generator with name {{ .Name }}.
-I can use now the args:
+---
+to: internal/handlers/{{ name | snake }}_handler.go
+---
+package handlers
 
-{{ $argList := splitByDelimiter .Args "," }}
+type {{ n.pascal_case }}Handler struct {}
 
-{{- range $i, $item := $argList }}
-    {{- $fieldDef := splitByDelimiter $item ":" }}
-    {{ index $fieldDef 0 | casePascal }} {{ index $fieldDef 1 }} `json:"{{ $name_lower }}"`
-{{- end }}
+func New{{ n.pascal_case }}Handler() *{{ n.pascal_case }}Handler {
+    return &{{ n.pascal_case }}Handler{}
+}
 ```
 
-Will result in:
+Generators support three actions:
+- **Create** - Write new files (default)
+- **Append** - Add to existing files (`append: true`)
+- **Inject** - Insert before/after markers (`inject: true` + `before:`/`after:`)
 
-```
-My generator with name myGenerator.
-I can use now the args:
+## Cookiecutter Migration
 
-Name string `json:"name"`
-Age int `json:"age"`
-```
-
-In addition to this, _TAG_ provides a special object `N`.\
-This object facilitates getting the `name` you pass in the command line in different formats:
-
-* PascalCase // `MyGenerator`
-* CamelCase  // `myGenerator`
-* SnakeCase  // `my_generator`
-* KebabCase  // `my-generator`
-* LowerCase  // `mygenerator`
-* UpperCase  // `MYGENERATOR`
-
-So, in your template you can use. `{{ .N.PascalCase }}` to make things easier. :)
-
-### Use different directory
-
-```
-tag --path example/_templates generate cmd --name setup
-tag -p example/_templates generate cmd --name setup
-```
-
-### Use different file extension
-
-The default file extension is `.tmpl`
-
-```
-tag --extension ".template" generate cmd --name setup
-tag -x ".template" generate cmd --name setup
-```
-
-### Dry run mode
-
-Dry run will log to console rather than write to file
-
-```
-tag -d generate cmd --name setup
-tag --dry-run generate cmd --name setup
-```
-
-### Different shared folder
-
-Default shared templates path is `_templates/shared`
-
-```
-tag --shared foo/bar generate cmd --name setup
-tag -s foo/bar generate cmd --name setup
-```
-
-### Dev mode
-
-provides the short file name with logging
+Convert existing Cookiecutter templates:
 
 ```bash
-ENV=DEV tag -p example/_templates generate fakr --meta foo=bar,bin=baz
+tag convert cookiecutter gh:user/cookiecutter-django ./django-tag
 ```
 
-### Using shared templates
+The converter:
+- Transforms `cookiecutter.json` to `tag.template.json`
+- Renames path placeholders (`{{ cookiecutter.var }}` → `__var__`)
+- Reports Jinja2/Gonja syntax differences
+- Copies and analyzes hooks
 
-In some instances you will want to reuse some templates across multiple generators. This can be done by having a
-`shared` directory within the `_templates` directory.\
-Any templates that are declared in the [shared](example/_templates/shared/config.tmpl) directory will be loading along
-with the generator.\
-[Reference](example/_templates/fakr/shared_config.tmpl) the shared template within your generator directory in order to
-inject / append / create file.
+## Commands
 
-## Bundles
+| Command | Description |
+|---------|-------------|
+| `tag scaffold <template>` | Create project from template |
+| `tag generate <generator> <name>` | Run a generator |
+| `tag convert cookiecutter <source>` | Convert Cookiecutter template |
+| `tag init` | Initialize TAG in a project |
+| `tag new <name>` | Create a new generator |
+| `tag new-bundle <name>` | Create a new bundle |
 
-A bundle is a collection of templates you can run all in one go.
+## Global Flags
 
-### Creating bundles
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--dry-run` | `-d` | false | Preview without writing |
+| `--path` | `-tp` | `_templates` | Templates directory |
+| `--shared` | `-sp` | `_shared` | Shared templates directory |
+| `--extension` | `-x` | `.tmpl` | Template file extension |
 
-You can create a bundle like this:
+## Development
 
-`tag new-bundle myBundle`
+```bash
+# Build
+make build
 
-By default, bundles are located in the directory `_bundles` inside of the templates directory.\
+# Test
+go test ./...
 
-If you open the generate file, you can see is a simple `JSON` object in which you can add generators.
-
-### Running bundles
-
-To run a bundle you can use the following command:
-
-`tag generate -b myBundle myName myArgs`
-
-See that the command is very similar to the one we use to run a single generator, but with the addition of the `-b` flag.
-
-This command will run all the generators inside of the bundle file.
-
-## Formatter properties
-
-Formatter will pick up any of these variables within the `---` block and hydrate the metadata for the template.\
-Any properties matching the signature will be added to the Meta property, for example `foo: bar` will be accessible by
-`{{ Meta.foo }}`. View more [examples](example/_templates).
-
-| Property | Type          | Default | Example                 |
-|----------|---------------|---------|-------------------------|
-| to:      | string (path) | ""      | src/lib/utils/readme.md |
-| append:  | bool          | false   | false                   |
-| inject:  | bool          | false   | false                   |
-| before:  | string        | ""      | type config struct      |
-| after:   | string        | ""      | // commands             |
-
-## Built-in template functions and inflectors
-
-ships with some already built in template functions, some [examples](example/_templates/fakr/farkr_case.tmpl)
-
-| func name           | description                         | code example                                | result                        |
-|---------------------|-------------------------------------|---------------------------------------------|-------------------------------| 
-| caseSnake           | convert to snake case               | {{ MetaData \| caseSnake }}                 | meta_data                     |
-| caseKebab           | convert to kebab case               | {{ MetaData \| caseKebab }}                 | meta-data                     |
-| casePascal          | convert to pascal case              | {{ meta_data \| casePascal }}               | MetaData                      |
-| caseLower           | convert to lower case               | {{ MetaData \| caseLower }}                 | metadata                      |
-| caseTitle           | convert to title case               | {{ MetaData \| caseTitle }}                 | METADATA                      |
-| caseCamel           | convert to camel case               | {{ MetaData \| caseCamel }}                 | metaData                      |
-| splitByDelimiter    | splits string by delimiter          | {{ splitByDelimiter "long,list" "," }}      | []string{"long" "list"}       |
-| splitAfterDelimiter | splits string after delimiter       | {{ splitAfterDelimiter "a,long,list" "," }} | []string{"a," "long," "list"} |
-| contains            | checks if string contains substring | {{ contains "foobarbin" "bar" }}            | true                          |
-| hasPrefix           | checks if string has the prefix     | {{ contains "foobarbin" "foo" }}            | true                          |
-| hasSuffix           | checks if string has the suffix     | {{ contains "foobarbin" "bin" }}            | true                          |
-
-`tag` also provide some Inflections using [flect](https://github.com/gobuffalo/flect)
-
-- pluralise
-- singularise
-- ordinalize
-- titleize
-- humanize
-
-## Pass in meta via the command line
-
-you can pass in meta data via the `--meta` or `-m` flag, which takes in a comma (`,`) delimited list, and overrides the
-`{{ .Meta.<your-property> }}` within the template.
-
-```
-tag generate fakr --meta foo=bar,bin=baz
-tag generate fakr -m foo=bar,bin=baz
+# Lint
+make lint
 ```
 
-## Sample output
+## License
 
-```sh
-$ bin/tag generate -b scaffold UserSetting "settings:types.MessagePack"
-[11:55:01.772] tag info: running bundle bundle="scaffold" target="UserSetting"
-[11:55:01.775] tag info: created file="internal/adapters/user_setting.go"
-[11:55:01.776] tag info: created file="internal/models/user_setting.go"
-[11:55:01.778] tag info: created file="internal/controllers/user_setting_controller.go"
-[11:55:01.780] tag info: created file="internal/services/user_setting_service.go"
-[11:55:01.781] tag info: modified file="internal/persistence/repository.go"
-[11:55:01.782] tag info: modified file="internal/persistence/interfaces.go"
-[11:55:01.784] tag info: created file="internal/persistence/postgres/user_setting_repository.go"
-[11:55:01.791] tag info: modified file="internal/persistence/postgres/repository.go"
-[11:55:01.797] tag info: modified file="internal/persistence/postgres/repository.go"
-[11:55:01.798] tag info: modified file="internal/persistence/postgres/helpers.go"
-[11:55:01.799] tag info: created file="tests/component/user_setting_stage_test.go"
-[11:55:01.799] tag info: created file="tests/component/user_setting_test.go"
-[11:55:01.800] tag info: modified file="tests/component/common.go"
-[11:55:01.800] tag info: modified file="internal/server/router.go"
-[11:55:01.808] tag info: modified file="internal/server/router.go"
-[11:55:01.808] tag info: modified file="db/migrate.go"
-[11:55:01.808] tag info: running hook hook="./bin/goimports -w -l ."
-db/migrate.go
-internal/adapters/user_setting.go
-internal/controllers/user_setting_controller.go
-internal/models/user_setting.go
-internal/persistence/interfaces.go
-internal/persistence/postgres/helpers.go
-internal/persistence/postgres/repository.go
-internal/persistence/postgres/user_setting_repository.go
-internal/persistence/repository.go
-internal/server/router.go
-internal/services/user_setting_service.go
-tests/component/common.go
-tests/component/user_setting_stage_test.go
-tests/component/user_setting_test.go
-
-[11:55:04.012] tag info: running hook hook="./bin/gofumpt -w -l ."
-internal/adapters/user_setting.go
-tests/component/user_setting_stage_test.go
-
-[11:55:04.292] tag info: running hook hook="./bin/golangci-lint run"
-```
+MIT

--- a/docs/commands/convert.md
+++ b/docs/commands/convert.md
@@ -1,0 +1,172 @@
+# tag convert cookiecutter
+
+Convert a Cookiecutter template to TAG format.
+
+## Synopsis
+
+```bash
+tag convert cookiecutter <source> [destination] [flags]
+```
+
+## Description
+
+The `convert cookiecutter` command converts existing [Cookiecutter](https://cookiecutter.readthedocs.io/) templates to TAG format. This enables migration of the large ecosystem of Cookiecutter templates to work with TAG.
+
+The conversion process:
+1. Converts `cookiecutter.json` to `tag.template.json`
+2. Renames path placeholders from `{{ cookiecutter.var }}` to `__var__` syntax
+3. Copies and analyzes hook scripts
+4. Reports any content incompatibilities between Jinja2 and Gonja
+
+## Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `source` | Yes | Path or remote reference to the Cookiecutter template |
+| `destination` | No | Output directory (default: `<source-name>-tag`) |
+
+## Flags
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--output <path>` | `-o` | Output directory (alternative to destination argument) |
+| `--dry-run` | | Preview conversion without writing files |
+| `--force` | `-f` | Overwrite output directory if it exists |
+
+## Examples
+
+### Basic Conversion
+
+```bash
+# Convert a local Cookiecutter template
+tag convert cookiecutter ./cookiecutter-myproject ./myproject-tag
+
+# Convert a remote template
+tag convert cookiecutter gh:user/cookiecutter-django ./django-tag
+```
+
+### Preview Mode
+
+```bash
+# See what would be converted without writing files
+tag convert cookiecutter ./cookiecutter-myproject --dry-run
+```
+
+### Force Overwrite
+
+```bash
+# Overwrite existing output directory
+tag convert cookiecutter ./cookiecutter-myproject --force
+```
+
+### Using Output Flag
+
+```bash
+# Alternative to destination argument
+tag convert cookiecutter ./cookiecutter-myproject -o ./output-dir
+```
+
+## Output
+
+The converter displays a detailed summary:
+
+```
+Converted template: ./myproject-tag
+
+✓ Variables: 8 converted
+✓ Directories renamed: 3
+✓ Files renamed: 12
+✓ Files processed: 25
+⚠ Hooks: 2 files copied (review required)
+⚠ Content incompatibilities found: 1
+  Minor adjustments may be needed:
+  - setup.py.tmpl:8 - default_filter_syntax
+    Found: {{ author|default('Anonymous') }}
+    Gonja: {{ author|default:"Anonymous" }}
+
+See: https://tag.kaikenlabs.com/docs/migration
+```
+
+## What Gets Converted
+
+### Configuration
+
+| Cookiecutter | TAG |
+|--------------|-----|
+| `cookiecutter.json` | `tag.template.json` |
+| Variable definitions | Converted with types inferred |
+| Private variables (`_name`) | Preserved as computed variables |
+
+### Directory Structure
+
+| Before | After |
+|--------|-------|
+| `{{ cookiecutter.project_name }}/` | `__project_name__/` |
+| `{{ cookiecutter.var | lower }}/` | `__var | lower__/` |
+
+### Template Content
+
+Template content (Jinja2 syntax) is **mostly compatible**. The converter will:
+- Leave content unchanged (Gonja supports Jinja2)
+- Report incompatibilities that need manual adjustment
+- Document filter syntax differences
+
+## Compatibility Notes
+
+### Fully Compatible Features
+
+- Variable interpolation: `{{ cookiecutter.var }}`
+- Control flow: `{% if %}`, `{% for %}`, `{% endif %}`, `{% endfor %}`
+- Comments: `{# comment #}`
+- Template inheritance: `{% extends %}`, `{% block %}`
+- Macros: `{% macro %}`
+- Filters: Most common filters work identically
+
+### Syntax Differences (Gonja vs Jinja2)
+
+| Feature | Jinja2 | Gonja |
+|---------|--------|-------|
+| Filter with argument | `{{ x\|default('val') }}` | `{{ x\|default:"val" }}` |
+| Format filter | `{{ x\|format('%s') }}` | `{{ x\|format:"%s" }}` |
+| Dict iteration | `{% for k, v in dict.items() %}` | `{% for k, v in dict %}` |
+
+The converter detects and reports these differences automatically.
+
+### Hooks
+
+Cookiecutter hooks (Python scripts in `hooks/`) are copied but require manual review:
+- Shell scripts usually work as-is
+- Python hooks may need adaptation to work without Cookiecutter's environment
+- Environment variables are provided differently (see [Hooks Guide](../templates/hooks.md))
+
+## Post-Conversion Steps
+
+1. **Review incompatibilities**: Fix any reported syntax differences
+2. **Test hooks**: Ensure hook scripts work with TAG's environment
+3. **Verify variables**: Check `tag.template.json` for correct types
+4. **Test scaffold**: Run `tag scaffold` on the converted template
+5. **Update documentation**: Modify any README references to Cookiecutter
+
+## Variable Type Mapping
+
+| Cookiecutter Value | Inferred TAG Type |
+|--------------------|-------------------|
+| `"string value"` | `string` |
+| `true` / `false` | `boolean` |
+| `123` / `45.67` | `number` |
+| `["opt1", "opt2"]` | `choice` with options |
+| `"{{ computed }}"` | Computed variable (string) |
+
+## Error Handling
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| "source template is required" | Missing source argument | Provide a template path |
+| "failed to initialize converter" | Invalid template structure | Verify it's a valid Cookiecutter template |
+| "cookiecutter.json not found" | Missing config file | Ensure `cookiecutter.json` exists in template root |
+
+## See Also
+
+- [Template Authoring](../templates/authoring.md) - TAG template structure
+- [Migration Guide](../migration/v1-to-v2.md) - Detailed migration information
+- [tag.template.json Reference](../reference/tag.template.json.md) - Configuration format

--- a/docs/commands/generate.md
+++ b/docs/commands/generate.md
@@ -1,0 +1,224 @@
+# tag generate
+
+Run a generator or bundle to add code to an existing project.
+
+## Synopsis
+
+```bash
+tag generate <generator|bundle> <name> [args] [flags]
+```
+
+## Description
+
+The `generate` command runs a generator (or bundle of generators) to add files to your existing project. Unlike `scaffold` which creates new projects, `generate` is for incremental code generation within an existing codebase.
+
+Generators are defined in the `_templates/` directory and can:
+- Create new files
+- Append to existing files
+- Inject content before/after markers in files
+
+## Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `generator` or `bundle` | Yes | Name of the generator or bundle to run |
+| `name` | Yes | Name to pass to the template (e.g., `User`, `OrderService`) |
+| `args` | No | Additional arguments accessible as `.Args` in templates |
+
+## Flags
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--bundle` | `-b` | Run a bundle instead of a single generator |
+| `--meta <key=value>` | `-m` | Pass metadata to templates (repeatable) |
+| `--dry-run` | `-d` | Preview output without writing files |
+
+## Global Flags
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--path` | `-tp` | `_templates` | Templates directory path |
+| `--shared` | `-sp` | `_shared` | Shared templates directory name |
+| `--extension` | `-x` | `.tmpl` | Template file extension |
+
+## Examples
+
+### Basic Generation
+
+```bash
+# Generate a handler named "User"
+tag generate handler User
+
+# Generate with arguments
+tag generate model User "name:string,email:string,age:int"
+```
+
+### Using Metadata
+
+```bash
+# Pass single metadata value
+tag generate handler User -m package=api
+
+# Pass multiple metadata values
+tag generate handler User -m package=api -m version=v1
+```
+
+### Running Bundles
+
+```bash
+# Run a bundle (collection of generators)
+tag generate -b scaffold User
+
+# Bundle with arguments
+tag generate -b crud UserProfile "name:string"
+```
+
+### Dry Run Mode
+
+```bash
+# Preview what would be generated
+tag generate handler User --dry-run
+```
+
+### Using Different Template Paths
+
+```bash
+# Custom templates directory
+tag generate handler User --path custom_templates
+
+# Custom file extension
+tag generate handler User --extension .template
+```
+
+## Template Data
+
+Generators receive the following context variables:
+
+| Variable | Type | Description |
+|----------|------|-------------|
+| `name` | `string` | The name argument passed to the command |
+| `vars` | `map[string]any` | Key-value pairs from `--meta` flags |
+| `cookiecutter` | `map[string]any` | Alias for `vars` (compatibility) |
+| `n.pascal_case` | `string` | Name in PascalCase |
+| `n.camel_case` | `string` | Name in camelCase |
+| `n.snake_case` | `string` | Name in snake_case |
+| `n.kebab_case` | `string` | Name in kebab-case |
+| `n.lower_case` | `string` | Name in lowercase |
+| `n.upper_case` | `string` | Name in UPPERCASE |
+
+> **Note**: The `args` argument is available in the metadata block but not in the template body context.
+
+### Example Template
+
+```
+---
+to: internal/handlers/{{ name | snake }}_handler.go
+---
+package handlers
+
+type {{ n.pascal_case }}Handler struct {}
+
+func New{{ n.pascal_case }}Handler() *{{ n.pascal_case }}Handler {
+    return &{{ n.pascal_case }}Handler{}
+}
+```
+
+## Generator vs Bundle
+
+| Feature | Generator | Bundle |
+|---------|-----------|--------|
+| Creates | One or more related files | Multiple generators' output |
+| Location | `_templates/<name>/` | `_bundles/<name>/<name>.bundle.json` |
+| Use case | Single concern (handler, model) | Full feature (CRUD, module) |
+
+### Bundle File Format
+
+```json
+{
+  "generators": [
+    { "name": "model" },
+    { "name": "handler" },
+    { "name": "service" }
+  ]
+}
+```
+
+## Configuration
+
+Generator behavior can be configured via `.tagconfig.json` in your project root:
+
+```json
+{
+  "env": {
+    "TAG_PATH": "_templates",
+    "TAG_EXTENSION": ".tmpl",
+    "TAG_SHARED_PATH": "_shared",
+    "TAG_BUNDLE_PATH": "_bundles"
+  },
+  "hooks": {
+    "pre": [],
+    "post": [
+      ["gofmt", "-w", "."],
+      ["goimports", "-w", "."]
+    ]
+  }
+}
+```
+
+## Hooks
+
+Hooks defined in `.tagconfig.json` run automatically:
+
+- **Pre-hooks**: Run before generation
+- **Post-hooks**: Run after generation (e.g., formatters, linters)
+
+## Template Actions
+
+Templates support three actions via metadata:
+
+### Create (default)
+```
+---
+to: path/to/file.go
+---
+```
+
+### Append
+```
+---
+to: path/to/file.go
+append: true
+---
+```
+
+### Inject
+```
+---
+to: path/to/file.go
+inject: true
+after: "// MARKER"
+---
+```
+
+Or inject before a marker:
+```
+---
+to: path/to/file.go
+inject: true
+before: "// END MARKER"
+---
+```
+
+## Error Handling
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| "generator not found" | Generator directory doesn't exist | Check `_templates/` directory |
+| "cannot open bundle file" | Bundle file not found | Verify bundle exists in `_bundles/` |
+| "hook failed" | Pre/post hook returned error | Check hook command and permissions |
+
+## See Also
+
+- [Template Authoring](../templates/authoring.md) - Creating generators
+- [Hooks Guide](../templates/hooks.md) - Pre and post hooks
+- [Migration Guide](../migration/v1-to-v2.md) - Template syntax changes in v2

--- a/docs/commands/scaffold.md
+++ b/docs/commands/scaffold.md
@@ -1,0 +1,179 @@
+# tag scaffold
+
+Create a new project from a template.
+
+## Synopsis
+
+```bash
+tag scaffold <template> [project-name] [flags]
+```
+
+## Description
+
+The `scaffold` command creates a new project from a local or remote template. It reads the template's `tag.template.json` configuration file to determine available variables and prompts you interactively (unless `--no-input` is specified).
+
+## Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `template` | Yes | Local path or remote reference to the template |
+| `project-name` | No | Override the `project_name` variable |
+
+## Flags
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--output <path>` | `-o` | Output directory (default: `./<project_name>`) |
+| `--values <file>` | | JSON file with variable values |
+| `--meta <key=value>` | `-m` | Variable override (repeatable) |
+| `--no-input` | | Skip interactive prompts, use defaults only |
+| `--force` | `-f` | Overwrite output directory if it exists |
+| `--update` | `-u` | Force refresh of cached remote templates |
+| `--replay` | | Reuse saved values from a previous scaffold |
+| `--no-save` | | Don't save values for future replay |
+
+## Template Formats
+
+TAG supports various template sources:
+
+| Format | Example |
+|--------|---------|
+| Local directory | `./my-template`, `/path/to/template` |
+| GitHub | `gh:user/repo`, `gh:user/repo@v1.0.0`, `gh:user/repo/subdir` |
+| GitLab | `gl:user/repo`, `gl:user/repo@v1.0.0` |
+| Bitbucket | `bb:user/repo` |
+| Git URL | `https://github.com/user/repo.git` |
+| SSH Git URL | `git@github.com:user/repo.git` |
+| Zip URL | `https://example.com/template.zip` |
+| Local zip | `./template.zip` |
+
+See [Remote References](../reference/remote-refs.md) for detailed format documentation.
+
+## Examples
+
+### Basic Usage
+
+```bash
+# Scaffold from a local template
+tag scaffold ./my-template
+
+# Scaffold from a GitHub template
+tag scaffold gh:user/awesome-template
+```
+
+### Specifying Project Name
+
+```bash
+# Project name as argument
+tag scaffold gh:user/go-api my-awesome-api
+
+# Using the -o flag for custom output directory
+tag scaffold gh:user/go-api -o ./projects/my-api
+```
+
+### Providing Variables
+
+```bash
+# Single variable
+tag scaffold gh:user/template -m author="John Doe"
+
+# Multiple variables
+tag scaffold gh:user/template -m author="John Doe" -m license=MIT
+
+# From a JSON file
+tag scaffold gh:user/template --values config.json
+```
+
+**Example values file (config.json):**
+```json
+{
+  "project_name": "my-project",
+  "author": "John Doe",
+  "license": "MIT",
+  "use_docker": true
+}
+```
+
+### Version Pinning
+
+```bash
+# Specific version tag
+tag scaffold gh:user/template@v1.0.0
+
+# Specific branch
+tag scaffold gh:user/template@develop
+
+# Template in a subdirectory
+tag scaffold gh:user/templates/go-api@v1.0.0
+```
+
+### Non-Interactive Mode
+
+```bash
+# Use all default values (for CI/CD)
+tag scaffold gh:user/template --no-input
+
+# Combine with --values for automated scaffolding
+tag scaffold gh:user/template --values config.json --no-input
+```
+
+### Replay Previous Inputs
+
+```bash
+# First scaffold (inputs are saved automatically)
+tag scaffold gh:user/template my-project-1
+
+# Later, scaffold again with saved values
+tag scaffold gh:user/template my-project-2 --replay
+
+# Scaffold without saving inputs
+tag scaffold gh:user/template test-project --no-save
+```
+
+### Force Overwrite
+
+```bash
+# Overwrite existing directory
+tag scaffold gh:user/template my-project --force
+```
+
+### Update Cached Template
+
+```bash
+# Force re-fetch of a cached remote template
+tag scaffold gh:user/template --update
+```
+
+## Variable Input Priority
+
+Variables are resolved in this order (highest priority first):
+
+1. `--meta` flag values
+2. `--values` file
+3. `--replay` saved values
+4. Interactive prompts (if TTY)
+5. Default values from `tag.template.json`
+
+## Replay System
+
+TAG automatically saves your inputs after a successful scaffold (unless `--no-save` is used). Replay files are stored in `~/.tag/replay/`.
+
+The replay system is useful for:
+- Creating multiple projects with similar configuration
+- Re-running scaffolds after template updates
+- Sharing configurations across team members (copy the replay JSON files)
+
+## Error Handling
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| "template path is required" | Missing template argument | Provide a template path or reference |
+| "failed to resolve template" | Invalid reference or network error | Check the template reference format |
+| "output directory already exists" | Target directory exists | Use `--force` or choose a different output |
+| "missing required variable" | Required variable has no value | Provide value via `--meta` or prompts |
+
+## See Also
+
+- [Template Authoring](../templates/authoring.md) - How to create templates
+- [Remote References](../reference/remote-refs.md) - Template source formats
+- [tag.template.json Reference](../reference/tag.template.json.md) - Configuration format

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,110 @@
+# Getting Started with TAG
+
+This guide will help you get started with TAG, from installation to creating your first project from a template.
+
+## Installation
+
+### Using Go Install
+
+```bash
+go install github.com/kaikenlabs/tag@latest
+```
+
+### From Source
+
+```bash
+git clone https://github.com/kaikenlabs/tag.git
+cd tag
+go build -o tag
+./tag --help
+```
+
+## Quick Start
+
+### 1. Scaffold a Project from a Template
+
+The quickest way to start is using an existing template:
+
+```bash
+# From a GitHub template
+tag scaffold gh:user/my-template
+
+# From a local template
+tag scaffold ./my-local-template
+
+# With a project name
+tag scaffold gh:user/go-api my-awesome-api
+```
+
+TAG will:
+1. Fetch the template (if remote)
+2. Prompt you for variable values interactively
+3. Generate your project with all files processed
+
+### 2. Create a Generator for Incremental Code Generation
+
+For adding code to existing projects, use generators:
+
+```bash
+# Initialize TAG in your project
+tag init
+
+# Create a new generator
+tag new handler
+
+# Edit your generator templates in _templates/handler/
+# Then run:
+tag generate handler UserAuth
+```
+
+## Core Concepts
+
+### Templates vs Generators
+
+| Concept | Command | Purpose |
+|---------|---------|---------|
+| **Template** | `tag scaffold` | Create a complete new project from scratch |
+| **Generator** | `tag generate` | Add files to an existing project |
+
+### Template Sources
+
+TAG supports multiple template sources:
+
+| Format | Example | Description |
+|--------|---------|-------------|
+| Local directory | `./my-template` | Local filesystem |
+| GitHub | `gh:user/repo` | GitHub repository |
+| GitLab | `gl:user/repo` | GitLab repository |
+| Bitbucket | `bb:user/repo` | Bitbucket repository |
+| Git URL | `https://github.com/user/repo.git` | Any Git repository |
+| Zip URL | `https://example.com/template.zip` | Remote zip file |
+
+See [Remote References](reference/remote-refs.md) for the complete reference.
+
+### Template Syntax (Jinja2/Gonja)
+
+TAG uses [Gonja](https://github.com/noirbizarre/gonja), a Jinja2-compatible template engine:
+
+~~~jinja2
+# {{ vars.project_name }}
+
+Author: {{ vars.author }}
+
+{% if vars.use_docker %}
+## Docker
+
+Build the image:
+
+    docker build -t {{ vars.project_name|kebab }} .
+
+{% endif %}
+~~~
+
+See [Template Syntax](templates/syntax.md) for the complete syntax guide.
+
+## What's Next?
+
+- [Scaffold Command Reference](commands/scaffold.md) - All flags and options for project scaffolding
+- [Creating Templates](templates/authoring.md) - How to create your own templates
+- [Filter Reference](templates/filters.md) - Available template filters
+- [Migration from v1](migration/v1-to-v2.md) - If upgrading from TAG v1

--- a/docs/migration/v1-to-v2.md
+++ b/docs/migration/v1-to-v2.md
@@ -1,0 +1,473 @@
+# Migration Guide: TAG v1 to v2
+
+This guide covers migrating from TAG v1 (Go `text/template`) to TAG v2 (Jinja2/Gonja).
+
+## Overview
+
+TAG v2 introduces a new template engine based on [Gonja](https://github.com/noirbizarre/gonja), which provides Jinja2-compatible syntax. This change affects:
+
+1. **Template syntax** - Different delimiters and syntax for control flow
+2. **Variable access** - How you reference variables
+3. **Filters** - Functions become filters
+4. **New features** - Template inheritance, macros, and more
+
+## Quick Reference
+
+| Feature | v1 (Go template) | v2 (Jinja2/Gonja) |
+|---------|------------------|-------------------|
+| Variable | `{{ .Name }}` | `{{ name }}` |
+| Meta access | `{{ .Meta.key }}` | `{{ vars.key }}` |
+| Name variants | `{{ .N.PascalCase }}` | `{{ n.pascal_case }}` |
+| Filter | `{{ .Name \| caseSnake }}` | `{{ name\|snake }}` |
+| Conditional | `{{ if .Flag }}...{{ end }}` | `{% if flag %}...{% endif %}` |
+| Loop | `{{ range .Items }}...{{ end }}` | `{% for item in items %}...{% endfor %}` |
+| Comment | `{{/* comment */}}` | `{# comment #}` |
+
+## Variable Access
+
+### Basic Variables
+
+**v1:**
+```go
+{{ .Name }}
+{{ .Args }}
+```
+
+**v2:**
+```jinja2
+{{ name }}
+{{ args }}
+```
+
+### Metadata/Custom Variables
+
+**v1:**
+```go
+{{ .Meta.author }}
+{{ .Meta.license }}
+```
+
+**v2:**
+```jinja2
+{{ vars.author }}
+{{ vars.license }}
+```
+
+### Name Variants
+
+**v1:**
+```go
+{{ .N.PascalCase }}
+{{ .N.CamelCase }}
+{{ .N.SnakeCase }}
+{{ .N.KebabCase }}
+{{ .N.LowerCase }}
+{{ .N.UpperCase }}
+```
+
+**v2:**
+```jinja2
+{{ n.pascal_case }}
+{{ n.camel_case }}
+{{ n.snake_case }}
+{{ n.kebab_case }}
+{{ n.lower_case }}
+{{ n.upper_case }}
+```
+
+## Filters (formerly Functions)
+
+### Case Transformations
+
+**v1:**
+```go
+{{ caseSnake .Name }}
+{{ casePascal .Name }}
+{{ caseCamel .Name }}
+{{ caseKebab .Name }}
+{{ caseLower .Name }}
+{{ caseTitle .Name }}
+```
+
+**v2:**
+```jinja2
+{{ name|snake }}
+{{ name|pascal }}
+{{ name|camel }}
+{{ name|kebab }}
+{{ name|lower }}
+{{ name|title }}
+```
+
+### Inflections
+
+**v1:**
+```go
+{{ pluralise .Name }}
+{{ singularise .Name }}
+{{ ordinalize .Name }}
+{{ titleize .Name }}
+{{ humanize .Name }}
+```
+
+**v2:**
+```jinja2
+{{ name|plural }}
+{{ name|singular }}
+{{ name|ordinalize }}
+{{ name|titleize }}
+{{ name|humanize }}
+```
+
+### String Operations
+
+**v1:**
+```go
+{{ splitByDelimiter .Args "," }}
+{{ splitAfterDelimiter .Args "," }}
+{{ contains .Name "admin" }}
+{{ hasPrefix .Name "user" }}
+{{ hasSuffix .Name "Handler" }}
+```
+
+**v2:**
+```jinja2
+{{ args|split:"," }}
+{{ args|split:"," }}
+{{ name|contains:"admin" }}
+{{ name|hasprefix:"user" }}
+{{ name|hassuffix:"Handler" }}
+```
+
+### Chaining Filters
+
+**v1:**
+```go
+{{ pluralise (casePascal .Name) }}
+```
+
+**v2:**
+```jinja2
+{{ name|pascal|plural }}
+```
+
+## Control Flow
+
+### Conditionals
+
+**v1:**
+```go
+{{ if .Meta.useDocker }}
+  Docker content
+{{ end }}
+
+{{ if eq .Meta.license "MIT" }}
+  MIT license
+{{ else if eq .Meta.license "Apache" }}
+  Apache license
+{{ else }}
+  Other license
+{{ end }}
+```
+
+**v2:**
+```jinja2
+{% if vars.use_docker %}
+  Docker content
+{% endif %}
+
+{% if vars.license == "MIT" %}
+  MIT license
+{% elif vars.license == "Apache" %}
+  Apache license
+{% else %}
+  Other license
+{% endif %}
+```
+
+### Boolean Logic
+
+**v1:**
+```go
+{{ if and .Meta.useDocker .Meta.useCI }}
+{{ if or .Meta.useLogging .Meta.useMetrics }}
+{{ if not .Meta.skipTests }}
+```
+
+**v2:**
+```jinja2
+{% if vars.use_docker and vars.use_ci %}
+{% if vars.use_logging or vars.use_metrics %}
+{% if not vars.skip_tests %}
+```
+
+### Loops
+
+**v1:**
+```go
+{{ range $index, $item := .Items }}
+  {{ $index }}: {{ $item }}
+{{ end }}
+```
+
+**v2:**
+```jinja2
+{% for item in items %}
+  {{ loop.index0 }}: {{ item }}
+{% endfor %}
+```
+
+**Loop Variables in v2:**
+- `loop.index` - 1-indexed iteration count
+- `loop.index0` - 0-indexed iteration count
+- `loop.first` - True on first iteration
+- `loop.last` - True on last iteration
+- `loop.length` - Total number of items
+
+### Loop with Else
+
+**v1:**
+```go
+{{ if .Items }}
+  {{ range .Items }}...{{ end }}
+{{ else }}
+  No items
+{{ end }}
+```
+
+**v2:**
+```jinja2
+{% for item in items %}
+  ...
+{% else %}
+  No items
+{% endfor %}
+```
+
+## Comments
+
+**v1:**
+```go
+{{/* This is a comment */}}
+```
+
+**v2:**
+```jinja2
+{# This is a comment #}
+```
+
+## Template Metadata Block
+
+The metadata block syntax remains unchanged:
+
+```
+---
+to: path/to/output.go
+inject: true
+after: // marker
+---
+Template content here
+```
+
+However, the template content after `---` now uses Jinja2 syntax.
+
+## New Features in v2
+
+### Template Inheritance
+
+```jinja2
+{# base.tmpl #}
+<!DOCTYPE html>
+<html>
+  <head>{% block head %}{% endblock %}</head>
+  <body>{% block content %}{% endblock %}</body>
+</html>
+
+{# child.tmpl #}
+{% extends "base.tmpl" %}
+{% block content %}
+  <h1>{{ vars.title }}</h1>
+{% endblock %}
+```
+
+### Macros
+
+```jinja2
+{% macro input(name, type="text") %}
+<input type="{{ type }}" name="{{ name }}">
+{% endmacro %}
+
+{{ input("username") }}
+{{ input("password", type="password") }}
+```
+
+### Includes
+
+```jinja2
+{% include "partials/header.tmpl" %}
+```
+
+### Raw Blocks
+
+```jinja2
+{% raw %}
+This {{ will not }} be processed
+{% endraw %}
+```
+
+### Set Variables
+
+```jinja2
+{% set full_name = vars.first_name ~ " " ~ vars.last_name %}
+{{ full_name }}
+```
+
+## Migration Steps
+
+### Step 1: Update Variable References
+
+Replace all Go template variable references:
+
+```bash
+# Find patterns to update
+grep -r "{{ \." _templates/
+
+# Common replacements:
+# {{ .Name }} → {{ name }}
+# {{ .Meta.X }} → {{ vars.x }}
+# {{ .N.PascalCase }} → {{ n.pascal_case }}
+```
+
+### Step 2: Convert Functions to Filters
+
+```bash
+# Find function calls
+grep -r "case\|pluralise\|singularise" _templates/
+
+# Replace patterns:
+# {{ caseSnake .X }} → {{ x|snake }}
+# {{ pluralise .X }} → {{ x|plural }}
+```
+
+### Step 3: Update Control Flow
+
+```bash
+# Find Go template control flow
+grep -r "{{ if\|{{ range\|{{ end }}" _templates/
+
+# Replace:
+# {{ if .X }}...{{ end }} → {% if x %}...{% endif %}
+# {{ range .X }}...{{ end }} → {% for x in items %}...{% endfor %}
+```
+
+### Step 4: Update Comments
+
+```bash
+# Find Go template comments
+grep -r "{{/\*" _templates/
+
+# Replace:
+# {{/* comment */}} → {# comment #}
+```
+
+### Step 5: Test Each Template
+
+```bash
+# Test with dry run
+tag generate my_generator TestName --dry-run
+
+# Compare output with expected result
+```
+
+## Example Migration
+
+### Before (v1)
+
+```go
+---
+to: internal/handlers/{{ .Name | caseSnake }}_handler.go
+---
+package handlers
+
+{{/* {{ .N.PascalCase }}Handler handles {{ .Name }} requests */}}
+
+{{ if .Meta.useLogging }}
+import "log/slog"
+{{ end }}
+
+type {{ .N.PascalCase }}Handler struct {
+    {{ if .Meta.useDB }}
+    db *Database
+    {{ end }}
+}
+
+{{ range $method := splitByDelimiter .Args "," }}
+func (h *{{ $.N.PascalCase }}Handler) {{ $method | casePascal }}() error {
+    {{ if $.Meta.useLogging }}
+    slog.Info("{{ $method }} called")
+    {{ end }}
+    return nil
+}
+{{ end }}
+```
+
+### After (v2)
+
+```jinja2
+---
+to: internal/handlers/{{ name | snake }}_handler.go
+---
+package handlers
+
+{# {{ n.pascal_case }}Handler handles {{ name }} requests #}
+
+{% if vars.use_logging %}
+import "log/slog"
+{% endif %}
+
+type {{ n.pascal_case }}Handler struct {
+    {% if vars.use_db %}
+    db *Database
+    {% endif %}
+}
+
+{% for method in args|split:"," %}
+func (h *{{ n.pascal_case }}Handler) {{ method|pascal }}() error {
+    {% if vars.use_logging %}
+    slog.Info("{{ method }} called")
+    {% endif %}
+    return nil
+}
+{% endfor %}
+```
+
+## Troubleshooting
+
+### Common Errors
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| `undefined variable` | Variable not in context | Check variable name spelling and case |
+| `unknown filter` | Filter name changed | Use new filter name (e.g., `snake` not `caseSnake`) |
+| `unexpected token` | Mixed v1/v2 syntax | Complete the migration for the file |
+
+### Getting Help
+
+If you encounter issues:
+
+1. Check the [Template Syntax Guide](../templates/syntax.md)
+2. Review the [Filter Reference](../templates/filters.md)
+3. Test with `--dry-run` to see output without writing files
+
+## Backwards Compatibility
+
+- **Generators**: Existing generators need syntax migration
+- **Bundles**: Bundle files (JSON) are unchanged
+- **Configuration**: `.tagconfig.json` format is unchanged
+- **Hooks**: Hook syntax in `.tagconfig.json` is unchanged
+
+## See Also
+
+- [Template Syntax](../templates/syntax.md) - Complete v2 syntax guide
+- [Filter Reference](../templates/filters.md) - All available filters
+- [Template Authoring](../templates/authoring.md) - Creating new templates

--- a/docs/reference/remote-refs.md
+++ b/docs/reference/remote-refs.md
@@ -1,0 +1,335 @@
+# Remote Template References
+
+TAG supports fetching templates from various remote sources. This document covers all supported reference formats.
+
+## Quick Reference
+
+| Format | Example |
+|--------|---------|
+| GitHub | `gh:user/repo` |
+| GitLab | `gl:user/repo` |
+| Bitbucket | `bb:user/repo` |
+| With version | `gh:user/repo@v1.0.0` |
+| With subpath | `gh:user/repo/templates/go-api` |
+| Git URL | `https://github.com/user/repo.git` |
+| SSH URL | `git@github.com:user/repo.git` |
+| Zip URL | `https://example.com/template.zip` |
+| Local path | `./my-template` |
+| Local zip | `./template.zip` |
+
+## Shorthand Formats
+
+### GitHub (`gh:`)
+
+```bash
+gh:user/repo
+gh:organization/repo
+gh:user/repo@v1.0.0
+gh:user/repo@main
+gh:user/repo/path/to/template
+gh:user/repo@v1.0.0/path/to/template
+```
+
+**Examples:**
+```bash
+tag scaffold gh:kaikenlabs/go-api-template
+tag scaffold gh:myorg/templates@v2.0.0
+tag scaffold gh:myorg/templates/microservice
+```
+
+### GitLab (`gl:`)
+
+```bash
+gl:user/repo
+gl:group/subgroup/repo
+gl:user/repo@v1.0.0
+gl:user/repo/path/to/template
+```
+
+**Examples:**
+```bash
+tag scaffold gl:mygroup/templates
+tag scaffold gl:company/infra/templates@main
+```
+
+### Bitbucket (`bb:`)
+
+```bash
+bb:user/repo
+bb:workspace/repo
+bb:user/repo@v1.0.0
+bb:user/repo/path/to/template
+```
+
+**Examples:**
+```bash
+tag scaffold bb:myteam/go-template
+tag scaffold bb:myteam/templates@develop/python-api
+```
+
+## Version Specifiers
+
+Use `@` to specify a version (tag, branch, or commit):
+
+| Specifier | Example | Description |
+|-----------|---------|-------------|
+| Tag | `@v1.0.0` | Specific release tag |
+| Branch | `@main` | Branch name |
+| Branch | `@develop` | Feature branch |
+| Commit | `@a1b2c3d` | Specific commit SHA |
+
+**Examples:**
+```bash
+# Latest (default branch)
+tag scaffold gh:user/template
+
+# Specific version
+tag scaffold gh:user/template@v1.2.3
+
+# Development branch
+tag scaffold gh:user/template@develop
+
+# Specific commit
+tag scaffold gh:user/template@abc123def
+```
+
+## Subpaths
+
+Access templates in subdirectories:
+
+```bash
+# Template at repo-root/templates/go-api/
+gh:user/repo/templates/go-api
+
+# With version
+gh:user/repo@v1.0.0/templates/go-api
+```
+
+This is useful for monorepos containing multiple templates:
+
+```
+templates-repo/
+├── templates/
+│   ├── go-api/
+│   │   └── tag.template.json
+│   ├── python-cli/
+│   │   └── tag.template.json
+│   └── react-app/
+│       └── tag.template.json
+```
+
+```bash
+tag scaffold gh:company/templates/templates/go-api
+tag scaffold gh:company/templates/templates/python-cli
+```
+
+## Full Git URLs
+
+### HTTPS URLs
+
+```bash
+https://github.com/user/repo.git
+https://gitlab.com/user/repo.git
+https://bitbucket.org/user/repo.git
+https://git.example.com/user/repo.git
+```
+
+**With version:**
+```bash
+https://github.com/user/repo.git@v1.0.0
+```
+
+### SSH URLs
+
+```bash
+git@github.com:user/repo.git
+git@gitlab.com:user/repo.git
+git+ssh://git@github.com/user/repo.git
+```
+
+### Git Protocol URLs
+
+```bash
+git://github.com/user/repo.git
+```
+
+## Zip Files
+
+### Remote Zip
+
+```bash
+tag scaffold https://example.com/template.zip
+tag scaffold https://github.com/user/repo/archive/refs/tags/v1.0.0.zip
+```
+
+### Local Zip
+
+```bash
+tag scaffold ./my-template.zip
+tag scaffold /path/to/template.zip
+```
+
+## Local Paths
+
+```bash
+# Relative paths
+tag scaffold ./my-template
+tag scaffold ../shared-templates/go-api
+
+# Absolute paths
+tag scaffold /home/user/templates/go-api
+tag scaffold ~/templates/go-api
+```
+
+## Cache Behavior
+
+Remote templates are cached locally to avoid repeated downloads.
+
+### Cache Location
+
+```
+~/.tag/cache/
+├── gh_user_repo/           # Latest version
+├── gh_user_repo@v1.0.0/    # Pinned version
+├── gl_org_template/
+└── _url_a1b2c3d4e5f6/      # URL-based (hashed)
+```
+
+### Cache Management
+
+**Force refresh:**
+```bash
+tag scaffold gh:user/template --update
+```
+
+**Clear all cache:**
+```bash
+rm -rf ~/.tag/cache/
+```
+
+### Cache TTL
+
+- Non-pinned templates (no `@version`) expire after **24 hours**
+- Version-pinned templates (`@v1.0.0`) never expire
+- Use `--update` to force refresh regardless of TTL
+
+## Authentication
+
+### SSH Keys
+
+For SSH URLs, TAG uses your SSH agent or `~/.ssh/` keys:
+
+```bash
+# Uses ~/.ssh/id_rsa or SSH agent
+tag scaffold git@github.com:private/repo.git
+```
+
+### HTTPS Credentials
+
+For private repositories over HTTPS, TAG uses provider-specific tokens via environment variables:
+
+```bash
+# GitHub
+export GITHUB_TOKEN=your-personal-access-token
+
+# GitLab
+export GITLAB_TOKEN=your-personal-access-token
+
+# Bitbucket
+export BITBUCKET_TOKEN=your-app-password
+```
+
+TAG automatically uses these tokens when fetching from the corresponding provider.
+
+### Personal Access Tokens
+
+For GitHub/GitLab/Bitbucket private repos:
+
+```bash
+# Set the appropriate token for your provider
+export GITHUB_TOKEN=ghp_xxxxxxxxxxxx
+
+# Then fetch normally
+tag scaffold gh:myorg/private-template
+```
+
+## Error Handling
+
+### Common Errors
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| "empty reference" | No template specified | Provide a template path or reference |
+| "missing repository path" | Invalid shorthand | Use format `gh:user/repo` |
+| "invalid shorthand format" | Missing user or repo | Check reference format |
+| "local path not found" | Path doesn't exist | Verify the path exists |
+| "local zip file not found" | Zip file missing | Check file path |
+| "network error" | No connectivity | Check internet connection |
+| "authentication failed" | Invalid credentials | Verify SSH keys or tokens |
+
+### Debugging
+
+```bash
+# Verbose output
+ENV=DEV tag scaffold gh:user/template
+```
+
+## Best Practices
+
+### 1. Use Version Pinning for Production
+
+```bash
+# Don't use in CI/CD (may change)
+tag scaffold gh:company/template
+
+# Do use in CI/CD (stable)
+tag scaffold gh:company/template@v1.2.3
+```
+
+### 2. Use Shorthand When Possible
+
+```bash
+# Preferred
+tag scaffold gh:user/repo
+
+# More verbose
+tag scaffold https://github.com/user/repo.git
+```
+
+### 3. Organize Monorepo Templates
+
+```
+company-templates/
+├── README.md
+├── go/
+│   ├── api/
+│   │   └── tag.template.json
+│   └── cli/
+│       └── tag.template.json
+├── python/
+│   └── flask/
+│       └── tag.template.json
+```
+
+```bash
+tag scaffold gh:company/templates/go/api
+tag scaffold gh:company/templates/python/flask@v2.0.0
+```
+
+### 4. Document Your Template Reference
+
+In your project's README:
+
+```markdown
+## Create New Service
+
+```bash
+tag scaffold gh:company/templates/microservice@v1.5.0 my-new-service
+```
+```
+
+## See Also
+
+- [Scaffold Command](../commands/scaffold.md) - Full command reference
+- [Template Authoring](../templates/authoring.md) - Creating templates
+- [Getting Started](../getting-started.md) - Quick start guide

--- a/docs/reference/tag.template.json.md
+++ b/docs/reference/tag.template.json.md
@@ -1,0 +1,423 @@
+# tag.template.json Reference
+
+The `tag.template.json` file defines the configuration for a TAG scaffold template.
+
+## Location
+
+Place `tag.template.json` in the root of your template directory:
+
+```
+my-template/
+├── tag.template.json    ← Configuration file
+├── __project_name__/
+│   └── ...
+```
+
+## Schema Reference
+
+For IDE autocompletion, add the `$schema` property:
+
+```json
+{
+  "$schema": "https://tag.kaikenlabs.com/schemas/tag.template.schema.json",
+  "name": "My Template",
+  ...
+}
+```
+
+## Top-Level Properties
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `name` | string | No | Template display name |
+| `description` | string | No | Template description |
+| `version` | string | No | Template version (semver recommended) |
+| `vars` | object | No | Variable definitions |
+| `hooks` | object | No | Pre and post scaffold hooks |
+
+### Example
+
+```json
+{
+  "name": "Go API Template",
+  "description": "A production-ready Go API with Docker and CI/CD",
+  "version": "1.2.0",
+  "vars": {
+    "project_name": "my-api",
+    "author": "Your Name"
+  },
+  "hooks": {
+    "post_scaffold": ["go mod tidy"]
+  }
+}
+```
+
+## Variable Definitions
+
+Variables can be defined in two formats: short form and long form.
+
+### Short Form
+
+Use short form for simple string defaults:
+
+```json
+{
+  "vars": {
+    "project_name": "my-project",
+    "author": "Your Name",
+    "version": "1.0.0"
+  }
+}
+```
+
+Short form also works for boolean and number defaults:
+
+```json
+{
+  "vars": {
+    "use_docker": true,
+    "port": 8080
+  }
+}
+```
+
+### Long Form
+
+Use long form for full control over variable behavior:
+
+```json
+{
+  "vars": {
+    "author": {
+      "type": "string",
+      "prompt": "Who is the author?",
+      "default": "Your Name",
+      "required": true
+    }
+  }
+}
+```
+
+### Variable Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `type` | string | Variable type: `string`, `boolean`, `number`, `choice` |
+| `prompt` | string | Question shown during interactive input |
+| `default` | any | Default value if not provided |
+| `required` | boolean | Whether the variable must have a value (default: false) |
+| `options` | string[] | Available choices (required for `choice` type) |
+| `secret` | boolean | Hide input and exclude from replay (default: false) |
+
+## Variable Types
+
+### String Variables
+
+```json
+{
+  "vars": {
+    "author": {
+      "type": "string",
+      "prompt": "Author name",
+      "default": "Your Name"
+    }
+  }
+}
+```
+
+**Prompt display:**
+```
+Author name [Your Name]: █
+```
+
+### Boolean Variables
+
+```json
+{
+  "vars": {
+    "use_docker": {
+      "type": "boolean",
+      "prompt": "Include Docker setup?",
+      "default": false
+    }
+  }
+}
+```
+
+**Prompt display:**
+```
+Include Docker setup? [y/N]: █
+```
+
+### Number Variables
+
+```json
+{
+  "vars": {
+    "port": {
+      "type": "number",
+      "prompt": "Server port",
+      "default": 8080
+    }
+  }
+}
+```
+
+**Prompt display:**
+```
+Server port [8080]: █
+```
+
+### Choice Variables
+
+```json
+{
+  "vars": {
+    "license": {
+      "type": "choice",
+      "prompt": "Select a license",
+      "options": ["MIT", "BSD-3", "Apache-2.0", "GPL-3.0"],
+      "default": "MIT"
+    }
+  }
+}
+```
+
+**Prompt display:**
+```
+Select a license:
+  1. MIT
+  2. BSD-3
+  3. Apache-2.0
+  4. GPL-3.0
+Choose [1]: █
+```
+
+### Required Variables
+
+```json
+{
+  "vars": {
+    "module_path": {
+      "type": "string",
+      "prompt": "Go module path (e.g., github.com/user/project)",
+      "required": true
+    }
+  }
+}
+```
+
+Required variables:
+- Must be provided via prompt, `--meta`, or `--values`
+- Don't have a default value (or default is empty)
+- Scaffold fails if not provided with `--no-input`
+
+### Secret Variables
+
+```json
+{
+  "vars": {
+    "api_key": {
+      "type": "string",
+      "prompt": "API key",
+      "secret": true
+    }
+  }
+}
+```
+
+Secret variables:
+- Input is hidden during prompting
+- **Not saved** in replay files
+- Must be re-entered on `--replay`
+
+### Private Variables
+
+Variables starting with `_` are private (not prompted):
+
+```json
+{
+  "vars": {
+    "project_name": "my-project",
+    "_project_slug": "{{ vars.project_name|snake }}",
+    "_docker_image": "{{ vars.project_name|kebab }}"
+  }
+}
+```
+
+Private variables:
+- Not shown in interactive prompts
+- Stored as literal strings in the configuration
+- The Jinja2 expressions shown above are NOT pre-evaluated
+- To use computed values, reference them in templates or use template filters inline
+
+## Hooks Configuration
+
+### Structure
+
+```json
+{
+  "hooks": {
+    "pre_scaffold": ["command1", "command2"],
+    "post_scaffold": ["command1", "command2"]
+  }
+}
+```
+
+### Pre-Scaffold Hooks
+
+```json
+{
+  "hooks": {
+    "pre_scaffold": [
+      "./scripts/validate-env.sh",
+      "echo 'Starting scaffold...'"
+    ]
+  }
+}
+```
+
+- Run **before** file generation
+- Working directory: template directory
+- Failure **stops** scaffold (no files created)
+
+### Post-Scaffold Hooks
+
+```json
+{
+  "hooks": {
+    "post_scaffold": [
+      "go mod tidy",
+      "git init",
+      "git add .",
+      "git commit -m 'Initial commit'"
+    ]
+  }
+}
+```
+
+- Run **after** file generation
+- Working directory: output directory
+- Failure is a **warning** (files are kept)
+
+See [Hooks Guide](../templates/hooks.md) for complete documentation.
+
+## Complete Example
+
+```json
+{
+  "$schema": "https://tag.kaikenlabs.com/schemas/tag.template.schema.json",
+  "name": "Go Microservice Template",
+  "description": "Production-ready Go microservice with Docker, CI/CD, and observability",
+  "version": "2.1.0",
+
+  "vars": {
+    "project_name": "my-service",
+
+    "module_path": {
+      "type": "string",
+      "prompt": "Go module path (e.g., github.com/company/service)",
+      "required": true
+    },
+
+    "author": {
+      "type": "string",
+      "prompt": "Author name",
+      "default": "Your Name"
+    },
+
+    "description": {
+      "type": "string",
+      "prompt": "Project description",
+      "default": "A Go microservice"
+    },
+
+    "port": {
+      "type": "number",
+      "prompt": "HTTP server port",
+      "default": 8080
+    },
+
+    "license": {
+      "type": "choice",
+      "prompt": "License",
+      "options": ["MIT", "Apache-2.0", "BSD-3-Clause", "Proprietary"],
+      "default": "MIT"
+    },
+
+    "use_docker": {
+      "type": "boolean",
+      "prompt": "Include Docker support?",
+      "default": true
+    },
+
+    "use_ci": {
+      "type": "boolean",
+      "prompt": "Include GitHub Actions CI?",
+      "default": true
+    },
+
+    "database": {
+      "type": "choice",
+      "prompt": "Database",
+      "options": ["none", "postgres", "mysql", "mongodb"],
+      "default": "postgres"
+    },
+
+    "_project_slug": "{{ vars.project_name|snake }}",
+    "_docker_image": "{{ vars.project_name|kebab }}",
+    "_package_name": "{{ vars.module_path|split:'/'|last }}"
+  },
+
+  "hooks": {
+    "pre_scaffold": [
+      "echo 'Creating {{ vars.project_name }}...'"
+    ],
+    "post_scaffold": [
+      "go mod tidy",
+      "git init",
+      "git add .",
+      "git commit -m 'Initial commit from TAG template'",
+      "echo ''",
+      "echo 'Project created successfully!'",
+      "echo 'Next steps:'",
+      "echo '  cd {{ vars.project_name }}'",
+      "echo '  make run'"
+    ]
+  }
+}
+```
+
+## Version Format
+
+The `version` field should follow [Semantic Versioning](https://semver.org/):
+
+```
+MAJOR.MINOR.PATCH[-PRERELEASE][+BUILD]
+```
+
+Examples:
+- `1.0.0`
+- `2.1.0`
+- `1.0.0-beta.1`
+- `1.0.0+build.123`
+
+## JSON Schema
+
+The full JSON Schema is embedded in TAG and available at:
+- Runtime: `internal/schema/tag.template.schema.json`
+- Published: `https://tag.kaikenlabs.com/schemas/tag.template.schema.json`
+
+## Validation
+
+TAG validates `tag.template.json` at scaffold time:
+- Required `options` for `choice` type
+- Valid variable types
+- Valid semver for `version` (if provided)
+- JSON structure conformance to the schema
+
+## See Also
+
+- [Template Authoring](../templates/authoring.md) - Creating templates
+- [Hooks Guide](../templates/hooks.md) - Hook configuration details
+- [Scaffold Command](../commands/scaffold.md) - Using templates

--- a/docs/templates/authoring.md
+++ b/docs/templates/authoring.md
@@ -1,0 +1,424 @@
+# Template Authoring Guide
+
+This guide covers how to create TAG templates for project scaffolding.
+
+## Template Structure
+
+A TAG template is a directory with the following structure:
+
+```
+my-template/
+├── tag.template.json              # Template configuration (required)
+├── __project_name__/              # Project files with path placeholders
+│   ├── cmd/
+│   │   └── main.go.tmpl           # Processed as Jinja2 template
+│   ├── internal/
+│   │   └── __module_name__/       # Directory with placeholder
+│   │       └── service.go.tmpl
+│   ├── assets/
+│   │   └── logo.png               # Copied as-is (no .tmpl)
+│   ├── README.md.tmpl
+│   └── .gitignore
+└── _generators/                   # Optional: becomes _templates/ in output
+    └── handler/
+        └── handler.tmpl
+```
+
+## File Processing Rules
+
+| File Pattern | Processing |
+|--------------|------------|
+| `*.tmpl` | Parsed as Jinja2 template, `.tmpl` extension removed |
+| `__varname__` in path | Replaced with variable value |
+| `__varname \| filter__` in path | Replaced with filtered variable value |
+| All other files | Copied as-is (binary-safe) |
+
+## tag.template.json
+
+The `tag.template.json` file defines your template's configuration:
+
+```json
+{
+  "name": "Go API Template",
+  "description": "A production-ready Go API template",
+  "version": "1.0.0",
+  "vars": {
+    "project_name": "my-project",
+    "author": {
+      "type": "string",
+      "prompt": "Who is the author?",
+      "default": "Your Name",
+      "required": true
+    },
+    "license": {
+      "type": "choice",
+      "prompt": "Select a license",
+      "options": ["MIT", "BSD-3", "Apache-2.0"],
+      "default": "MIT"
+    },
+    "use_docker": {
+      "type": "boolean",
+      "prompt": "Include Docker setup?",
+      "default": false
+    },
+    "port": {
+      "type": "number",
+      "prompt": "Server port",
+      "default": 8080
+    },
+    "_project_slug": "{{ vars.project_name|snake }}"
+  },
+  "hooks": {
+    "pre_scaffold": ["./scripts/validate.sh"],
+    "post_scaffold": ["go mod tidy", "git init"]
+  }
+}
+```
+
+See [tag.template.json Reference](../reference/tag.template.json.md) for complete documentation.
+
+## Variable Definition Formats
+
+### Short Form (String Default)
+
+```json
+{
+  "vars": {
+    "project_name": "my-project"
+  }
+}
+```
+
+### Long Form (Full Options)
+
+```json
+{
+  "vars": {
+    "author": {
+      "type": "string",
+      "prompt": "Who is the author?",
+      "default": "Your Name",
+      "required": true
+    }
+  }
+}
+```
+
+### Variable Types
+
+| Type | Description | Example |
+|------|-------------|---------|
+| `string` | Free text input | Author name, description |
+| `boolean` | Yes/No selection | `use_docker`, `include_tests` |
+| `number` | Numeric input | Port number, version |
+| `choice` | Selection from list | License, framework |
+
+### Private/Computed Variables
+
+Variables starting with `_` are not prompted and are treated as computed values:
+
+```json
+{
+  "vars": {
+    "project_name": "my-project",
+    "_project_slug": "{{ vars.project_name|snake }}"
+  }
+}
+```
+
+> **Note**: Computed variable expressions (like `{{ vars.project_name|snake }}`) are stored as literal strings in the configuration. They are NOT pre-evaluated before template rendering - the expression is passed through as-is and must be rendered in your templates if you want the computed value.
+
+## Path Placeholders
+
+Use `__varname__` syntax in file and directory names:
+
+### Basic Substitution
+
+```
+__project_name__/           → my_awesome_project/
+__module_name__.go.tmpl     → users.go
+```
+
+### With Filters
+
+```
+__project_name | snake__/   → my_awesome_project/
+__project_name | pascal__/  → MyAwesomeProject/
+__model | plural__/         → users/
+```
+
+### Supported Path Filters
+
+- `snake` - snake_case
+- `pascal` - PascalCase
+- `camel` - camelCase
+- `kebab` - kebab-case
+- `lower` - lowercase
+- `upper` - UPPERCASE
+- `plural` - pluralize
+- `singular` - singularize
+
+## Template Syntax
+
+TAG uses Jinja2-compatible syntax (via Gonja):
+
+### Variables
+
+```jinja2
+{{ vars.project_name }}
+{{ vars.author|upper }}
+```
+
+### Conditionals
+
+```jinja2
+{% if vars.use_docker %}
+FROM golang:1.21
+WORKDIR /app
+{% endif %}
+```
+
+### Loops
+
+```jinja2
+{% for feature in vars.features %}
+- {{ feature }}
+{% endfor %}
+```
+
+### Filters
+
+```jinja2
+{{ vars.project_name|snake }}
+{{ vars.model|plural|pascal }}
+```
+
+See [Template Syntax](syntax.md) and [Filter Reference](filters.md) for complete documentation.
+
+## Template Context
+
+Variables available in scaffold templates:
+
+| Variable | Type | Description |
+|----------|------|-------------|
+| `vars` | `map[string]any` | All user-defined variables |
+| `cookiecutter` | `map[string]any` | Alias for `vars` (Cookiecutter compat) |
+| `<varname>` | `any` | Each variable also available at root level |
+
+All variables defined in `tag.template.json` are available both in the `vars` namespace and directly at the root level:
+
+```jinja2
+{# Both are equivalent #}
+{{ vars.project_name }}
+{{ project_name }}
+```
+
+> **Note**: For generator templates (used with `tag generate`), different context variables are available. See [Generate Command](../commands/generate.md) for details.
+
+## Including Generators
+
+To include generators in your scaffolded projects, add a `_generators/` directory:
+
+```
+my-template/
+├── tag.template.json
+├── __project_name__/
+│   └── ...
+└── _generators/
+    ├── handler/
+    │   └── handler.tmpl
+    └── model/
+        └── model.tmpl
+```
+
+This becomes `_templates/` in the generated project, allowing users to run `tag generate` commands.
+
+## Hooks
+
+### Pre-Scaffold Hooks
+
+Run before file generation, in the template directory:
+
+```json
+{
+  "hooks": {
+    "pre_scaffold": [
+      "./scripts/validate-env.sh",
+      "echo 'Starting scaffold...'"
+    ]
+  }
+}
+```
+
+Use cases:
+- Environment validation
+- Pre-flight checks
+- User notifications
+
+### Post-Scaffold Hooks
+
+Run after file generation, in the output directory:
+
+```json
+{
+  "hooks": {
+    "post_scaffold": [
+      "go mod tidy",
+      "git init",
+      "npm install"
+    ]
+  }
+}
+```
+
+Use cases:
+- Dependency installation
+- Git initialization
+- Code formatting
+
+See [Hooks Guide](hooks.md) for complete documentation.
+
+## Best Practices
+
+### 1. Use Meaningful Defaults
+
+```json
+{
+  "vars": {
+    "author": {
+      "default": "{{ env.USER }}",
+      "prompt": "Author name"
+    }
+  }
+}
+```
+
+### 2. Group Related Variables
+
+Organize your `tag.template.json` logically:
+
+```json
+{
+  "vars": {
+    "project_name": "...",
+    "description": "...",
+
+    "author": "...",
+    "email": "...",
+
+    "use_docker": false,
+    "use_ci": false
+  }
+}
+```
+
+### 3. Provide Clear Prompts
+
+```json
+{
+  "vars": {
+    "license": {
+      "type": "choice",
+      "prompt": "Select an open-source license for your project",
+      "options": ["MIT", "BSD-3", "Apache-2.0", "GPL-3.0"],
+      "default": "MIT"
+    }
+  }
+}
+```
+
+### 4. Use Computed Variables for Derived Values
+
+```json
+{
+  "vars": {
+    "project_name": "my-project",
+    "_package_name": "{{ vars.project_name|snake }}",
+    "_docker_image": "{{ vars.project_name|kebab }}"
+  }
+}
+```
+
+### 5. Document Your Template
+
+Include a `README.md.tmpl` in your template:
+
+```markdown
+# {{ vars.project_name }}
+
+{{ vars.description }}
+
+## Getting Started
+
+1. Install dependencies: `{{ vars.package_manager }} install`
+2. Run: `{{ vars.package_manager }} start`
+```
+
+## Testing Your Template
+
+```bash
+# Test locally
+tag scaffold ./my-template test-output
+
+# Test with specific values
+tag scaffold ./my-template test -m project_name=test -m author="Test User"
+
+# Test non-interactive mode
+tag scaffold ./my-template test --no-input
+```
+
+## Example: Complete Go API Template
+
+```
+go-api-template/
+├── tag.template.json
+├── __project_name__/
+│   ├── cmd/
+│   │   └── main.go.tmpl
+│   ├── internal/
+│   │   ├── api/
+│   │   │   └── handler.go.tmpl
+│   │   └── config/
+│   │       └── config.go.tmpl
+│   ├── go.mod.tmpl
+│   ├── Dockerfile.tmpl
+│   ├── Makefile.tmpl
+│   └── README.md.tmpl
+└── _generators/
+    └── handler/
+        └── handler.tmpl
+```
+
+**tag.template.json:**
+```json
+{
+  "name": "Go API Template",
+  "version": "1.0.0",
+  "vars": {
+    "project_name": "my-api",
+    "module_path": {
+      "type": "string",
+      "prompt": "Go module path (e.g., github.com/user/project)",
+      "required": true
+    },
+    "port": {
+      "type": "number",
+      "default": 8080
+    },
+    "use_docker": {
+      "type": "boolean",
+      "default": true
+    }
+  },
+  "hooks": {
+    "post_scaffold": ["go mod tidy"]
+  }
+}
+```
+
+## See Also
+
+- [Template Syntax](syntax.md) - Jinja2/Gonja syntax guide
+- [Filter Reference](filters.md) - Available filters
+- [Hooks Guide](hooks.md) - Pre and post hooks
+- [tag.template.json Reference](../reference/tag.template.json.md) - Configuration schema

--- a/docs/templates/filters.md
+++ b/docs/templates/filters.md
@@ -1,0 +1,315 @@
+# Filter Reference
+
+TAG provides custom filters for common code generation tasks, in addition to Gonja's built-in filters.
+
+## Usage
+
+Apply filters using the pipe (`|`) operator:
+
+```jinja2
+{{ vars.project_name|snake }}
+{{ vars.name|plural|pascal }}
+```
+
+Filters can be chained (applied left to right).
+
+## Case Transformation Filters
+
+| Filter | Input | Output | Description |
+|--------|-------|--------|-------------|
+| `snake` | `MyProject` | `my_project` | Convert to snake_case |
+| `pascal` | `my_project` | `MyProject` | Convert to PascalCase |
+| `camel` | `my_project` | `myProject` | Convert to camelCase |
+| `kebab` | `MyProject` | `my-project` | Convert to kebab-case |
+| `lower` | `MyProject` | `myproject` | Convert to lowercase |
+| `upper` | `MyProject` | `MYPROJECT` | Convert to UPPERCASE |
+| `title` | `my project` | `My Project` | Convert to Title Case |
+
+### Aliases
+
+For convenience, these aliases are also available:
+
+| Alias | Equivalent |
+|-------|------------|
+| `snake_case` | `snake` |
+| `pascal_case` | `pascal` |
+| `camel_case` | `camel` |
+| `kebab_case` | `kebab` |
+
+### Examples
+
+```jinja2
+{{ "MyAwesomeProject"|snake }}     {# my_awesome_project #}
+{{ "user_service"|pascal }}         {# UserService #}
+{{ "UserHandler"|camel }}           {# userHandler #}
+{{ "UserService"|kebab }}           {# user-service #}
+```
+
+## Inflection Filters
+
+| Filter | Input | Output | Description |
+|--------|-------|--------|-------------|
+| `plural` | `user` | `users` | Pluralize word |
+| `singular` | `users` | `user` | Singularize word |
+| `ordinalize` | `3` | `3rd` | Add ordinal suffix |
+| `titleize` | `my_project` | `My Project` | Convert to readable title |
+| `humanize` | `my_project` | `My project` | Convert to sentence form |
+
+### Aliases
+
+| Alias | Equivalent |
+|-------|------------|
+| `pluralize` | `plural` |
+| `singularize` | `singular` |
+
+### Examples
+
+```jinja2
+{{ "user"|plural }}             {# users #}
+{{ "categories"|singular }}     {# category #}
+{{ "1"|ordinalize }}            {# 1st #}
+{{ "2"|ordinalize }}            {# 2nd #}
+{{ "user_profile"|titleize }}   {# User Profile #}
+{{ "user_profile"|humanize }}   {# User profile #}
+```
+
+## String Operation Filters
+
+### split
+
+Split a string by delimiter.
+
+**Syntax:** `split` or `split:"delimiter"`
+
+```jinja2
+{{ "a,b,c"|split:"," }}                {# ["a", "b", "c"] #}
+{{ "hello world"|split }}              {# ["hello", "world"] (whitespace) #}
+{{ "one-two-three"|split:"-" }}        {# ["one", "two", "three"] #}
+```
+
+### join
+
+Join a list with a separator.
+
+**Syntax:** `join:"separator"`
+
+```jinja2
+{{ ["a", "b", "c"]|join:", " }}        {# a, b, c #}
+{{ vars.features|join:" | " }}         {# feat1 | feat2 | feat3 #}
+```
+
+### contains
+
+Check if a string contains a substring.
+
+**Syntax:** `contains:"substring"`
+
+```jinja2
+{% if vars.name|contains:"admin" %}
+  Has admin in name
+{% endif %}
+```
+
+### hasprefix
+
+Check if a string starts with a prefix.
+
+**Syntax:** `hasprefix:"prefix"`
+
+```jinja2
+{% if vars.module|hasprefix:"github.com" %}
+  GitHub module
+{% endif %}
+```
+
+### hassuffix
+
+Check if a string ends with a suffix.
+
+**Syntax:** `hassuffix:"suffix"`
+
+```jinja2
+{% if vars.filename|hassuffix:".go" %}
+  Go file
+{% endif %}
+```
+
+### replace
+
+Replace all occurrences of a substring.
+
+**Syntax:** `replace:"old":"new"`
+
+```jinja2
+{{ "hello world"|replace:"world":"universe" }}   {# hello universe #}
+{{ vars.path|replace:"/":"_" }}                  {# convert slashes #}
+```
+
+### trim
+
+Remove leading and trailing whitespace (or specified characters).
+
+**Syntax:** `trim` or `trim:"chars"`
+
+```jinja2
+{{ "  hello  "|trim }}                 {# hello #}
+{{ "...hello..."|trim:"." }}           {# hello #}
+```
+
+### default
+
+Provide a default value for empty/nil values.
+
+**Syntax:** `default:"value"`
+
+```jinja2
+{{ vars.author|default:"Anonymous" }}
+{{ vars.port|default:8080 }}
+```
+
+Returns the default if the input is:
+- `nil` / `null`
+- Empty string `""`
+- Error value
+
+### truncate
+
+Truncate a string to a maximum length.
+
+**Syntax:** `truncate:length` or `truncate:length:"ellipsis"`
+
+```jinja2
+{{ "Hello World"|truncate:5 }}              {# Hello... #}
+{{ "Hello World"|truncate:5:"" }}           {# Hello #}
+{{ "Hello World"|truncate:5:"…" }}          {# Hello… #}
+{{ vars.description|truncate:100 }}
+```
+
+The default ellipsis is `...`.
+
+## Built-in Gonja Filters
+
+TAG also includes all standard Gonja/Jinja2 filters:
+
+### String Filters
+
+| Filter | Description |
+|--------|-------------|
+| `capitalize` | Capitalize first character |
+| `center:width` | Center in field of given width |
+| `escape` or `e` | HTML escape |
+| `format:fmt` | String formatting (Go fmt syntax) |
+| `indent:width` | Indent each line |
+| `ljust:width` | Left-justify in field |
+| `rjust:width` | Right-justify in field |
+| `safe` | Mark as safe (no escaping) |
+| `striptags` | Remove HTML tags |
+| `wordwrap:width` | Wrap at word boundaries |
+
+### List Filters
+
+| Filter | Description |
+|--------|-------------|
+| `batch:size` | Split into batches |
+| `first` | Get first element |
+| `last` | Get last element |
+| `length` | Get length |
+| `list` | Convert to list |
+| `random` | Get random element |
+| `reverse` | Reverse order |
+| `shuffle` | Randomly shuffle |
+| `slice:start:stop` | Get slice |
+| `sort` | Sort elements |
+| `unique` | Remove duplicates |
+
+### Numeric Filters
+
+| Filter | Description |
+|--------|-------------|
+| `abs` | Absolute value |
+| `float` | Convert to float |
+| `int` | Convert to integer |
+| `round` | Round to nearest integer |
+| `filesizeformat` | Format as file size |
+
+### Type Filters
+
+| Filter | Description |
+|--------|-------------|
+| `string` | Convert to string |
+| `tojson` | Convert to JSON |
+
+## Filter Combinations
+
+Filters can be chained for powerful transformations:
+
+```jinja2
+{# model name variations #}
+{{ vars.model|plural|pascal }}         {# Users #}
+{{ vars.model|plural|snake }}          {# users #}
+{{ vars.model|singular|pascal }}       {# User #}
+
+{# file names #}
+{{ vars.service|snake }}_service.go    {# user_service.go #}
+{{ vars.handler|kebab }}-handler.ts    {# user-handler.ts #}
+
+{# clean and transform #}
+{{ vars.name|trim|snake|lower }}
+```
+
+## Common Patterns
+
+### Go Type Names
+
+```jinja2
+type {{ vars.model|pascal }}Service struct {}
+func New{{ vars.model|pascal }}Service() *{{ vars.model|pascal }}Service {}
+```
+
+### Package Names
+
+```jinja2
+package {{ vars.module|snake }}
+```
+
+### File Names
+
+```jinja2
+{# In path: __model | snake__/service.go.tmpl #}
+```
+
+### URL Slugs
+
+```jinja2
+{{ vars.title|kebab }}
+```
+
+### Database Tables
+
+```jinja2
+{{ vars.model|plural|snake }}
+```
+
+### Environment Variables
+
+```jinja2
+{{ vars.name|upper|replace:" ":"_" }}
+```
+
+## Error Handling
+
+If a filter encounters an error:
+- The error is propagated through the filter chain
+- The template execution continues but outputs the error
+- Check your variable types match the filter's expected input
+
+Example error cases:
+- `split` on a non-string value
+- `truncate` with a negative length
+- `replace` with wrong number of arguments
+
+## See Also
+
+- [Template Syntax](syntax.md) - Complete syntax guide
+- [Template Authoring](authoring.md) - Creating templates
+- [Gonja Documentation](https://github.com/noirbizarre/gonja) - Full Gonja reference

--- a/docs/templates/hooks.md
+++ b/docs/templates/hooks.md
@@ -1,0 +1,406 @@
+# Hooks Guide
+
+Hooks allow you to run shell commands before and after scaffold operations. This is useful for validation, initialization, and post-processing tasks.
+
+## Overview
+
+TAG supports two types of hooks:
+
+| Hook | When it Runs | Working Directory | Failure Behavior |
+|------|--------------|-------------------|------------------|
+| `pre_scaffold` | After variable collection, before file generation | Template directory | Stops scaffold, no files created |
+| `post_scaffold` | After all files are generated | Output directory | Warning only, files are kept |
+
+## Configuration
+
+Define hooks in `tag.template.json`:
+
+```json
+{
+  "vars": {
+    "project_name": "my-project"
+  },
+  "hooks": {
+    "pre_scaffold": [
+      "./scripts/validate.sh",
+      "echo 'Starting scaffold...'"
+    ],
+    "post_scaffold": [
+      "go mod tidy",
+      "git init",
+      "npm install"
+    ]
+  }
+}
+```
+
+## Hook Execution
+
+### Shell Execution
+
+Hooks are executed via the system shell:
+- **Unix/macOS**: `/bin/sh -c "command"`
+- **Windows**: `cmd.exe /C "command"`
+
+### Sequential Execution
+
+Hooks run in order, one at a time. If a hook fails (non-zero exit code), subsequent hooks in that phase don't run.
+
+### Timeout
+
+Each hook has a maximum execution time of **5 minutes**. Hooks that exceed this timeout are terminated.
+
+### Output
+
+- Output is captured (stdout and stderr combined)
+- Maximum output size: **1 MB** (truncated if exceeded)
+- Output is displayed to the user during scaffold
+
+## Environment Variables
+
+Hooks receive all template variables as environment variables:
+
+| Environment Variable | Description |
+|---------------------|-------------|
+| `TAG_TEMPLATE_DIR` | Absolute path to the template directory |
+| `TAG_OUTPUT_DIR` | Absolute path to the output directory |
+| `TAG_PROJECT_NAME` | Value of the `project_name` variable |
+| `TAG_VAR_<NAME>` | Each variable as `TAG_VAR_` + uppercase name |
+
+### Variable Name Transformation
+
+Variable names are converted to environment variable format:
+- Uppercase
+- Non-alphanumeric characters become underscores
+
+| Variable | Environment Variable |
+|----------|---------------------|
+| `project_name` | `TAG_VAR_PROJECT_NAME` |
+| `use-docker` | `TAG_VAR_USE_DOCKER` |
+| `author` | `TAG_VAR_AUTHOR` |
+
+### Complex Values
+
+Complex values (arrays, objects) are JSON-encoded:
+
+```bash
+# If vars.features = ["auth", "logging"]
+echo $TAG_VAR_FEATURES  # ["auth","logging"]
+```
+
+## Pre-Scaffold Hooks
+
+Pre-scaffold hooks run **before any files are created**, in the **template directory**.
+
+### Use Cases
+
+1. **Environment Validation**
+   ```json
+   {
+     "hooks": {
+       "pre_scaffold": ["./scripts/check-requirements.sh"]
+     }
+   }
+   ```
+
+   ```bash
+   #!/bin/bash
+   # check-requirements.sh
+   if ! command -v go &> /dev/null; then
+       echo "Error: Go is required but not installed"
+       exit 1
+   fi
+   ```
+
+2. **API Validation**
+   ```json
+   {
+     "hooks": {
+       "pre_scaffold": ["./scripts/validate-github-token.sh"]
+     }
+   }
+   ```
+
+3. **User Confirmation**
+   ```json
+   {
+     "hooks": {
+       "pre_scaffold": ["echo 'Creating project: $TAG_PROJECT_NAME'"]
+     }
+   }
+   ```
+
+### Failure Behavior
+
+If a pre-scaffold hook fails:
+- The scaffold process stops immediately
+- **No files are created**
+- Error message is displayed to the user
+
+## Post-Scaffold Hooks
+
+Post-scaffold hooks run **after all files are created**, in the **output directory**.
+
+### Use Cases
+
+1. **Dependency Installation**
+   ```json
+   {
+     "hooks": {
+       "post_scaffold": [
+         "go mod tidy",
+         "npm install"
+       ]
+     }
+   }
+   ```
+
+2. **Git Initialization**
+   ```json
+   {
+     "hooks": {
+       "post_scaffold": [
+         "git init",
+         "git add .",
+         "git commit -m 'Initial commit from TAG template'"
+       ]
+     }
+   }
+   ```
+
+3. **Code Formatting**
+   ```json
+   {
+     "hooks": {
+       "post_scaffold": [
+         "gofmt -w .",
+         "prettier --write '**/*.{js,ts,json}'"
+       ]
+     }
+   }
+   ```
+
+4. **Display Next Steps**
+   ```json
+   {
+     "hooks": {
+       "post_scaffold": [
+         "echo ''",
+         "echo 'Project created successfully!'",
+         "echo ''",
+         "echo 'Next steps:'",
+         "echo '  cd $TAG_PROJECT_NAME'",
+         "echo '  make run'"
+       ]
+     }
+   }
+   ```
+
+### Failure Behavior
+
+If a post-scaffold hook fails:
+- A **warning** is displayed
+- **Generated files are preserved**
+- User is notified that some post-scaffold tasks may not have run
+
+Example warning:
+```
+Warning: post-scaffold hook failed: exit status 1
+Note: Scaffold completed successfully, but some post-scaffold tasks may not have run.
+```
+
+## Writing Hook Scripts
+
+### Best Practices
+
+1. **Use Absolute Paths or Relative to Template**
+   ```json
+   {
+     "hooks": {
+       "pre_scaffold": ["./scripts/validate.sh"]
+     }
+   }
+   ```
+
+2. **Check Exit Codes**
+   ```bash
+   #!/bin/bash
+   set -e  # Exit on error
+
+   if ! some_command; then
+       echo "Error: something failed"
+       exit 1
+   fi
+   ```
+
+3. **Handle Missing Tools Gracefully**
+   ```bash
+   #!/bin/bash
+   if command -v gofmt &> /dev/null; then
+       gofmt -w .
+   else
+       echo "Warning: gofmt not found, skipping formatting"
+   fi
+   ```
+
+4. **Use Environment Variables**
+   ```bash
+   #!/bin/bash
+   echo "Setting up $TAG_VAR_PROJECT_NAME..."
+
+   if [ "$TAG_VAR_USE_DOCKER" = "true" ]; then
+       docker-compose build
+   fi
+   ```
+
+### Cross-Platform Compatibility
+
+For maximum compatibility:
+
+1. **Use Simple Shell Commands**
+   ```json
+   {
+     "hooks": {
+       "post_scaffold": ["echo Done"]
+     }
+   }
+   ```
+
+2. **Avoid Bash-Specific Features** (for Windows compatibility)
+   - Use `[ ]` instead of `[[ ]]`
+   - Avoid bash arrays
+   - Use portable commands
+
+3. **Consider Separate Scripts**
+   ```
+   my-template/
+   ├── scripts/
+   │   ├── post-scaffold.sh    # Unix
+   │   └── post-scaffold.bat   # Windows
+   ```
+
+## Debugging Hooks
+
+### View Hook Output
+
+Hook output is displayed during scaffold:
+
+```bash
+$ tag scaffold ./my-template
+
+Running pre-scaffold hooks...
+Validating environment...
+All checks passed!
+
+Scaffolding project...
+✓ Created my-project/cmd/main.go
+✓ Created my-project/README.md
+
+Running post-scaffold hooks...
+go: finding module for package...
+Initialized empty Git repository in /path/to/my-project/.git/
+```
+
+### Test Hooks Independently
+
+Test your hook scripts before including them:
+
+```bash
+# Set environment variables manually
+export TAG_VAR_PROJECT_NAME="test-project"
+export TAG_OUTPUT_DIR="/tmp/test"
+
+# Run the script
+./scripts/post-scaffold.sh
+```
+
+### Test with a Temporary Directory
+
+To test scaffolding without affecting your project:
+
+```bash
+tag scaffold ./my-template /tmp/test-output
+```
+
+## Common Hook Patterns
+
+### Conditional Hook Execution
+
+```bash
+#!/bin/bash
+# Only run if Docker is enabled
+if [ "$TAG_VAR_USE_DOCKER" = "true" ]; then
+    docker-compose build
+fi
+```
+
+### Multiple Conditional Commands
+
+```json
+{
+  "hooks": {
+    "post_scaffold": [
+      "[ \"$TAG_VAR_USE_DOCKER\" = \"true\" ] && docker-compose build || true",
+      "[ \"$TAG_VAR_USE_CI\" = \"true\" ] && ./scripts/setup-ci.sh || true"
+    ]
+  }
+}
+```
+
+### Python Post-Processing
+
+```json
+{
+  "hooks": {
+    "post_scaffold": ["python3 ./scripts/finalize.py"]
+  }
+}
+```
+
+### Node.js Post-Processing
+
+```json
+{
+  "hooks": {
+    "post_scaffold": ["node ./scripts/setup.js"]
+  }
+}
+```
+
+## Migrating from Cookiecutter Hooks
+
+Cookiecutter hooks use Python scripts. When converting:
+
+1. **Simple Commands**: Convert directly
+   ```python
+   # Cookiecutter
+   subprocess.call(['git', 'init'])
+
+   # TAG
+   "git init"
+   ```
+
+2. **Python Logic**: Use shell scripts or keep Python
+   ```json
+   {
+     "hooks": {
+       "post_scaffold": ["python3 ./hooks/post_gen_project.py"]
+     }
+   }
+   ```
+
+3. **Access Variables**: Use environment variables instead of `cookiecutter` dict
+   ```python
+   # Cookiecutter
+   project_name = '{{ cookiecutter.project_name }}'
+
+   # TAG (Python script)
+   import os
+   project_name = os.environ.get('TAG_VAR_PROJECT_NAME')
+   ```
+
+## See Also
+
+- [Template Authoring](authoring.md) - Complete template guide
+- [tag.template.json Reference](../reference/tag.template.json.md) - Configuration format
+- [Convert Command](../commands/convert.md) - Cookiecutter migration

--- a/docs/templates/syntax.md
+++ b/docs/templates/syntax.md
@@ -1,0 +1,459 @@
+# Template Syntax Guide
+
+TAG uses [Gonja](https://github.com/noirbizarre/gonja), a Jinja2-compatible template engine written in pure Go. This guide covers the template syntax available in TAG.
+
+## Variable Output
+
+Use double curly braces to output variables:
+
+```jinja2
+{{ vars.project_name }}
+{{ vars.author }}
+```
+
+### Variable Namespaces
+
+TAG provides two equivalent namespaces:
+
+```jinja2
+{# TAG style (recommended) #}
+{{ vars.project_name }}
+
+{# Cookiecutter compatible (also works) #}
+{{ cookiecutter.project_name }}
+```
+
+Both reference the same underlying variables.
+
+### Name Helpers (Generator Templates Only)
+
+> **Note**: The `n` helper object is only available in **generator templates** (used with `tag generate`), not in scaffold templates.
+
+For generator templates, the `n` object provides pre-computed name variants:
+
+```jinja2
+{{ n.pascal_case }}    {# MyProject #}
+{{ n.camel_case }}     {# myProject #}
+{{ n.snake_case }}     {# my_project #}
+{{ n.kebab_case }}     {# my-project #}
+{{ n.lower_case }}     {# myproject #}
+{{ n.upper_case }}     {# MYPROJECT #}
+```
+
+In scaffold templates, use filters instead:
+
+```jinja2
+{{ vars.project_name|pascal }}
+{{ vars.project_name|snake }}
+```
+
+## Filters
+
+Apply filters with the pipe (`|`) operator:
+
+```jinja2
+{{ vars.project_name|snake }}
+{{ vars.author|upper }}
+{{ vars.model|plural|pascal }}
+```
+
+See [Filter Reference](filters.md) for all available filters.
+
+### Filter Arguments
+
+Some filters accept arguments with colon syntax:
+
+```jinja2
+{{ vars.name|default:"Anonymous" }}
+{{ vars.text|truncate:50 }}
+{{ vars.text|replace:"old":"new" }}
+```
+
+## Control Structures
+
+### Conditionals
+
+```jinja2
+{% if vars.use_docker %}
+FROM golang:1.21
+WORKDIR /app
+COPY . .
+{% endif %}
+```
+
+With else:
+
+```jinja2
+{% if vars.use_typescript %}
+import { Config } from './types';
+{% else %}
+const Config = require('./types');
+{% endif %}
+```
+
+With elif:
+
+```jinja2
+{% if vars.database == "postgres" %}
+import "database/sql"
+import _ "github.com/lib/pq"
+{% elif vars.database == "mysql" %}
+import "database/sql"
+import _ "github.com/go-sql-driver/mysql"
+{% else %}
+// No database configured
+{% endif %}
+```
+
+### Boolean Operators
+
+```jinja2
+{% if vars.use_docker and vars.use_ci %}
+# CI with Docker
+{% endif %}
+
+{% if vars.use_logging or vars.use_metrics %}
+import "github.com/example/observability"
+{% endif %}
+
+{% if not vars.skip_tests %}
+go test ./...
+{% endif %}
+```
+
+### Truthiness
+
+The following values are considered **falsy**:
+- `false`
+- `0`
+- Empty string `""`
+- `null` / `nil`
+- Empty lists `[]`
+- Empty dicts `{}`
+
+Everything else is **truthy**.
+
+### Loops
+
+Iterate over lists:
+
+```jinja2
+{% for feature in vars.features %}
+- {{ feature }}
+{% endfor %}
+```
+
+With index:
+
+```jinja2
+{% for item in vars.items %}
+{{ loop.index }}. {{ item }}
+{% endfor %}
+```
+
+Loop variables:
+
+| Variable | Description |
+|----------|-------------|
+| `loop.index` | Current iteration (1-indexed) |
+| `loop.index0` | Current iteration (0-indexed) |
+| `loop.first` | True if first iteration |
+| `loop.last` | True if last iteration |
+| `loop.length` | Total number of items |
+
+Iterate over maps:
+
+```jinja2
+{% for key, value in vars.config %}
+{{ key }}: {{ value }}
+{% endfor %}
+```
+
+### Loop with Else
+
+Handle empty lists:
+
+```jinja2
+{% for user in vars.users %}
+- {{ user }}
+{% else %}
+No users defined.
+{% endfor %}
+```
+
+## Comments
+
+Single-line comments:
+
+```jinja2
+{# This is a comment #}
+```
+
+Multi-line comments:
+
+```jinja2
+{#
+  This is a
+  multi-line comment
+#}
+```
+
+Comments are removed from the output.
+
+## Whitespace Control
+
+Control whitespace with `-` at the beginning or end of tags:
+
+```jinja2
+{% for item in items -%}
+{{ item }}
+{%- endfor %}
+```
+
+| Syntax | Effect |
+|--------|--------|
+| `{%-` | Remove whitespace before the tag |
+| `-%}` | Remove whitespace after the tag |
+| `{{-` | Remove whitespace before output |
+| `-}}` | Remove whitespace after output |
+
+### Example
+
+Without whitespace control:
+
+```jinja2
+{% for i in [1, 2, 3] %}
+{{ i }}
+{% endfor %}
+```
+
+Output:
+```
+
+1
+
+2
+
+3
+
+```
+
+With whitespace control:
+
+```jinja2
+{% for i in [1, 2, 3] -%}
+{{ i }}
+{% endfor %}
+```
+
+Output:
+```
+1
+2
+3
+
+```
+
+## Template Inheritance
+
+### Base Template
+
+```jinja2
+{# base.tmpl #}
+<!DOCTYPE html>
+<html>
+<head>
+  <title>{% block title %}Default Title{% endblock %}</title>
+</head>
+<body>
+  {% block content %}{% endblock %}
+</body>
+</html>
+```
+
+### Child Template
+
+```jinja2
+{% extends "base.tmpl" %}
+
+{% block title %}{{ vars.page_title }}{% endblock %}
+
+{% block content %}
+<h1>Welcome to {{ vars.project_name }}</h1>
+{% endblock %}
+```
+
+## Macros
+
+Define reusable template fragments:
+
+```jinja2
+{% macro input(name, type="text", value="") %}
+<input type="{{ type }}" name="{{ name }}" value="{{ value }}">
+{% endmacro %}
+
+{{ input("username") }}
+{{ input("password", type="password") }}
+{{ input("email", type="email", value=vars.default_email) }}
+```
+
+### Macro with Body
+
+```jinja2
+{% macro card(title) %}
+<div class="card">
+  <h3>{{ title }}</h3>
+  <div class="body">
+    {{ caller() }}
+  </div>
+</div>
+{% endmacro %}
+
+{% call card("Welcome") %}
+<p>This is the card content.</p>
+{% endcall %}
+```
+
+## Includes
+
+Include other template files:
+
+```jinja2
+{% include "partials/header.tmpl" %}
+
+<main>
+  Content here
+</main>
+
+{% include "partials/footer.tmpl" %}
+```
+
+## Raw Blocks
+
+Output literal Jinja2 syntax without processing:
+
+```jinja2
+{% raw %}
+This {{ will not }} be processed
+{% endraw %}
+```
+
+Useful for documenting templates or generating template files.
+
+## Expressions
+
+### String Concatenation
+
+```jinja2
+{{ vars.first_name ~ " " ~ vars.last_name }}
+```
+
+### Comparisons
+
+```jinja2
+{% if vars.count > 10 %}...{% endif %}
+{% if vars.name == "admin" %}...{% endif %}
+{% if vars.version != "1.0.0" %}...{% endif %}
+{% if vars.level >= 5 %}...{% endif %}
+```
+
+### Membership Tests
+
+```jinja2
+{% if "admin" in vars.roles %}
+  Has admin access
+{% endif %}
+
+{% if vars.feature not in vars.disabled_features %}
+  Feature is enabled
+{% endif %}
+```
+
+### Ternary Operator
+
+```jinja2
+{{ "Yes" if vars.enabled else "No" }}
+{{ vars.count if vars.count > 0 else "None" }}
+```
+
+## Set Variables
+
+Define variables within templates:
+
+```jinja2
+{% set full_name = vars.first_name ~ " " ~ vars.last_name %}
+Hello, {{ full_name }}!
+
+{% set items = ["one", "two", "three"] %}
+{% for item in items %}...{% endfor %}
+```
+
+## Common Patterns
+
+### Conditional File Generation
+
+Create files based on conditions:
+
+```jinja2
+{# Only include Docker content if use_docker is true #}
+{% if vars.use_docker %}
+FROM golang:1.21-alpine
+WORKDIR /app
+COPY go.* ./
+RUN go mod download
+COPY . .
+RUN go build -o main .
+CMD ["./main"]
+{% endif %}
+```
+
+### Dynamic Imports
+
+```jinja2
+package main
+
+import (
+    "fmt"
+{% if vars.use_logging %}
+    "log/slog"
+{% endif %}
+{% if vars.use_http %}
+    "net/http"
+{% endif %}
+)
+```
+
+### List Joining
+
+```jinja2
+{{ vars.features|join:", " }}
+```
+
+### Default Values
+
+```jinja2
+{{ vars.author|default:"Anonymous" }}
+{{ vars.port|default:8080 }}
+```
+
+### Conditional Classes
+
+```jinja2
+<div class="container{% if vars.full_width %} full-width{% endif %}">
+```
+
+## Gonja vs Jinja2 Differences
+
+TAG uses Gonja, which is mostly compatible with Jinja2 but has minor differences:
+
+| Feature | Jinja2 | Gonja |
+|---------|--------|-------|
+| Filter arguments | `{{ x\|default('val') }}` | `{{ x\|default:"val" }}` |
+| Format filter | `{{ x\|format('%s') }}` | `{{ x\|format:"%s" }}` |
+| Dict iteration | `{% for k, v in dict.items() %}` | `{% for k, v in dict %}` |
+
+## See Also
+
+- [Filter Reference](filters.md) - All available filters
+- [Template Authoring](authoring.md) - Creating templates
+- [Migration Guide](../migration/v1-to-v2.md) - Migrating from Go templates


### PR DESCRIPTION
## Summary

This PR implements Epic 8: Documentation & Polish (#13) for TAG v2.0.

**Changes:**

- Add complete documentation in `docs/` directory structure:
  - `getting-started.md` - Quick start guide
  - `commands/scaffold.md` - Scaffold command reference
  - `commands/generate.md` - Generate command reference  
  - `commands/convert.md` - Convert cookiecutter command reference
  - `templates/authoring.md` - Template authoring guide
  - `templates/syntax.md` - Jinja2/Gonja syntax guide
  - `templates/filters.md` - Filter reference
  - `templates/hooks.md` - Hooks guide
  - `migration/v1-to-v2.md` - Migration guide from Go templates to Jinja2
  - `reference/tag.template.json.md` - Configuration reference
  - `reference/remote-refs.md` - Remote template formats

- Update `README.md` with v2 features and documentation links
- Create `CHANGELOG.md` documenting v2.0.0 release

**Note:** JSON Schema publishing (#13 sub-item) is intentionally excluded and will be handled in a separate ticket.

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] Build succeeds (`go build -o tag`)
- [x] Linting passes (`make lint`)
- [ ] Documentation reviewed for accuracy against implementation
- [ ] Internal links verified to work

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)