### PR TITLE
feat: auto-detect Cookiecutter templates in tag scaffold (#25)

### DIFF
--- a/internal/commands/scaffold.go
+++ b/internal/commands/scaffold.go
@@ -2,7 +2,10 @@ package commands
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
+	"github.com/kaikenlabs/tag/internal/convert"
 	"github.com/kaikenlabs/tag/internal/remote"
 	"github.com/kaikenlabs/tag/internal/scaffold"
 	"github.com/kaikenlabs/tag/pkg/app"
@@ -152,8 +155,63 @@ func scaffoldAction(c *cli.Context) error {
 	}
 
 	if err := s.Run(opts); err != nil {
+		// Check if this is a Cookiecutter template detection
+		var ccErr *scaffold.ErrCookiecutterDetected
+		if errors.As(err, &ccErr) {
+			return handleCookiecutterDetection(c, ccErr, templateRef, templateDir, opts)
+		}
 		return app.Errorf("scaffolding failed: %w", err)
 	}
 
+	return nil
+}
+
+// handleCookiecutterDetection handles the case when a Cookiecutter template is detected.
+func handleCookiecutterDetection(c *cli.Context, ccErr *scaffold.ErrCookiecutterDetected, templateRef, templateDir string, opts scaffold.Options) error {
+	// In non-interactive mode, fail with helpful error
+	if c.Bool("no-input") || !scaffold.IsTTY() {
+		return app.Errorf("This appears to be a Cookiecutter template (found %s).\n"+
+			"Cannot convert in non-interactive mode.\n"+
+			"Run without --no-input to convert interactively, or use:\n"+
+			"  tag convert cookiecutter %s",
+			ccErr.CookiecutterPath, templateRef)
+	}
+
+	// Prompt for conversion
+	prompter := scaffold.NewInteractivePrompter()
+	confirmed, err := prompter.Confirm(
+		fmt.Sprintf("This appears to be a Cookiecutter template (found %s). Convert to TAG format?",
+			ccErr.CookiecutterPath),
+		true, // default yes
+	)
+	if err != nil {
+		return app.Errorf("prompt failed: %w", err)
+	}
+	if !confirmed {
+		return app.Errorf("Conversion declined. Use 'tag convert cookiecutter %s' to convert manually.", templateRef)
+	}
+
+	// Run in-place conversion
+	converter, err := convert.NewConverter()
+	if err != nil {
+		return app.Errorf("failed to create converter: %w", err)
+	}
+	ctx := context.Background()
+	if err := converter.ConvertInPlace(ctx, templateDir); err != nil {
+		return app.Errorf("conversion failed: %w", err)
+	}
+
+	fmt.Println("Created tag.template.json")
+	fmt.Println("Template ready")
+	fmt.Println()
+
+	// Retry scaffolding
+	s, err := scaffold.NewScaffold(opts)
+	if err != nil {
+		return app.Errorf("failed to reinitialize scaffold: %w", err)
+	}
+	if err := s.Run(opts); err != nil {
+		return app.Errorf("scaffolding failed: %w", err)
+	}
 	return nil
 }

--- a/internal/convert/cookiecutter.go
+++ b/internal/convert/cookiecutter.go
@@ -261,6 +261,57 @@ func (c *Converter) processTemplateFiles(srcDir, destDir string, config *scaffol
 	})
 }
 
