### PR TITLE
fix: implement Phase 2 high priority fixes (#33, #34, #35, #36, #37)

### DIFF
--- a/internal/commands/bundle.go
+++ b/internal/commands/bundle.go
@@ -65,7 +65,7 @@ func bundleAction(c *cli.Context, cfg *config.Config) error {
 	}
 	defer func() {
 		if err := file.Close(); err != nil {
-			slog.Info("error closing file", "error", err.Error())
+			slog.Warn("error closing file", "error", err.Error())
 		}
 	}()
 

--- a/internal/commands/init.go
+++ b/internal/commands/init.go
@@ -28,13 +28,13 @@ func initAction(c *cli.Context) error {
 	slog.Info(chalk.Green("creating initial setup"), "path", c.String(flags.PathFlag))
 	dirPath := filepath.Join(".", c.String(flags.PathFlag), c.String(flags.SharedPathFlag), ".gitkeep")
 	if err := os.MkdirAll(filepath.Dir(dirPath), 0o750); err != nil {
-		slog.Info("error initialising tag's shared path", "error", err.Error())
+		slog.Error("error initialising tag's shared path", "error", err.Error())
 		return err
 	}
 
 	dirPath = filepath.Join(".", c.String(flags.PathFlag), c.String(flags.BundlePathFlag), ".gitkeep")
 	if err := os.MkdirAll(filepath.Dir(dirPath), 0o750); err != nil {
-		slog.Info("error initialising tag's bundle path", "error", err.Error())
+		slog.Error("error initialising tag's bundle path", "error", err.Error())
 		return err
 	}
 

--- a/internal/commands/new.go
+++ b/internal/commands/new.go
@@ -63,7 +63,7 @@ func newAction(c *cli.Context, cfg *config.Config) error {
 	}
 	defer func() {
 		if err := file.Close(); err != nil {
-			slog.Info("error closing file", "error", err.Error())
+			slog.Warn("error closing file", "error", err.Error())
 		}
 	}()
 

--- a/internal/fileutil/fileutil.go
+++ b/internal/fileutil/fileutil.go
@@ -55,7 +55,11 @@ func CopyFile(src, dst string) error {
 		return err
 	}
 
-	dstFile, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, srcInfo.Mode())
+	// Strip setuid, setgid, and sticky bits to prevent privilege escalation
+	// from untrusted template sources.
+	mode := srcInfo.Mode() &^ (os.ModeSetuid | os.ModeSetgid | os.ModeSticky)
+
+	dstFile, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
 	if err != nil {
 		return err
 	}

--- a/internal/fileutil/fileutil_test.go
+++ b/internal/fileutil/fileutil_test.go
@@ -87,6 +87,37 @@ func TestUT_CopyFile(t *testing.T) {
 		assert.Equal(t, os.FileMode(0o755), info.Mode().Perm())
 	})
 
