### PR TITLE
test: Phase 0 test harness for scaffold security-critical code

### DIFF
--- a/internal/scaffold/output_test.go
+++ b/internal/scaffold/output_test.go
@@ -1,0 +1,711 @@
+package scaffold
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/kaikenlabs/tag/internal/template"
+	"github.com/kaikenlabs/tag/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- validatePathWithinDir ---
+
+func TestUT_ValidatePathWithinDir_ValidPaths(t *testing.T) {
+	base := t.TempDir()
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{"simple file", filepath.Join(base, "file.txt")},
+		{"nested file", filepath.Join(base, "sub", "dir", "file.txt")},
+		{"dot in name", filepath.Join(base, ".hidden", "file.txt")},
+		{"cleaned relative", filepath.Join(base, "sub", "..", "sub", "file.txt")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validatePathWithinDir(tt.path, base)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestUT_ValidatePathWithinDir_PathTraversal(t *testing.T) {
+	base := t.TempDir()
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{"parent traversal", filepath.Join(base, "..", "escape.txt")},
+		{"double parent traversal", filepath.Join(base, "..", "..", "escape.txt")},
+		{"absolute path outside", "/tmp/evil.txt"},
+		{"prefix collision", base + "X/file.txt"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validatePathWithinDir(tt.path, base)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "escapes base directory")
+		})
+	}
+}
+
+func TestUT_ValidatePathWithinDir_PathEqualsBase(t *testing.T) {
+	base := t.TempDir()
+	// Path equal to base should be allowed (the `absPath != absBase` check)
+	err := validatePathWithinDir(base, base)
+	assert.NoError(t, err)
+}
+
+func TestUT_ValidatePathWithinDir_EmptyPath(t *testing.T) {
+	base := t.TempDir()
+	// Empty path resolves to cwd via filepath.Abs, which is outside base
+	err := validatePathWithinDir("", base)
+	assert.Error(t, err)
+}
+
+// --- sanitizeFileMode ---
+
+func TestUT_SanitizeFileMode(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    fs.FileMode
+		expected fs.FileMode
+	}{
+		{"normal file permissions", 0o644, 0o644},
+		{"normal dir permissions", 0o755, 0o755},
+		{"setuid bit removed", fs.ModeSetuid | 0o755, 0o755},
+		{"setgid bit removed", fs.ModeSetgid | 0o755, 0o755},
+		{"sticky bit removed", fs.ModeSticky | 0o755, 0o755},
+		{"all dangerous bits removed", fs.ModeSetuid | fs.ModeSetgid | fs.ModeSticky | 0o755, 0o755},
+		{"zero permissions", 0, 0},
+		{"only setuid no perms", fs.ModeSetuid, 0},
+		{"executable preserved", 0o755, 0o755},
+		{"read only preserved", 0o444, 0o444},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := sanitizeFileMode(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// --- Write (end-to-end integration) ---
+
+func mustNewEngine(t *testing.T) *template.Engine {
+	t.Helper()
+	engine, err := template.NewEngine()
+	require.NoError(t, err)
+	return engine
+}
+
+func mustNewOutputWriter(t *testing.T) *DefaultOutputWriter {
+	t.Helper()
+	engine := mustNewEngine(t)
+	pathProcessor := NewPathProcessor(engine)
+	return NewOutputWriter(engine, pathProcessor)
+}
+
+func TestUT_Write_TemplateRendering(t *testing.T) {
+	writer := mustNewOutputWriter(t)
+
+	// Setup template directory
+	templateDir := t.TempDir()
+	outputDir := t.TempDir()
+
+	// Create a template file
+	err := os.WriteFile(
+		filepath.Join(templateDir, "hello.txt"),
+		[]byte("Hello, {{ vars.name }}!"),
+		0o644,
+	)
+	require.NoError(t, err)
+
+	vars := map[string]any{"name": "World"}
+	err = writer.Write(templateDir, outputDir, vars)
+	require.NoError(t, err)
+
+	// Verify rendered content
+	content, err := os.ReadFile(filepath.Join(outputDir, "hello.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "Hello, World!", string(content))
+}
+
+func TestUT_Write_BinaryFilePassthrough(t *testing.T) {
+	writer := mustNewOutputWriter(t)
+
+	templateDir := t.TempDir()
+	outputDir := t.TempDir()
+
+	// Create binary file with null bytes and {{ sequences (should not be processed as template)
+	binaryContent := []byte{0x89, 0x50, 0x4E, 0x47, 0x00, 0x00, '{', '{', ' ', 'v', 'a', 'r', 's', '.', 'x', ' ', '}', '}'}
+	err := os.WriteFile(filepath.Join(templateDir, "image.png"), binaryContent, 0o644)
+	require.NoError(t, err)
+
+	vars := map[string]any{"x": "should_not_appear"}
+	err = writer.Write(templateDir, outputDir, vars)
+	require.NoError(t, err)
+
+	// Binary file should be copied as-is, not template-processed
+	content, err := os.ReadFile(filepath.Join(outputDir, "image.png"))
+	require.NoError(t, err)
+	assert.Equal(t, binaryContent, content)
+}
+
+func TestUT_Write_DirectoryCreation(t *testing.T) {
+	writer := mustNewOutputWriter(t)
+
+	templateDir := t.TempDir()
+	outputDir := t.TempDir()
+
+	// Create nested directory structure
+	nestedDir := filepath.Join(templateDir, "sub", "dir")
+	require.NoError(t, os.MkdirAll(nestedDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(nestedDir, "file.txt"), []byte("content"), 0o644))
+
+	vars := map[string]any{}
+	err := writer.Write(templateDir, outputDir, vars)
+	require.NoError(t, err)
+
+	// Verify directory was created and file exists
+	info, err := os.Stat(filepath.Join(outputDir, "sub", "dir"))
+	require.NoError(t, err)
+	assert.True(t, info.IsDir())
+
+	content, err := os.ReadFile(filepath.Join(outputDir, "sub", "dir", "file.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "content", string(content))
+}
+
+func TestUT_Write_SkipsTagTemplateJSON(t *testing.T) {
+	writer := mustNewOutputWriter(t)
+
+	templateDir := t.TempDir()
+	outputDir := t.TempDir()
+
+	// Create tag.template.json (should be skipped)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(templateDir, types.TemplateConfigFile),
+		[]byte(`{"vars":{}}`),
+		0o644,
+	))
+	// Create a normal file
+	require.NoError(t, os.WriteFile(
+		filepath.Join(templateDir, "keep.txt"),
+		[]byte("kept"),
+		0o644,
+	))
+
+	vars := map[string]any{}
+	err := writer.Write(templateDir, outputDir, vars)
+	require.NoError(t, err)
+
+	// tag.template.json should NOT exist in output
+	_, err = os.Stat(filepath.Join(outputDir, types.TemplateConfigFile))
+	assert.True(t, os.IsNotExist(err))
+
+	// Normal file should exist
+	_, err = os.Stat(filepath.Join(outputDir, "keep.txt"))
+	assert.NoError(t, err)
+}
+
+func TestUT_Write_SkipsGeneratorsDir(t *testing.T) {
+	writer := mustNewOutputWriter(t)
+
+	templateDir := t.TempDir()
+	outputDir := t.TempDir()
+
+	// Create _generators directory with content
+	genDir := filepath.Join(templateDir, types.GeneratorsDir)
+	require.NoError(t, os.MkdirAll(genDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(genDir, "gen.txt"), []byte("gen"), 0o644))
+
+	// Create normal file
+	require.NoError(t, os.WriteFile(filepath.Join(templateDir, "keep.txt"), []byte("kept"), 0o644))
+
+	vars := map[string]any{}
+	err := writer.Write(templateDir, outputDir, vars)
+	require.NoError(t, err)
+
+	// _generators should NOT exist in output
+	_, err = os.Stat(filepath.Join(outputDir, types.GeneratorsDir))
+	assert.True(t, os.IsNotExist(err))
+
+	// Normal file should exist
+	_, err = os.Stat(filepath.Join(outputDir, "keep.txt"))
+	assert.NoError(t, err)
+}
+
+func TestUT_Write_PathPlaceholders(t *testing.T) {
+	writer := mustNewOutputWriter(t)
+
+	templateDir := t.TempDir()
+	outputDir := t.TempDir()
+
+	// Create file with placeholder in directory name
+	placeholderDir := filepath.Join(templateDir, "{{ vars.project_name }}")
+	require.NoError(t, os.MkdirAll(placeholderDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(placeholderDir, "main.go"),
+		[]byte("package {{ vars.project_name }}"),
+		0o644,
+	))
+
+	vars := map[string]any{"project_name": "myapp"}
+	err := writer.Write(templateDir, outputDir, vars)
+	require.NoError(t, err)
+
+	// Verify placeholder was resolved in path and content
+	content, err := os.ReadFile(filepath.Join(outputDir, "myapp", "main.go"))
+	require.NoError(t, err)
+	assert.Equal(t, "package myapp", string(content))
+}
+
+func TestUT_Write_SymlinkSkipping(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink tests unreliable on Windows")
+	}
+
+	writer := mustNewOutputWriter(t)
+
+	templateDir := t.TempDir()
+	outputDir := t.TempDir()
+
+	// Create a real file
+	require.NoError(t, os.WriteFile(filepath.Join(templateDir, "real.txt"), []byte("real"), 0o644))
+
+	// Create a symlink (should be skipped)
+	targetFile := filepath.Join(t.TempDir(), "outside.txt")
+	require.NoError(t, os.WriteFile(targetFile, []byte("outside"), 0o644))
+	require.NoError(t, os.Symlink(targetFile, filepath.Join(templateDir, "link.txt")))
+
+	vars := map[string]any{}
+	err := writer.Write(templateDir, outputDir, vars)
+	require.NoError(t, err)
+
+	// Real file should exist
+	_, err = os.Stat(filepath.Join(outputDir, "real.txt"))
+	assert.NoError(t, err)
+
+	// Symlink should NOT be in output
+	_, err = os.Stat(filepath.Join(outputDir, "link.txt"))
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestUT_Write_ConditionalFileExclusion(t *testing.T) {
+	writer := mustNewOutputWriter(t)
+
+	templateDir := t.TempDir()
+	outputDir := t.TempDir()
+
+	// Create file with conditional filename (false condition -> excluded)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(templateDir, `{% if vars.include == "yes" %}optional.txt{% endif %}`),
+		[]byte("optional content"),
+		0o644,
+	))
+	// Create normal file
+	require.NoError(t, os.WriteFile(filepath.Join(templateDir, "always.txt"), []byte("always"), 0o644))
+
+	vars := map[string]any{"include": "no"}
+	err := writer.Write(templateDir, outputDir, vars)
+	require.NoError(t, err)
+
+	// Conditional file should NOT exist
+	_, err = os.Stat(filepath.Join(outputDir, "optional.txt"))
+	assert.True(t, os.IsNotExist(err))
+
+	// Normal file should exist
+	_, err = os.Stat(filepath.Join(outputDir, "always.txt"))
+	assert.NoError(t, err)
+}
+
+func TestUT_Write_PathTraversalViaPlaceholder(t *testing.T) {
+	writer := mustNewOutputWriter(t)
+
+	templateDir := t.TempDir()
+	outputDir := t.TempDir()
+
+	// Create a file whose path placeholder resolves to a traversal attempt
+	require.NoError(t, os.WriteFile(
+		filepath.Join(templateDir, "{{ vars.out }}"),
+		[]byte("escaped"),
+		0o644,
+	))
+
+	vars := map[string]any{"out": "../escape.txt"}
+	err := writer.Write(templateDir, outputDir, vars)
+	require.Error(t, err)
+
+	var pathErr *PathError
+	assert.ErrorAs(t, err, &pathErr)
+	assert.Contains(t, err.Error(), "path traversal detected")
+
+	// Escaped file should NOT exist outside output dir
+	_, statErr := os.Stat(filepath.Join(outputDir, "..", "escape.txt"))
+	assert.True(t, os.IsNotExist(statErr))
+}
+
+func TestUT_Write_SymlinkDirSkipping(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink tests unreliable on Windows")
+	}
+
+	writer := mustNewOutputWriter(t)
+
+	templateDir := t.TempDir()
+	outputDir := t.TempDir()
+
+	// Create a real file
+	require.NoError(t, os.WriteFile(filepath.Join(templateDir, "real.txt"), []byte("real"), 0o644))
+
+	// Create a symlink to a directory outside the template
+	externalDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(externalDir, "secret.txt"), []byte("secret"), 0o644))
+	require.NoError(t, os.Symlink(externalDir, filepath.Join(templateDir, "linked_dir")))
+
+	vars := map[string]any{}
+	err := writer.Write(templateDir, outputDir, vars)
+	require.NoError(t, err)
+
+	// Real file should exist
+	_, err = os.Stat(filepath.Join(outputDir, "real.txt"))
+	assert.NoError(t, err)
+
+	// Symlinked directory and its contents should NOT be in output
+	_, err = os.Stat(filepath.Join(outputDir, "linked_dir"))
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestUT_Write_EmptyTemplate(t *testing.T) {
+	writer := mustNewOutputWriter(t)
+
+	templateDir := t.TempDir()
+	outputDir := t.TempDir()
+
+	// Create empty file
+	require.NoError(t, os.WriteFile(filepath.Join(templateDir, "empty.txt"), []byte(""), 0o644))
+
+	vars := map[string]any{}
+	err := writer.Write(templateDir, outputDir, vars)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(filepath.Join(outputDir, "empty.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "", string(content))
+}
+
+// --- processFile ---
+
+// mockTemplate implements template.Template for testing.
+type mockTemplate struct {
+	result string
+	err    error
+}
+
+func (m *mockTemplate) Execute(_ template.Context) (string, error) {
+	return m.result, m.err
+}
+
+// mockRenderer implements template.TemplateRenderer for testing.
+type mockRenderer struct {
+	parseStringTemplate template.Template
+	parseStringErr      error
+	executeResult       string
+	executeErr          error
+}
+
+func (m *mockRenderer) ParseString(_ string) (template.Template, error) {
+	return m.parseStringTemplate, m.parseStringErr
+}
+
+func (m *mockRenderer) ParseStringNamed(_, _ string) (template.Template, error) {
+	return m.parseStringTemplate, m.parseStringErr
+}
+
+func (m *mockRenderer) ExecuteToString(_ string, _ template.Context) (string, error) {
+	return m.executeResult, m.executeErr
+}
+
+var _ template.TemplateRenderer = (*mockRenderer)(nil)
+
+func TestUT_ProcessFile_TextTemplate(t *testing.T) {
+	mock := &mockRenderer{
+		parseStringTemplate: &mockTemplate{result: "rendered output", err: nil},
+	}
+	writer := NewOutputWriter(mock, nil)
+
+	templateDir := t.TempDir()
+	outputDir := t.TempDir()
+
+	srcPath := filepath.Join(templateDir, "file.txt")
+	require.NoError(t, os.WriteFile(srcPath, []byte("{{ vars.name }}"), 0o644))
+
+	destPath := filepath.Join(outputDir, "file.txt")
+	info, err := os.Stat(srcPath)
+	require.NoError(t, err)
+
+	// Create a dirEntry from the file info
+	ctx := template.Context{"vars": map[string]any{"name": "test"}}
+	err = writer.processFile(srcPath, destPath, ctx, newTestDirEntry(info))
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(destPath)
+	require.NoError(t, err)
+	assert.Equal(t, "rendered output", string(content))
+}
+
+func TestUT_ProcessFile_BinaryFile(t *testing.T) {
+	// Binary files should be copied as-is, mock should NOT be called for parsing
+	mock := &mockRenderer{
+		parseStringTemplate: &mockTemplate{result: "SHOULD NOT APPEAR", err: nil},
+	}
+	writer := NewOutputWriter(mock, nil)
+
+	templateDir := t.TempDir()
+	outputDir := t.TempDir()
+
+	binaryContent := []byte{0x00, 0x01, 0x02, 0xFF}
+	srcPath := filepath.Join(templateDir, "binary.bin")
+	require.NoError(t, os.WriteFile(srcPath, binaryContent, 0o644))
+
+	destPath := filepath.Join(outputDir, "binary.bin")
+	info, err := os.Stat(srcPath)
+	require.NoError(t, err)
+
+	ctx := template.Context{}
+	err = writer.processFile(srcPath, destPath, ctx, newTestDirEntry(info))
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(destPath)
+	require.NoError(t, err)
+	assert.Equal(t, binaryContent, content)
+}
+
+func TestUT_ProcessFile_SanitizesFileMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("file mode tests not reliable on Windows")
+	}
+
+	mock := &mockRenderer{
+		parseStringTemplate: &mockTemplate{result: "content", err: nil},
+	}
+	writer := NewOutputWriter(mock, nil)
+
+	templateDir := t.TempDir()
+	outputDir := t.TempDir()
+
+	srcPath := filepath.Join(templateDir, "exec.sh")
+	require.NoError(t, os.WriteFile(srcPath, []byte("#!/bin/sh"), 0o755))
+	// Set setuid bit on source file
+	require.NoError(t, os.Chmod(srcPath, fs.ModeSetuid|0o755))
+
+	destPath := filepath.Join(outputDir, "exec.sh")
+	info, err := os.Stat(srcPath)
+	require.NoError(t, err)
+
+	ctx := template.Context{}
+	err = writer.processFile(srcPath, destPath, ctx, newTestDirEntry(info))
+	require.NoError(t, err)
+
+	destInfo, err := os.Stat(destPath)
+	require.NoError(t, err)
+	// Setuid bit should be stripped
+	assert.Equal(t, fs.FileMode(0), destInfo.Mode()&fs.ModeSetuid)
+	// Execute bit should be preserved
+	assert.NotEqual(t, fs.FileMode(0), destInfo.Mode()&0o111)
+}
+
+func TestUT_ProcessFile_TemplateParseError(t *testing.T) {
+	mock := &mockRenderer{
+		parseStringErr: fmt.Errorf("parse error: invalid syntax"),
+	}
+	writer := NewOutputWriter(mock, nil)
+
+	templateDir := t.TempDir()
+	outputDir := t.TempDir()
+
+	srcPath := filepath.Join(templateDir, "bad.txt")
+	require.NoError(t, os.WriteFile(srcPath, []byte("valid text"), 0o644))
+
+	destPath := filepath.Join(outputDir, "bad.txt")
+	info, err := os.Stat(srcPath)
+	require.NoError(t, err)
+
+	ctx := template.Context{}
+	err = writer.processFile(srcPath, destPath, ctx, newTestDirEntry(info))
+	require.Error(t, err)
+
+	var tmplErr *TemplateError
+	assert.ErrorAs(t, err, &tmplErr)
+}
+
+func TestUT_ProcessFile_TemplateExecuteError(t *testing.T) {
+	mock := &mockRenderer{
+		parseStringTemplate: &mockTemplate{result: "", err: fmt.Errorf("execute failed")},
+	}
+	writer := NewOutputWriter(mock, nil)
+
+	templateDir := t.TempDir()
+	outputDir := t.TempDir()
+
+	srcPath := filepath.Join(templateDir, "bad.txt")
+	require.NoError(t, os.WriteFile(srcPath, []byte("valid text"), 0o644))
+
+	destPath := filepath.Join(outputDir, "bad.txt")
+	info, err := os.Stat(srcPath)
+	require.NoError(t, err)
+
+	ctx := template.Context{}
+	err = writer.processFile(srcPath, destPath, ctx, newTestDirEntry(info))
+	require.Error(t, err)
+
+	var tmplErr *TemplateError
+	assert.ErrorAs(t, err, &tmplErr)
+}
+
+// --- CopyGenerators ---
+
+func TestUT_CopyGenerators_WithGenerators(t *testing.T) {
+	templateDir := t.TempDir()
+	outputDir := t.TempDir()
+
+	// Create _generators with content
+	genDir := filepath.Join(templateDir, types.GeneratorsDir)
+	require.NoError(t, os.MkdirAll(filepath.Join(genDir, "mygen"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(genDir, "mygen", "template.txt"), []byte("gen content"), 0o644))
+
+	err := CopyGenerators(templateDir, outputDir)
+	require.NoError(t, err)
+
+	// Should be copied to .tag.templates
+	content, err := os.ReadFile(filepath.Join(outputDir, types.TemplatesDir, "mygen", "template.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "gen content", string(content))
+}
+
+func TestUT_CopyGenerators_NoGenerators(t *testing.T) {
+	templateDir := t.TempDir()
+	outputDir := t.TempDir()
+
+	// No _generators directory exists
+	err := CopyGenerators(templateDir, outputDir)
+	require.NoError(t, err)
+
+	// Should create empty .tag.templates
+	info, err := os.Stat(filepath.Join(outputDir, types.TemplatesDir))
+	require.NoError(t, err)
+	assert.True(t, info.IsDir())
+}
+
+func TestUT_CopyGenerators_SkipsSymlinks(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink tests unreliable on Windows")
+	}
+
+	templateDir := t.TempDir()
+	outputDir := t.TempDir()
+
+	genDir := filepath.Join(templateDir, types.GeneratorsDir)
+	require.NoError(t, os.MkdirAll(genDir, 0o755))
+
+	// Create real file
+	require.NoError(t, os.WriteFile(filepath.Join(genDir, "real.txt"), []byte("real"), 0o644))
+
+	// Create symlink pointing outside
+	target := filepath.Join(t.TempDir(), "outside.txt")
+	require.NoError(t, os.WriteFile(target, []byte("outside"), 0o644))
+	require.NoError(t, os.Symlink(target, filepath.Join(genDir, "link.txt")))
+
+	err := CopyGenerators(templateDir, outputDir)
+	require.NoError(t, err)
+
+	// Real file should be copied
+	_, err = os.Stat(filepath.Join(outputDir, types.TemplatesDir, "real.txt"))
+	assert.NoError(t, err)
+
+	// Symlink should NOT be copied
+	_, err = os.Stat(filepath.Join(outputDir, types.TemplatesDir, "link.txt"))
+	assert.True(t, os.IsNotExist(err))
+}
+
+// --- GenerateTagConfig ---
+
+func TestUT_GenerateTagConfig(t *testing.T) {
+	outputDir := t.TempDir()
+
+	err := GenerateTagConfig(outputDir)
+	require.NoError(t, err)
+
+	configPath := filepath.Join(outputDir, ".tagconfig.json")
+	data, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+
+	// Parse and validate JSON structure
+	var config map[string]any
+	require.NoError(t, json.Unmarshal(data, &config))
+
+	// Verify env section
+	env, ok := config["env"].(map[string]any)
+	require.True(t, ok, "env should be a map")
+	assert.Equal(t, types.TemplatesDir, env["TAG_PATH"])
+	assert.Equal(t, types.SharedDir, env["TAG_SHARED_PATH"])
+	assert.Equal(t, types.BundlesDir, env["TAG_BUNDLE_PATH"])
+
+	// Verify hooks section
+	hooks, ok := config["hooks"].(map[string]any)
+	require.True(t, ok, "hooks should be a map")
+	assert.NotNil(t, hooks["pre"])
+	assert.NotNil(t, hooks["post"])
+}
+
+// --- buildTemplateContext ---
+
+func TestUT_BuildTemplateContext(t *testing.T) {
+	vars := map[string]any{
+		"name":    "test",
+		"version": "1.0",
+	}
+
+	ctx := buildTemplateContext(vars)
+
+	// Context should have vars namespace
+	ctxVars, ok := ctx["vars"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "test", ctxVars["name"])
+	assert.Equal(t, "1.0", ctxVars["version"])
+
+	// Context should also have root-level vars (from WithRootVars)
+	// This makes {{ name }} work in addition to {{ vars.name }}
+	rootName, ok := ctx["name"]
+	assert.True(t, ok, "root-level vars should be set via WithRootVars")
+	assert.Equal(t, "test", rootName)
+}
+
+// --- test helpers ---
+
+// testDirEntry wraps os.FileInfo to implement fs.DirEntry for tests.
+type testDirEntry struct {
+	info os.FileInfo
+}
+
+func newTestDirEntry(info os.FileInfo) fs.DirEntry {
+	return &testDirEntry{info: info}
+}
+
+func (d *testDirEntry) Name() string               { return d.info.Name() }
+func (d *testDirEntry) IsDir() bool                { return d.info.IsDir() }
+func (d *testDirEntry) Type() fs.FileMode          { return d.info.Mode().Type() }
+func (d *testDirEntry) Info() (fs.FileInfo, error) { return d.info, nil }

--- a/internal/scaffold/processor_test.go
+++ b/internal/scaffold/processor_test.go
@@ -502,3 +502,138 @@ func TestUT_PathProcessor_MockExecutorError(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "mock render error")
 }
+
+// ============================================================================
+// SSTI REGRESSION TESTS (Ticket #65)
+//
+// These tests document the current behavior of recursive template rendering
+// in processSegment. The recursive rendering (up to 5 iterations) means that
+// user-controlled variable values containing template syntax will be executed.
+//
+// This is a Server-Side Template Injection (SSTI) vulnerability.
+// When the S1 fix is applied (Phase 2.3), these tests should be updated:
+// - Tests marked "current behavior" should change expected results to show
+//   that user-provided template syntax is NO LONGER rendered.
+// ============================================================================
+
+func TestUT_ProcessSegment_RecursiveRendering_CurrentBehavior(t *testing.T) {
+	// SSTI REGRESSION: This test demonstrates that user-provided variable values
+	// containing template syntax are rendered by the recursive processSegment loop.
+	// After S1 fix: user-provided {{ }} in values should NOT be rendered.
+	processor := mustNewPathProcessor(t)
+
+	vars := map[string]any{
+		"project_name": "myproject",
+		// User-controlled value that contains template syntax
+		"user_input": "{{ vars.project_name }}",
+	}
+
+	// Current behavior: the template in user_input is rendered, yielding "myproject"
+	result, err := processor.ProcessPath("{{ vars.user_input }}", vars)
+	require.NoError(t, err)
+	// SSTI: user_input's value "{{ vars.project_name }}" is rendered to "myproject"
+	assert.Equal(t, "myproject", result,
+		"SSTI: recursive rendering resolves template syntax in user-provided values")
+}
+
+func TestUT_ProcessSegment_NestedSSTI_CurrentBehavior(t *testing.T) {
+	// SSTI REGRESSION: Multi-level nested template injection.
+	// Variable A references Variable B's template expression, which in turn
+	// references Variable C's plain value.
+	processor := mustNewPathProcessor(t)
+
+	vars := map[string]any{
+		"level_c": "final_value",
+		"level_b": "{{ vars.level_c }}",
+		"level_a": "{{ vars.level_b }}",
+	}
+
+	// Current behavior: recursive rendering resolves through all levels
+	result, err := processor.ProcessPath("{{ vars.level_a }}", vars)
+	require.NoError(t, err)
+	// level_a → "{{ vars.level_b }}" → "{{ vars.level_c }}" → "final_value"
+	assert.Equal(t, "final_value", result,
+		"SSTI: multi-level recursive rendering resolves nested template expressions")
+}
+
+func TestUT_ProcessSegment_RecursionLimit(t *testing.T) {
+	// Verify the recursion limit (maxRenderIterations = 5) prevents infinite loops.
+	// Create a chain of variables that would require more than 5 iterations to fully resolve.
+	processor := mustNewPathProcessor(t)
+
+	// Build a chain: v1 → v2 → v3 → v4 → v5 → v6 → "done"
+	// With 5 iterations max, the chain should stop before fully resolving.
+	vars := map[string]any{
+		"v6": "done",
+		"v5": "{{ vars.v6 }}",
+		"v4": "{{ vars.v5 }}",
+		"v3": "{{ vars.v4 }}",
+		"v2": "{{ vars.v3 }}",
+		"v1": "{{ vars.v2 }}",
+	}
+
+	result, err := processor.ProcessPath("{{ vars.v1 }}", vars)
+	require.NoError(t, err)
+
+	// The chain requires 6 renders to fully resolve (v1→v2→v3→v4→v5→v6→done).
+	// With maxRenderIterations=5, we start with "{{ vars.v1 }}" and get 5 render passes:
+	// Pass 1: "{{ vars.v1 }}" → "{{ vars.v2 }}"
+	// Pass 2: "{{ vars.v2 }}" → "{{ vars.v3 }}"
+	// Pass 3: "{{ vars.v3 }}" → "{{ vars.v4 }}"
+	// Pass 4: "{{ vars.v4 }}" → "{{ vars.v5 }}"
+	// Pass 5: "{{ vars.v5 }}" → "{{ vars.v6 }}"
+	// Loop ends (5 iterations used). Result still contains template syntax.
+	assert.NotEqual(t, "done", result,
+		"recursion limit should prevent full resolution of a 6-level chain")
+	assert.Contains(t, result, "v6",
+		"result should still contain unresolved reference to v6")
+
+	// Also verify a 5-level chain DOES fully resolve (proving the limit is exactly 5)
+	vars5 := map[string]any{
+		"v5": "resolved",
+		"v4": "{{ vars.v5 }}",
+		"v3": "{{ vars.v4 }}",
+		"v2": "{{ vars.v3 }}",
+		"v1": "{{ vars.v2 }}",
+	}
+	result5, err := processor.ProcessPath("{{ vars.v1 }}", vars5)
+	require.NoError(t, err)
+	assert.Equal(t, "resolved", result5,
+		"a 5-level chain should fully resolve within the recursion limit")
+}
+
+func TestUT_ProcessSegment_CyclicReference(t *testing.T) {
+	// Verify that cyclic references (A→B, B→A) don't cause infinite loops.
+	// The recursion limit and the "no change" check should prevent this.
+	processor := mustNewPathProcessor(t)
+
+	vars := map[string]any{
+		"a": "{{ vars.b }}",
+		"b": "{{ vars.a }}",
+	}
+
+	result, err := processor.ProcessPath("{{ vars.a }}", vars)
+	require.NoError(t, err)
+	// Cyclic references should terminate without panic or infinite loop.
+	// The exact result is implementation-dependent but should be deterministic.
+	assert.NotEmpty(t, result, "cyclic reference should produce some output")
+	t.Logf("Cyclic reference test result: %q", result)
+}
+
+func TestUT_ProcessSegment_TemplateSyntaxInValue_NotPath(t *testing.T) {
+	// SSTI REGRESSION: Even when the template syntax in a variable value
+	// attempts to access something potentially dangerous, it still renders.
+	processor := mustNewPathProcessor(t)
+
+	vars := map[string]any{
+		"safe_name": "hello",
+		// Attacker tries to reference another variable through injection
+		"malicious": "{{ vars.safe_name }}_injected",
+	}
+
+	result, err := processor.ProcessPath("{{ vars.malicious }}", vars)
+	require.NoError(t, err)
+	// Current behavior: the template in malicious is rendered
+	assert.Equal(t, "hello_injected", result,
+		"SSTI: template expressions in variable values are currently rendered")
+}

--- a/internal/scaffold/prompt_test.go
+++ b/internal/scaffold/prompt_test.go
@@ -1,0 +1,174 @@
+package scaffold
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- NoopPrompter ---
+
+func TestUT_NoopPrompter_Input(t *testing.T) {
+	p := NewNoopPrompter()
+
+	tests := []struct {
+		name         string
+		label        string
+		defaultValue string
+		secret       bool
+	}{
+		{"returns default", "Name", "default_val", false},
+		{"empty default", "Name", "", false},
+		{"secret flag ignored", "Password", "secret123", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := p.Input(tt.label, tt.defaultValue, tt.secret)
+			require.NoError(t, err)
+			assert.Equal(t, tt.defaultValue, result)
+		})
+	}
+}
+
+func TestUT_NoopPrompter_Select(t *testing.T) {
+	p := NewNoopPrompter()
+
+	tests := []struct {
+		name         string
+		options      []string
+		defaultIndex int
+		expected     string
+		expectErr    bool
+	}{
+		{
+			name:         "returns option at default index",
+			options:      []string{"a", "b", "c"},
+			defaultIndex: 1,
+			expected:     "b",
+		},
+		{
+			name:         "returns first option for index 0",
+			options:      []string{"first", "second"},
+			defaultIndex: 0,
+			expected:     "first",
+		},
+		{
+			name:         "negative index falls back to first",
+			options:      []string{"a", "b"},
+			defaultIndex: -1,
+			expected:     "a",
+		},
+		{
+			name:         "out of range index falls back to first",
+			options:      []string{"a", "b"},
+			defaultIndex: 99,
+			expected:     "a",
+		},
+		{
+			name:         "empty options returns error",
+			options:      []string{},
+			defaultIndex: 0,
+			expectErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := p.Select("Choose", tt.options, tt.defaultIndex)
+			if tt.expectErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestUT_NoopPrompter_Confirm(t *testing.T) {
+	p := NewNoopPrompter()
+
+	tests := []struct {
+		name         string
+		defaultValue bool
+	}{
+		{"returns true default", true},
+		{"returns false default", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := p.Confirm("Continue?", tt.defaultValue)
+			require.NoError(t, err)
+			assert.Equal(t, tt.defaultValue, result)
+		})
+	}
+}
+
+func TestUT_NoopPrompter_Number(t *testing.T) {
+	p := NewNoopPrompter()
+
+	tests := []struct {
+		name         string
+		defaultValue float64
+	}{
+		{"zero", 0},
+		{"positive integer", 42},
+		{"positive float", 3.14},
+		{"negative integer", -10},
+		{"negative float", -2.5},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := p.Number("Value", tt.defaultValue)
+			require.NoError(t, err)
+			assert.Equal(t, tt.defaultValue, result)
+		})
+	}
+}
+
+// --- formatNumber ---
+
+func TestUT_FormatNumber(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    float64
+		expected string
+	}{
+		{"zero", 0, "0"},
+		{"positive integer", 42, "42"},
+		{"negative integer", -42, "-42"},
+		{"positive float", 3.14, "3.14"},
+		{"negative float", -3.14, "-3.14"},
+		{"integer-like float", 100.0, "100"},
+		{"large integer", 1000000, "1000000"},
+		{"small float", 0.001, "0.001"},
+		{"half", 0.5, "0.5"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := formatNumber(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// --- GetPrompter ---
+
+func TestUT_GetPrompter_NoInput(t *testing.T) {
+	// When noInput=true, should always return NoopPrompter
+	p := GetPrompter(true)
+	_, ok := p.(*NoopPrompter)
+	assert.True(t, ok, "GetPrompter(true) should return *NoopPrompter")
+}
+
+// --- Prompter interface compliance ---
+
+func TestUT_NoopPrompter_ImplementsPrompter(t *testing.T) {
+	var _ Prompter = (*NoopPrompter)(nil)
+	var _ Prompter = (*InteractivePrompter)(nil)
+}


### PR DESCRIPTION
## Summary
- Add comprehensive tests for `scaffold/output.go` achieving 88% coverage (security-critical path traversal prevention, file mode sanitization, template rendering, symlink skipping)
- Add SSTI regression tests documenting recursive rendering vulnerability in `scaffold/processor.go` with recursion limit and cyclic reference safety tests
- Add tests for `scaffold/prompt.go` covering NoopPrompter, formatNumber, and GetPrompter

Closes #64, closes #65, closes #66
Part of Epic #63 (Consolidated Refactoring Plan — Phase 0: Test Harness)

## Test plan
- [x] All new tests pass (`go test ./internal/scaffold/... -count=1`)
- [x] Full test suite passes (`go test ./... -count=1`)
- [x] `go vet ./...` clean
- [x] output.go coverage > 80% (achieved 88.1%)
- [x] SSTI regression tests document current vulnerable behavior
- [x] Reviewed by Codex (gpt-5.2) and Gemini (2.5-pro) — no issues found

🤖 Generated with [Claude Code](https://claude.com/claude-code)