+// ConvertInPlace converts a Cookiecutter template in-place by writing
+// tag.template.json to the same directory as cookiecutter.json.
+// Unlike Convert(), this does not copy files to a new directory.
+func (c *Converter) ConvertInPlace(ctx context.Context, templateDir string) error {
+	// Verify it's a Cookiecutter template
+	cookiecutterPath := filepath.Join(templateDir, "cookiecutter.json")
+	if _, err := os.Stat(cookiecutterPath); os.IsNotExist(err) {
+		return ErrNoCookiecutterConfig
+	}
+
+	// Read and convert cookiecutter.json
+	configData, err := os.ReadFile(cookiecutterPath)
+	if err != nil {
+		return fmt.Errorf("failed to read cookiecutter.json: %w", err)
+	}
+
+	tagConfig, _, _, err := ConvertCookiecutterConfig(configData)
+	if err != nil {
+		return err
+	}
+
+	// Process hooks (detect only, don't copy - they're already in place)
+	hooksProcessor := NewHooksProcessor(templateDir, templateDir, false)
+	hookFindings, err := hooksProcessor.DetectHooks()
+	if err != nil {
+		return fmt.Errorf("failed to detect hooks: %w", err)
+	}
+
+	// Add shell hooks to config
+	preHooks, postHooks := SuggestTagHooksConfig(hookFindings)
+	if len(preHooks) > 0 || len(postHooks) > 0 {
+		tagConfig.Hooks = &scaffold.HooksConfig{
+			PreScaffold:  preHooks,
+			PostScaffold: postHooks,
+		}
+	}
+
+	// Write tag.template.json
+	tagJSON, err := GenerateTagTemplateJSON(tagConfig, "", "Converted from Cookiecutter template")
+	if err != nil {
+		return fmt.Errorf("failed to generate tag.template.json: %w", err)
+	}
+
+	tagConfigPath := filepath.Join(templateDir, "tag.template.json")
+	if err := os.WriteFile(tagConfigPath, tagJSON, 0o644); err != nil {
+		return fmt.Errorf("failed to write tag.template.json: %w", err)
+	}
+
+	return nil
+}
+
 // copyFile copies a file from src to dst.
 func copyFile(src, dst string) error {
 	srcFile, err := os.Open(src)

--- a/internal/convert/cookiecutter_test.go
+++ b/internal/convert/cookiecutter_test.go
@@ -256,3 +256,99 @@ func TestUT_Converter_DefaultDestination(t *testing.T) {
 	// Clean up
 	os.RemoveAll(result.Destination)
 }
+
+func TestUT_ConvertInPlace_CreatesTagTemplateJSON(t *testing.T) {
+	// Create a minimal cookiecutter template
+	srcDir := t.TempDir()
+
+	// Create cookiecutter.json
+	ccConfig := `{
+		"project_name": "test_project",
+		"author": "Test Author",
+		"use_docker": true
+	}`
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "cookiecutter.json"), []byte(ccConfig), 0o644))
+
+	// Create a template file
+	templateDir := filepath.Join(srcDir, "{{ cookiecutter.project_name }}")
+	require.NoError(t, os.MkdirAll(templateDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(templateDir, "main.go"),
+		[]byte("package main\n"),
+		0o644,
+	))
+
+	// Run in-place conversion
+	converter, err := NewConverter()
+	require.NoError(t, err)
+
+	err = converter.ConvertInPlace(context.Background(), srcDir)
+	require.NoError(t, err)
+
+	// Verify tag.template.json was created in the same directory
+	tagConfigPath := filepath.Join(srcDir, "tag.template.json")
+	_, err = os.Stat(tagConfigPath)
+	require.NoError(t, err)
+
+	tagConfig, err := os.ReadFile(tagConfigPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(tagConfig), "project_name")
+	assert.Contains(t, string(tagConfig), "author")
+	assert.Contains(t, string(tagConfig), "use_docker")
+
+	// Verify original template files were NOT copied (in-place means no file duplication)
+	// The {{ cookiecutter.project_name }} directory should still exist as-is
+	_, err = os.Stat(templateDir)
+	require.NoError(t, err)
+
+	// Verify cookiecutter.json is still there
+	_, err = os.Stat(filepath.Join(srcDir, "cookiecutter.json"))
+	require.NoError(t, err)
+}
+
+func TestUT_ConvertInPlace_MissingCookiecutterJSON(t *testing.T) {
+	srcDir := t.TempDir()
+	// Don't create cookiecutter.json
+
+	converter, err := NewConverter()
+	require.NoError(t, err)
+
+	err = converter.ConvertInPlace(context.Background(), srcDir)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNoCookiecutterConfig)
+}
+
+func TestUT_ConvertInPlace_WithHooks(t *testing.T) {
+	srcDir := t.TempDir()
+
+	// Create cookiecutter.json
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "cookiecutter.json"), []byte(`{"name": "test"}`), 0o644))
+
+	// Create hooks
+	hooksDir := filepath.Join(srcDir, "hooks")
+	require.NoError(t, os.MkdirAll(hooksDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(hooksDir, "pre_gen_project.sh"), []byte("#!/bin/bash\necho pre"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(hooksDir, "post_gen_project.sh"), []byte("#!/bin/bash\necho post"), 0o755))
+
+	converter, err := NewConverter()
+	require.NoError(t, err)
+
+	err = converter.ConvertInPlace(context.Background(), srcDir)
+	require.NoError(t, err)
+
+	// Verify tag.template.json was created with hooks configuration
+	tagConfigPath := filepath.Join(srcDir, "tag.template.json")
+	tagConfig, err := os.ReadFile(tagConfigPath)
+	require.NoError(t, err)
+
+	// Should contain hooks configuration
+	assert.Contains(t, string(tagConfig), "hooks")
+	assert.Contains(t, string(tagConfig), "pre_scaffold")
+	assert.Contains(t, string(tagConfig), "post_scaffold")
+
+	// Original hooks should still be in place (not copied anywhere)
+	_, err = os.Stat(filepath.Join(hooksDir, "pre_gen_project.sh"))
+	require.NoError(t, err)
+	_, err = os.Stat(filepath.Join(hooksDir, "post_gen_project.sh"))
+	require.NoError(t, err)
+}