+	t.Run("strips setuid setgid and sticky bits", func(t *testing.T) {
+		src := filepath.Join(tmpDir, "setuid_file")
+		dst := filepath.Join(tmpDir, "setuid_copy")
+
+		err := os.WriteFile(src, []byte("content"), 0o755)
+		require.NoError(t, err)
+
+		// Set setuid, setgid, and sticky bits on the source file
+		err = os.Chmod(src, 0o755|os.ModeSetuid|os.ModeSetgid|os.ModeSticky)
+		require.NoError(t, err)
+
+		// Verify source has dangerous bits set
+		srcInfo, err := os.Stat(src)
+		require.NoError(t, err)
+		assert.NotZero(t, srcInfo.Mode()&os.ModeSetuid, "source should have setuid bit")
+
+		err = CopyFile(src, dst)
+		require.NoError(t, err)
+
+		dstInfo, err := os.Stat(dst)
+		require.NoError(t, err)
+
+		// Verify dangerous bits are stripped
+		assert.Zero(t, dstInfo.Mode()&os.ModeSetuid, "setuid bit should be stripped")
+		assert.Zero(t, dstInfo.Mode()&os.ModeSetgid, "setgid bit should be stripped")
+		assert.Zero(t, dstInfo.Mode()&os.ModeSticky, "sticky bit should be stripped")
+
+		// Verify regular permissions are preserved
+		assert.Equal(t, os.FileMode(0o755), dstInfo.Mode().Perm())
+	})
+
 	t.Run("source not found returns error", func(t *testing.T) {
 		err := CopyFile(filepath.Join(tmpDir, "nonexistent"), filepath.Join(tmpDir, "out"))
 		assert.Error(t, err)

--- a/internal/remote/reference.go
+++ b/internal/remote/reference.go
@@ -154,6 +154,11 @@ func parseShorthand(input, prefix string, provider Provider, host string) (*Refe
 	// Normalize: remove trailing slashes from subpath
 	subPath = strings.TrimSuffix(subPath, "/")
 
+	// Validate subpath against path traversal
+	if err := validateSubPath(subPath); err != nil {
+		return nil, &ParseError{Input: input, Message: err.Error()}
+	}
+
 	// Build clone URL
 	cloneURL := fmt.Sprintf("https://%s/%s/%s.git", host, owner, repo)
 
@@ -255,6 +260,11 @@ func parseGitHTTPURL(input string, parsed *url.URL, version string) (*Reference,
 	// Normalize subpath
 	subPath = strings.TrimSuffix(subPath, "/")
 
+	// Validate subpath against path traversal
+	if err := validateSubPath(subPath); err != nil {
+		return nil, &ParseError{Input: input, Message: err.Error()}
+	}
+
 	// Build clone URL (without tree/blob path components)
 	cloneURL := fmt.Sprintf("https://%s/%s/%s.git", parsed.Host, owner, repo)
 
@@ -308,6 +318,11 @@ func parseGitURL(input string) (*Reference, error) {
 
 	subPath = strings.TrimSuffix(subPath, "/")
 
+	// Validate subpath against path traversal
+	if err := validateSubPath(subPath); err != nil {
+		return nil, &ParseError{Input: input, Message: err.Error()}
+	}
+
 	provider := ProviderGeneric
 	if p, ok := hostToProvider[host]; ok {
 		provider = p
@@ -342,6 +357,11 @@ func parseSSHStyle(input string) (*Reference, error) {
 	version := strings.TrimPrefix(matches[5], "@")
 	subPath := strings.TrimPrefix(matches[6], "/")
 	subPath = strings.TrimSuffix(subPath, "/")
+
+	// Validate subpath against path traversal
+	if err := validateSubPath(subPath); err != nil {
+		return nil, &ParseError{Input: input, Message: err.Error()}
+	}
 
 	provider := ProviderGeneric
 	if p, ok := hostToProvider[host]; ok {
@@ -472,6 +492,41 @@ func sanitizeForPath(s string) string {
 		"|", "_",
 	)
 	return replacer.Replace(s)
+}
+
+// validateSubPath checks that a subpath is safe and does not contain path traversal components.
+// It rejects absolute paths, paths with ".." segments, and backslash separators.
+func validateSubPath(subPath string) error {
+	if subPath == "" {
+		return nil
+	}
+
+	// Reject absolute paths
+	if filepath.IsAbs(subPath) {
+		return fmt.Errorf("subpath must be relative, got absolute path: %s", subPath)
+	}
+
+	// Reject backslash separators (normalize to forward slash for checking)
+	if strings.ContainsRune(subPath, '\\') {
+		return fmt.Errorf("subpath contains invalid backslash separator: %s", subPath)
+	}
+
+	// Reject any ".." component in the raw path (defense-in-depth: reject before normalization)
+	for _, part := range strings.Split(subPath, "/") {
+		if part == ".." {
+			return fmt.Errorf("subpath contains path traversal component: %s", subPath)
+		}
+	}
+
+	// Also check the cleaned path for ".." components
+	cleaned := filepath.Clean(subPath)
+	for _, part := range strings.Split(cleaned, string(filepath.Separator)) {
+		if part == ".." {
+			return fmt.Errorf("subpath contains path traversal component: %s", subPath)
+		}
+	}
+
+	return nil
 }
 
 // String returns a human-readable representation of the reference.

--- a/internal/remote/reference_test.go
+++ b/internal/remote/reference_test.go
@@ -85,9 +85,9 @@ func TestUT_Parse_BitbucketShorthand(t *testing.T) {
 func TestUT_Parse_ShorthandWithGitSuffix(t *testing.T) {
 	// Test that .git suffix is stripped from shorthand refs to avoid double .git in URL
 	tests := []struct {
-		name        string
-		input       string
-		expectedURL string
+		name         string
+		input        string
+		expectedURL  string
 		expectedRepo string
 	}{
 		{
@@ -425,6 +425,70 @@ func TestUT_Parse_LocalZip(t *testing.T) {
 	assert.Equal(t, ReferenceTypeZip, ref.Type)
 	assert.Equal(t, ProviderGeneric, ref.Provider)
 	assert.Equal(t, zipPath, ref.URL)
+}
+
+func TestUT_ValidateSubPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		subPath string
+		wantErr bool
+	}{
+		{name: "empty string", subPath: "", wantErr: false},
+		{name: "simple directory", subPath: "templates", wantErr: false},
+		{name: "nested directory", subPath: "templates/go/api", wantErr: false},
+		{name: "dotdot traversal", subPath: "../../etc/passwd", wantErr: true},
+		{name: "leading dotdot", subPath: "../secret", wantErr: true},
+		{name: "embedded dotdot", subPath: "a/../../b", wantErr: true},
+		{name: "dotdot only", subPath: "..", wantErr: true},
+		{name: "absolute path unix", subPath: "/etc/passwd", wantErr: true},
+		{name: "backslash separator", subPath: "a\\b\\c", wantErr: true},
+		{name: "dotdot with trailing slash", subPath: "../", wantErr: true},
+		{name: "single dot is valid", subPath: ".", wantErr: false},
+		{name: "normalized clean path", subPath: "a/b/../c", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateSubPath(tt.subPath)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestUT_Parse_SubPath_Rejects_Traversal(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		errContains string
+	}{
+		{
+			name:        "shorthand with dotdot",
+			input:       "gh:user/repo/../../etc",
+			errContains: "path traversal",
+		},
+		{
+			name:        "shorthand version with dotdot subpath",
+			input:       "gh:user/repo@main/../../../etc",
+			errContains: "path traversal",
+		},
+		{
+			name:        "https URL with dotdot subpath",
+			input:       "https://github.com/user/repo/tree/main/../../etc",
+			errContains: "path traversal",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Parse(tt.input)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.errContains)
+		})
+	}
 }
 
 func TestUT_Parse_InvalidReference(t *testing.T) {

--- a/internal/remote/remote.go
+++ b/internal/remote/remote.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -142,11 +144,31 @@ func (r *Resolver) applySubPath(basePath, subPath string) (string, error) {
 		return basePath, nil
 	}
 
-	// The cached path already contains the full template
-	// We need to find the subpath within it
-	fullPath := basePath
-	if subPath != "" {
-		fullPath = basePath + "/" + subPath
+	// Defense-in-depth: validate subpath even though it was checked at parse time
+	if err := validateSubPath(subPath); err != nil {
+		return "", &FetchError{
+			Ref:     &Reference{SubPath: subPath},
+			Message: fmt.Sprintf("invalid subpath: %v", err),
+		}
+	}
+
+	// Use filepath.Join instead of string concatenation for safe path construction
+	fullPath := filepath.Join(basePath, subPath)
+
+	// Verify the resolved path stays within basePath (containment check)
+	absBase, err := filepath.Abs(basePath)
+	if err != nil {
+		return "", fmt.Errorf("cannot resolve base path: %w", err)
+	}
+	absFull, err := filepath.Abs(fullPath)
+	if err != nil {
+		return "", fmt.Errorf("cannot resolve full path: %w", err)
+	}
+	if !strings.HasPrefix(absFull, absBase+string(filepath.Separator)) && absFull != absBase {
+		return "", &FetchError{
+			Ref:     &Reference{SubPath: subPath},
+			Message: fmt.Sprintf("subpath %q escapes base directory", subPath),
+		}
 	}
 
 	info, err := os.Stat(fullPath)

--- a/internal/remote/remote_test.go
+++ b/internal/remote/remote_test.go
@@ -178,6 +178,43 @@ func TestUT_Resolver_InvalidReference(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid")
 }
 
+func TestUT_ApplySubPath_Containment(t *testing.T) {
+	tmpDir := t.TempDir()
+	cacheDir := filepath.Join(tmpDir, "cache")
+
+	resolver, err := NewResolverWithOptions(cacheDir, nil)
+	require.NoError(t, err)
+
+	// Create a base directory with a subdirectory
+	baseDir := filepath.Join(tmpDir, "base")
+	subDir := filepath.Join(baseDir, "templates")
+	require.NoError(t, os.MkdirAll(subDir, 0o755))
+
+	t.Run("valid subpath returns correct path", func(t *testing.T) {
+		path, err := resolver.applySubPath(baseDir, "templates")
+		require.NoError(t, err)
+		assert.Equal(t, subDir, path)
+	})
+
+	t.Run("empty subpath returns base path", func(t *testing.T) {
+		path, err := resolver.applySubPath(baseDir, "")
+		require.NoError(t, err)
+		assert.Equal(t, baseDir, path)
+	})
+
+	t.Run("dotdot traversal is rejected", func(t *testing.T) {
+		_, err := resolver.applySubPath(baseDir, "../../etc/passwd")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "path traversal")
+	})
+
+	t.Run("nonexistent subpath returns error", func(t *testing.T) {
+		_, err := resolver.applySubPath(baseDir, "nonexistent")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
 func TestUT_IsLocal(t *testing.T) {
 	// Create temp directory for local path test
 	tmpDir := t.TempDir()

--- a/internal/remote/zip.go
+++ b/internal/remote/zip.go
@@ -140,11 +140,15 @@ func (f *ZipFetcher) download(ctx context.Context, url string) (string, error) {
 	limited := io.LimitReader(resp.Body, f.maxFileSize)
 
 	_, err = io.Copy(tmpFile, limited)
-	tmpFile.Close()
+	closeErr := tmpFile.Close()
 
 	if err != nil {
 		os.Remove(tmpPath)
 		return "", fmt.Errorf("write file: %w", err)
+	}
+	if closeErr != nil {
+		os.Remove(tmpPath)
+		return "", fmt.Errorf("close temp file: %w", closeErr)
 	}
 
 	return tmpPath, nil

--- a/internal/writer/writer.go
+++ b/internal/writer/writer.go
@@ -1,9 +1,12 @@
 package writer
 
 import (
+	"fmt"
 	"io/fs"
 	"log/slog"
 	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 )
 
@@ -20,10 +23,41 @@ func New(dryRun bool) Write {
 	}
 }
 
-// WriteFile thin wrapper to decouple dependency of write file
+// validatePathWithinDir ensures that path stays within the base directory.
+// This prevents path traversal attacks where template output paths could escape the working directory.
+func validatePathWithinDir(path, baseDir string) error {
+	absPath, err := filepath.Abs(filepath.Clean(path))
+	if err != nil {
+		return fmt.Errorf("failed to resolve absolute path: %w", err)
+	}
+	absBase, err := filepath.Abs(filepath.Clean(baseDir))
+	if err != nil {
+		return fmt.Errorf("failed to resolve absolute base: %w", err)
+	}
+
+	if !strings.HasPrefix(absPath, absBase+string(filepath.Separator)) && absPath != absBase {
+		return fmt.Errorf("path %q escapes base directory %q", absPath, absBase)
+	}
+
+	return nil
+}
+
+// WriteFile thin wrapper to decouple dependency of write file.
+// Validates that the output path stays within the current working directory
+// to prevent path traversal via malicious generator templates.
 func (w *Write) WriteFile(name string, data []byte, perm fs.FileMode) error {
 	w.mx.Lock()
 	defer w.mx.Unlock()
+
+	// Validate path containment against working directory
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("cannot determine working directory: %w", err)
+	}
+	if err := validatePathWithinDir(name, cwd); err != nil {
+		return fmt.Errorf("path safety check failed: %w", err)
+	}
+
 	return w.fs.WriteFile(name, data, perm)
 }
 

--- a/internal/writer/writer_test.go
+++ b/internal/writer/writer_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 
@@ -33,6 +34,105 @@ func TestWrite_WriteFile_write_error_should_return_error(t *testing.T) {
 	}
 	err := w.WriteFile("blood", []byte("hello world"), 0o700)
 	assert.Error(t, err)
+}
+
+func TestUT_WriteFile_PathContainment(t *testing.T) {
+	t.Run("rejects paths outside working directory", func(t *testing.T) {
+		mockWr := fileReadWriteMock{}
+		writeCalled := false
+		mockWr.WriteFileFunc = func(name string, data []byte, perm fs.FileMode) error {
+			writeCalled = true
+			return nil
+		}
+
+		w := Write{
+			mx: sync.Mutex{},
+			fs: &mockWr,
+		}
+
+		err := w.WriteFile("/etc/cron.d/backdoor", []byte("malicious"), 0o750)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "path safety check failed")
+		assert.False(t, writeCalled, "file should not have been written")
+	})
+
+	t.Run("rejects dotdot traversal", func(t *testing.T) {
+		mockWr := fileReadWriteMock{}
+		writeCalled := false
+		mockWr.WriteFileFunc = func(name string, data []byte, perm fs.FileMode) error {
+			writeCalled = true
+			return nil
+		}
+
+		w := Write{
+			mx: sync.Mutex{},
+			fs: &mockWr,
+		}
+
+		err := w.WriteFile("../../etc/passwd", []byte("malicious"), 0o750)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "path safety check failed")
+		assert.False(t, writeCalled, "file should not have been written")
+	})
+
+	t.Run("allows paths within working directory", func(t *testing.T) {
+		mockWr := fileReadWriteMock{}
+
+		w := Write{
+			mx: sync.Mutex{},
+			fs: &mockWr,
+		}
+
+		err := w.WriteFile("mypackage/output.go", []byte("package mypackage"), 0o750)
+		require.NoError(t, err)
+	})
+}
+
+func TestUT_ValidatePathWithinDir(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	tests := []struct {
+		name    string
+		path    string
+		baseDir string
+		wantErr bool
+	}{
+		{
+			name:    "path within base",
+			path:    filepath.Join(tmpDir, "sub", "file.go"),
+			baseDir: tmpDir,
+			wantErr: false,
+		},
+		{
+			name:    "path escapes base",
+			path:    filepath.Join(tmpDir, "..", "escape"),
+			baseDir: tmpDir,
+			wantErr: true,
+		},
+		{
+			name:    "absolute path outside base",
+			path:    "/etc/passwd",
+			baseDir: tmpDir,
+			wantErr: true,
+		},
+		{
+			name:    "path equals base",
+			path:    tmpDir,
+			baseDir: tmpDir,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validatePathWithinDir(tt.path, tt.baseDir)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }
 
 func TestWrite_AppendFile_should_return_ok(t *testing.T) {


### PR DESCRIPTION
## Summary

Implements all 5 tickets from Epic #53 (Phase 2: High Priority Fixes):

### Security Fixes
- **#33 - Remote SubPath path traversal validation**: Added `validateSubPath()` function that rejects `..` components, absolute paths, and backslash separators. Integrated at parse time in all 4 reference parsers AND at resolution time in `applySubPath()` with containment check using `filepath.Abs` + `strings.HasPrefix`.
- **#34 - Legacy engine path containment**: Added `validatePathWithinDir()` to `writer.go` with CWD-based path containment validation in `WriteFile()` to prevent malicious template output paths from escaping the working directory.
- **#35 - CopyFile strips setuid/setgid/sticky bits**: `CopyFile()` now strips `os.ModeSetuid`, `os.ModeSetgid`, and `os.ModeSticky` bits from copied files to prevent privilege escalation from untrusted template sources.

### Bug Fixes
- **#36 - Fix error log levels**: Changed `slog.Info` to `slog.Error` for init failures (`init.go`), and `slog.Info` to `slog.Warn` for deferred file close errors (`new.go`, `bundle.go`).
- **#37 - Check tmpFile.Close() error**: Fixed unchecked `tmpFile.Close()` in `zip.go` to capture and handle close errors that could indicate buffered write failures.

Closes #33, closes #34, closes #35, closes #36, closes #37

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [x] `go vet ./...` clean
- [x] New tests for `validateSubPath` (12 cases including edge cases)
- [x] New tests for `Parse` subpath traversal rejection (3 parser paths)
- [x] New tests for `applySubPath` containment (4 subtests)
- [x] New tests for `WriteFile` path containment (3 subtests)
- [x] New tests for `validatePathWithinDir` (4 table-driven cases)
- [x] New test for CopyFile setuid/setgid/sticky bit stripping
- [x] Peer review by Gemini: LGTM

🤖 Generated with [Claude Code](https://claude.com/claude-code)