### PR TITLE
fix: update newGeneratorTemplate to Gonja syntax and fix typos (#68, #69)

### DIFF
--- a/internal/commands/new.go
+++ b/internal/commands/new.go
@@ -75,7 +75,7 @@ func newAction(c *cli.Context, cfg *config.Config) error {
 }
 
 var newGeneratorTemplate = `---
-to: %s/{{ .Name | caseSnake }}.go
+to: %s/{{ name | snake }}.go
 ---
 package %s
 

--- a/internal/commands/new_test.go
+++ b/internal/commands/new_test.go
@@ -152,8 +152,8 @@ func TestUT_NewAction_TemplateContent(t *testing.T) {
 	// Verify template has package declaration
 	assert.Contains(t, content, "package testpkg")
 
-	// Verify template uses .Name template variable
-	assert.Contains(t, content, "{{ .Name")
+	// Verify template uses Gonja name variable with snake filter
+	assert.Contains(t, content, "{{ name | snake }}")
 }
 
 func TestUT_NewCommand_ReturnsValidCommand(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,8 +30,7 @@ type Hooks struct {
 
 // CheckConfig validates that a config exists and returns an error if not.
 func CheckConfig(cfg *Config) error {
-	var emptyConfig *Config
-	if cfg == emptyConfig {
+	if cfg == nil {
 		return app.Errorf("please run the 'init' command first or run this command from where the '%s' file is located", File)
 	}
 	return nil

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -58,7 +58,7 @@ func (c *Core) Generate(data Data) error {
 		switch item.Action {
 		case parser.ActionAppend:
 			if err := c.fwr.AppendFile(item.To, item.Output); err != nil {
-				slog.Error("cannot appending to file", "file", item.To, "error", err)
+				slog.Error("cannot append to file", "file", item.To, "error", err)
 				return err
 			}
 			action = chalk.Yellow("modified")

--- a/internal/writer/writer.go
+++ b/internal/writer/writer.go
@@ -114,12 +114,12 @@ func (w *Write) InjectIntoFile(name string, data []byte, inject Inject) error {
 		slog.Error("cannot inject data", "file", name, "error", err)
 		return err
 	}
-	formatedOutput, err := mergeInjection(source, data, inject)
+	formattedOutput, err := mergeInjection(source, data, inject)
 	if err != nil {
 		slog.Error("cannot inject via matcher", "error", err, "file", name, "matcher", inject.Matcher, "clause", inject.Clause)
 		return err
 	}
-	if err := w.fs.WriteFile(name, formatedOutput, FileModeDefault); err != nil {
+	if err := w.fs.WriteFile(name, formattedOutput, FileModeDefault); err != nil {
 		slog.Error("cannot write to file", "file", name, "error", err)
 		return err
 	}


### PR DESCRIPTION
## Summary
- **#68**: Fix `newGeneratorTemplate` in `commands/new.go` — replaces stale v1 Go template syntax (`{{ .Name | caseSnake }}`) with correct Gonja syntax (`{{ name | snake }}`). This was a functional bug: `tag new` produced generators incompatible with the current engine.
- **#69**: Fix `formatedOutput` → `formattedOutput` typo in `writer.go`, fix `"cannot appending to file"` → `"cannot append to file"` grammar in `engine.go`, and simplify `CheckConfig` nil comparison to idiomatic `if cfg == nil` in `config.go`.

Closes #68
Closes #69

## Changes
| File | Change |
|---|---|
| `internal/commands/new.go` | `{{ .Name \| caseSnake }}` → `{{ name \| snake }}` |
| `internal/commands/new_test.go` | Updated test assertion to match new Gonja syntax |
| `internal/writer/writer.go` | `formatedOutput` → `formattedOutput` (2 occurrences) |
| `internal/engine/engine.go` | `"cannot appending to file"` → `"cannot append to file"` |
| `internal/config/config.go` | Simplified nil check: removed `var emptyConfig *Config` intermediary |

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [x] `go vet ./...` clean
- [x] `make lint` clean
- [x] Updated `TestUT_NewAction_TemplateContent` assertion to validate new Gonja syntax
- [x] Code reviewed by Codex — no issues found

🤖 Generated with [Claude Code](https://claude.com/claude-code)