--- a/internal/scaffold/cookiecutter_detect.go
+++ b/internal/scaffold/cookiecutter_detect.go
@@ -1,0 +1,21 @@
+package scaffold
+
+import (
+	"os"
+	"path/filepath"
+)
+
+const (
+	// CookiecutterConfigFile is the name of the Cookiecutter configuration file.
+	CookiecutterConfigFile = "cookiecutter.json"
+)
+
+// IsCookiecutterTemplate checks if a directory contains a Cookiecutter template.
+// Returns the path to cookiecutter.json if found, and a boolean indicating detection.
+func IsCookiecutterTemplate(templateDir string) (cookiecutterPath string, isCookiecutter bool) {
+	ccPath := filepath.Join(templateDir, CookiecutterConfigFile)
+	if _, err := os.Stat(ccPath); err == nil {
+		return ccPath, true
+	}
+	return "", false
+}

--- a/internal/scaffold/cookiecutter_detect_test.go
+++ b/internal/scaffold/cookiecutter_detect_test.go
@@ -1,0 +1,94 @@
+package scaffold
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUT_IsCookiecutterTemplate(t *testing.T) {
+	tests := []struct {
+		name               string
+		setupFunc          func(dir string) error
+		wantIsCookiecutter bool
+		wantPathContains   string
+	}{
+		{
+			name: "directory with cookiecutter.json",
+			setupFunc: func(dir string) error {
+				return os.WriteFile(filepath.Join(dir, "cookiecutter.json"), []byte(`{"name": "test"}`), 0o644)
+			},
+			wantIsCookiecutter: true,
+			wantPathContains:   "cookiecutter.json",
+		},
+		{
+			name: "directory without cookiecutter.json",
+			setupFunc: func(dir string) error {
+				return nil // Empty directory
+			},
+			wantIsCookiecutter: false,
+			wantPathContains:   "",
+		},
+		{
+			name: "directory with tag.template.json only",
+			setupFunc: func(dir string) error {
+				return os.WriteFile(filepath.Join(dir, "tag.template.json"), []byte(`{"name": "test"}`), 0o644)
+			},
+			wantIsCookiecutter: false,
+			wantPathContains:   "",
+		},
+		{
+			name: "directory with both files",
+			setupFunc: func(dir string) error {
+				if err := os.WriteFile(filepath.Join(dir, "cookiecutter.json"), []byte(`{"name": "test"}`), 0o644); err != nil {
+					return err
+				}
+				return os.WriteFile(filepath.Join(dir, "tag.template.json"), []byte(`{"name": "test"}`), 0o644)
+			},
+			wantIsCookiecutter: true, // Still detects cookiecutter.json
+			wantPathContains:   "cookiecutter.json",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			require.NoError(t, tt.setupFunc(dir))
+
+			gotPath, gotIsCookiecutter := IsCookiecutterTemplate(dir)
+
+			assert.Equal(t, tt.wantIsCookiecutter, gotIsCookiecutter)
+			if tt.wantIsCookiecutter {
+				assert.Contains(t, gotPath, tt.wantPathContains)
+			} else {
+				assert.Empty(t, gotPath)
+			}
+		})
+	}
+}
+
+func TestUT_ErrCookiecutterDetected(t *testing.T) {
+	t.Run("error message formatting", func(t *testing.T) {
+		err := &ErrCookiecutterDetected{CookiecutterPath: "/path/to/cookiecutter.json"}
+		assert.Equal(t, "cookiecutter template detected: /path/to/cookiecutter.json", err.Error())
+	})
+
+	t.Run("errors.As matching", func(t *testing.T) {
+		originalErr := &ErrCookiecutterDetected{CookiecutterPath: "/test/path"}
+
+		var ccErr *ErrCookiecutterDetected
+		assert.True(t, errors.As(originalErr, &ccErr))
+		assert.Equal(t, "/test/path", ccErr.CookiecutterPath)
+	})
+
+	t.Run("errors.As not matching non-cookiecutter error", func(t *testing.T) {
+		originalErr := errors.New("some other error")
+
+		var ccErr *ErrCookiecutterDetected
+		assert.False(t, errors.As(originalErr, &ccErr))
+	})
+}

--- a/internal/scaffold/errors.go
+++ b/internal/scaffold/errors.go
@@ -95,6 +95,16 @@ func NewTemplateError(file, message string, err error) *TemplateError {
 	return &TemplateError{File: file, Message: message, Err: err}
 }
 
+// ErrCookiecutterDetected represents a Cookiecutter template detection.
+// It carries the path to the detected cookiecutter.json file.
+type ErrCookiecutterDetected struct {
+	CookiecutterPath string
+}
+
+func (e *ErrCookiecutterDetected) Error() string {
+	return fmt.Sprintf("cookiecutter template detected: %s", e.CookiecutterPath)
+}
+
 // ErrHookFailed is returned when a hook command fails.
 var ErrHookFailed = errors.New("hook command failed")
 

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -207,6 +207,10 @@ func (s *Scaffold) loadAndValidateConfig(templateDir string) (*TemplateConfig, e
 
 	// Check if config file exists
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		// Check if this is a Cookiecutter template
+		if ccPath, isCookiecutter := IsCookiecutterTemplate(templateDir); isCookiecutter {
+			return nil, &ErrCookiecutterDetected{CookiecutterPath: ccPath}
+		}
 		return nil, fmt.Errorf("%w: %s", ErrConfigNotFound, configPath)
 	}
 


### PR DESCRIPTION
## Summary

When `tag scaffold` is run on a Cookiecutter template (has `cookiecutter.json` but no `tag.template.json`), detect this and prompt the user for automatic conversion before proceeding.

- Add `IsCookiecutterTemplate()` detection helper
- Add `ErrCookiecutterDetected` typed error for detection signaling
- Add `ConvertInPlace()` for in-place template conversion
- Handle detection in scaffold command with interactive prompt
- In non-interactive mode, fail with helpful error pointing to manual conversion

## Behavior

| Scenario | Behavior |
|----------|----------|
| Interactive mode | Prompts "Convert to TAG format?" → runs in-place conversion → retries scaffolding |
| `--no-input` flag | Fails with error message pointing to `tag convert cookiecutter` |
| Non-TTY (piped) | Same as `--no-input` |
| User declines | Fails with message to use manual conversion |
| Has both files | Uses `tag.template.json` (no change to existing behavior) |
| Remote templates | Works - conversion writes to cached template directory |

## Test plan

- [x] Unit tests for `IsCookiecutterTemplate()` detection
- [x] Unit tests for `ErrCookiecutterDetected` error type
- [x] Unit tests for `ConvertInPlace()` function
- [x] All existing tests pass

Closes #25

🤖 Generated with [Claude Code](https://claude.ai/code)