### PR TITLE
fix: Phase 2 security-critical fixes (#70, #71, #72, #74)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **BREAKING**: Template syntax (`{{ }}`, `{% %}`, `{# #}`) in user-provided variable values is no longer rendered during path processing. This prevents Server-Side Template Injection (SSTI) attacks. Derived variables (whose defaults are template expressions) are still resolved. Use `--allow-recursive-render` to restore the previous behavior if your templates rely on recursive rendering of user input.
+
+### Added
+
+- `--allow-recursive-render` flag for `tag scaffold` to opt in to the previous recursive rendering behavior
+- Unified path containment validation via `fileutil.ValidatePathContainment` with symlink resolution
+- Symlink detection in template file loading (`LoadTemplateFiles`)
+- HTTPS enforcement for remote ZIP template URLs (HTTP rejected)
+- TOCTOU-safe file operations in scaffold output writer (fd-based symlink verification)
+
+### Security
+
+- Fix SSTI vulnerability in path processor recursive rendering (#71)
+- Fix TOCTOU race condition in symlink check during scaffolding (#72)
+- Add symlink detection in template loader (#74)
+- Reject insecure HTTP URLs for ZIP template downloads (#74)
+- Consolidate path traversal validation with symlink resolution (#70)
+
 ## [2.0.0] - 2026-02-05
 
 ### Added

--- a/internal/commands/scaffold.go
+++ b/internal/commands/scaffold.go
@@ -104,6 +104,10 @@ Examples:
 				Name:  "accept-hooks",
 				Usage: "Accept and run pre/post scaffold hooks without prompting for confirmation",
 			},
+			&cli.BoolFlag{
+				Name:  "allow-recursive-render",
+				Usage: "Allow template syntax in variable values to be rendered (SECURITY: enables recursive template rendering)",
+			},
 		},
 		Action: scaffoldAction,
 	}
@@ -143,18 +147,19 @@ func scaffoldAction(c *cli.Context) error {
 
 	// Build options
 	opts := scaffold.Options{
-		TemplateDir: templateDir,
-		OutputDir:   c.String("output"),
-		ProjectName: projectName,
-		ValuesFile:  c.String("values"),
-		Meta:        meta,
-		NoInput:     c.Bool("no-input"),
-		Force:       c.Bool("force"),
-		Replay:      c.Bool("replay"),
-		NoSave:      c.Bool("no-save"),
-		TemplateRef: templateRef, // Pass original reference for replay ID generation
-		AcceptHooks: c.Bool("accept-hooks"),
-		IsRemote:    isRemote,
+		TemplateDir:          templateDir,
+		OutputDir:            c.String("output"),
+		ProjectName:          projectName,
+		ValuesFile:           c.String("values"),
+		Meta:                 meta,
+		NoInput:              c.Bool("no-input"),
+		Force:                c.Bool("force"),
+		Replay:               c.Bool("replay"),
+		NoSave:               c.Bool("no-save"),
+		TemplateRef:          templateRef, // Pass original reference for replay ID generation
+		AcceptHooks:          c.Bool("accept-hooks"),
+		IsRemote:             isRemote,
+		AllowRecursiveRender: c.Bool("allow-recursive-render"),
 	}
 
 	// Create and run scaffold

--- a/internal/commands/validate.go
+++ b/internal/commands/validate.go
@@ -2,8 +2,9 @@ package commands
 
 import (
 	"fmt"
-	"path/filepath"
 	"strings"
+
+	"github.com/kaikenlabs/tag/internal/fileutil"
 )
 
 // ValidateNameSafe checks that a CLI-provided name is safe to use as a path segment.
@@ -30,24 +31,5 @@ func ValidateNameSafe(name string) error {
 
 // ValidatePathContainment checks that the resolved path stays within the base directory.
 func ValidatePathContainment(basePath, fullPath string) error {
-	absBase, err := filepath.Abs(basePath)
-	if err != nil {
-		return fmt.Errorf("failed to resolve base path: %w", err)
-	}
-
-	absFull, err := filepath.Abs(fullPath)
-	if err != nil {
-		return fmt.Errorf("failed to resolve path: %w", err)
-	}
-
-	rel, err := filepath.Rel(absBase, absFull)
-	if err != nil {
-		return fmt.Errorf("failed to compute relative path: %w", err)
-	}
-
-	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-		return fmt.Errorf("path %q escapes base directory %q", fullPath, basePath)
-	}
-
-	return nil
+	return fileutil.ValidatePathContainment(basePath, fullPath)
 }

--- a/internal/fileutil/path_containment.go
+++ b/internal/fileutil/path_containment.go
@@ -1,0 +1,96 @@
+package fileutil
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ValidatePathContainment checks that fullPath is contained within basePath.
+// Both paths are resolved through filepath.EvalSymlinks (with fallback for
+// non-existent targets) and made absolute before comparison. This prevents
+// path traversal attacks including those using symlinks.
+func ValidatePathContainment(basePath, fullPath string) error {
+	absBase, err := resolveForContainment(basePath)
+	if err != nil {
+		return fmt.Errorf("failed to resolve base path: %w", err)
+	}
+
+	absTarget, err := resolveForContainment(fullPath)
+	if err != nil {
+		return fmt.Errorf("failed to resolve path: %w", err)
+	}
+
+	// Check if target is within base directory (or equals it)
+	if absTarget != absBase && !strings.HasPrefix(absTarget, absBase+string(filepath.Separator)) {
+		return fmt.Errorf("path %q escapes base directory %q", fullPath, basePath)
+	}
+
+	return nil
+}
+
+// resolveForContainment resolves a path for containment checking.
+// It attempts filepath.EvalSymlinks; if the path doesn't exist, it walks up
+// the directory tree to find the nearest existing ancestor, resolves that
+// through EvalSymlinks, and appends the remaining path segments. This handles
+// systems where temp directories involve symlinks (e.g., macOS /var -> /private/var).
+func resolveForContainment(path string) (string, error) {
+	cleaned := filepath.Clean(path)
+
+	// Try full resolution first
+	resolved, err := filepath.EvalSymlinks(cleaned)
+	if err == nil {
+		return filepath.Abs(resolved)
+	}
+
+	// If path doesn't exist, walk up to find existing ancestor
+	if os.IsNotExist(err) {
+		return resolveNonExistent(cleaned)
+	}
+
+	return "", fmt.Errorf("failed to evaluate symlinks for %q: %w", path, err)
+}
+
+// resolveNonExistent resolves a non-existent path by walking up the directory
+// tree to find the nearest existing ancestor, resolving it through EvalSymlinks,
+// and appending the remaining segments.
+func resolveNonExistent(cleaned string) (string, error) {
+	// Collect non-existent segments from bottom up
+	current := cleaned
+	var segments []string
+
+	for {
+		_, err := os.Lstat(current)
+		if err == nil {
+			// Found existing ancestor; resolve it
+			resolved, evalErr := filepath.EvalSymlinks(current)
+			if evalErr != nil {
+				return filepath.Abs(cleaned)
+			}
+			absResolved, absErr := filepath.Abs(resolved)
+			if absErr != nil {
+				return filepath.Abs(cleaned)
+			}
+			// Append the collected non-existent segments
+			result := absResolved
+			for i := len(segments) - 1; i >= 0; i-- {
+				result = filepath.Join(result, segments[i])
+			}
+			return result, nil
+		}
+
+		if !os.IsNotExist(err) {
+			// Some other error (permission, etc.)
+			return filepath.Abs(cleaned)
+		}
+
+		parent := filepath.Dir(current)
+		if parent == current {
+			// Reached root without finding existing ancestor
+			return filepath.Abs(cleaned)
+		}
+		segments = append(segments, filepath.Base(current))
+		current = parent
+	}
+}

--- a/internal/fileutil/path_containment_test.go
+++ b/internal/fileutil/path_containment_test.go
@@ -1,0 +1,131 @@
+package fileutil
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUT_ValidatePathContainment_ValidPaths(t *testing.T) {
+	base := t.TempDir()
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{"simple file", filepath.Join(base, "file.txt")},
+		{"nested file", filepath.Join(base, "sub", "dir", "file.txt")},
+		{"dot in name", filepath.Join(base, ".hidden", "file.txt")},
+		{"cleaned relative", filepath.Join(base, "sub", "..", "sub", "file.txt")},
+		{"path equals base", base},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidatePathContainment(base, tt.path)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestUT_ValidatePathContainment_PathTraversal(t *testing.T) {
+	base := t.TempDir()
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{"parent traversal", filepath.Join(base, "..", "escape.txt")},
+		{"double parent traversal", filepath.Join(base, "..", "..", "escape.txt")},
+		{"absolute path outside", "/tmp/evil.txt"},
+		{"prefix collision", base + "X/file.txt"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidatePathContainment(base, tt.path)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "escapes base directory")
+		})
+	}
+}
+
+func TestUT_ValidatePathContainment_NonExistentPath(t *testing.T) {
+	base := t.TempDir()
+
+	t.Run("non-existent file within base", func(t *testing.T) {
+		err := ValidatePathContainment(base, filepath.Join(base, "does", "not", "exist.txt"))
+		assert.NoError(t, err)
+	})
+
+	t.Run("non-existent file outside base", func(t *testing.T) {
+		err := ValidatePathContainment(base, filepath.Join(base, "..", "outside.txt"))
+		assert.Error(t, err)
+	})
+}
+
+func TestUT_ValidatePathContainment_EmptyPath(t *testing.T) {
+	base := t.TempDir()
+	// Empty path resolves to cwd via filepath.Abs, which is outside base
+	err := ValidatePathContainment(base, "")
+	assert.Error(t, err)
+}
+
+func TestUT_ValidatePathContainment_SymlinkResolution(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink tests unreliable on Windows")
+	}
+
+	base := t.TempDir()
+	external := t.TempDir()
+
+	// Create a real file within base
+	realFile := filepath.Join(base, "real.txt")
+	require.NoError(t, os.WriteFile(realFile, []byte("real"), 0o644))
+
+	// Create a symlink within base pointing to external directory
+	symlinkPath := filepath.Join(base, "escape_link")
+	require.NoError(t, os.Symlink(external, symlinkPath))
+
+	t.Run("symlink escaping base is rejected", func(t *testing.T) {
+		err := ValidatePathContainment(base, filepath.Join(symlinkPath, "file.txt"))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "escapes base directory")
+	})
+
+	// Create a symlink within base pointing to another location within base
+	subDir := filepath.Join(base, "subdir")
+	require.NoError(t, os.MkdirAll(subDir, 0o755))
+	internalLink := filepath.Join(base, "internal_link")
+	require.NoError(t, os.Symlink(subDir, internalLink))
+
+	t.Run("symlink within base is allowed", func(t *testing.T) {
+		err := ValidatePathContainment(base, filepath.Join(internalLink, "file.txt"))
+		assert.NoError(t, err)
+	})
+}
+
+func TestUT_ValidatePathContainment_BaseWithDotComponents(t *testing.T) {
+	base := t.TempDir()
+	subDir := filepath.Join(base, "a", "b")
+	require.NoError(t, os.MkdirAll(subDir, 0o755))
+
+	// Base with .. components that resolve to same directory
+	baseWithDots := filepath.Join(base, "a", "..", "a", "b")
+	target := filepath.Join(subDir, "file.txt")
+
+	err := ValidatePathContainment(baseWithDots, target)
+	assert.NoError(t, err)
+}
+
+func TestUT_ValidatePathContainment_TrailingSeparator(t *testing.T) {
+	base := t.TempDir()
+
+	// Base with trailing separator should work the same
+	err := ValidatePathContainment(base+string(filepath.Separator), filepath.Join(base, "file.txt"))
+	assert.NoError(t, err)
+}

--- a/internal/remote/zip.go
+++ b/internal/remote/zip.go
@@ -37,7 +37,16 @@ func (f *ZipFetcher) Fetch(ctx context.Context, ref *Reference) (string, error) 
 	}
 
 	// Determine if remote or local
-	isRemote := strings.HasPrefix(ref.URL, "http://") || strings.HasPrefix(ref.URL, "https://")
+	urlLower := strings.ToLower(ref.URL)
+	isRemote := strings.HasPrefix(urlLower, "http://") || strings.HasPrefix(urlLower, "https://")
+
+	// Security: reject insecure HTTP URLs for remote downloads
+	if strings.HasPrefix(urlLower, "http://") {
+		return "", &FetchError{
+			Ref:     ref,
+			Message: "insecure HTTP URL rejected; use HTTPS instead",
+		}
+	}
 
 	var zipPath string
 	var tmpZip bool

--- a/internal/remote/zip_test.go
+++ b/internal/remote/zip_test.go
@@ -316,6 +316,22 @@ func TestUT_ZipFetcher_SkipsHiddenAndMacOS(t *testing.T) {
 	assert.Equal(t, "template", filepath.Base(path))
 }
 
+func TestUT_ZipFetcher_RejectsHTTP(t *testing.T) {
+	fetcher := NewZipFetcher()
+
+	ref := &Reference{
+		Original: "http://example.com/template.zip",
+		Type:     ReferenceTypeZip,
+		Provider: ProviderGeneric,
+		URL:      "http://example.com/template.zip",
+	}
+
+	_, err := fetcher.Fetch(context.Background(), ref)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "insecure HTTP")
+	assert.Contains(t, err.Error(), "HTTPS")
+}
+
 func TestIT_ZipFetcher_RemoteDownload(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
@@ -333,14 +349,15 @@ func TestIT_ZipFetcher_RemoteDownload(t *testing.T) {
 	zipContent, err := os.ReadFile(zipPath)
 	require.NoError(t, err)
 
-	// Create test server
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	// Create HTTPS test server (HTTP is rejected by HTTPS enforcement)
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/zip")
 		_, _ = w.Write(zipContent)
 	}))
 	defer server.Close()
 
 	fetcher := NewZipFetcher()
+	fetcher.client = server.Client() // Trust test server's TLS certificate
 
 	ref := &Reference{
 		Original: server.URL + "/template.zip",
@@ -364,13 +381,14 @@ func TestIT_ZipFetcher_RemoteDownloadError(t *testing.T) {
 		t.Skip("skipping integration test in short mode")
 	}
 
-	// Create test server that returns 404
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	// Create HTTPS test server that returns 404
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 	}))
 	defer server.Close()
 
 	fetcher := NewZipFetcher()
+	fetcher.client = server.Client() // Trust test server's TLS certificate
 
 	ref := &Reference{
 		Original: server.URL + "/notfound.zip",

--- a/internal/scaffold/output.go
+++ b/internal/scaffold/output.go
@@ -3,6 +3,7 @@ package scaffold
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -32,6 +33,9 @@ func NewOutputWriter(engine template.TemplateRenderer, pathProcessor PathProcess
 		pathProcessor: pathProcessor,
 	}
 }
+
+// Ensure DefaultOutputWriter implements OutputWriter.
+var _ OutputWriter = (*DefaultOutputWriter)(nil)
 
 // Write processes the template directory and writes to the output directory.
 func (w *DefaultOutputWriter) Write(templateRoot, outputDir string, vars map[string]any) error {
@@ -114,23 +118,19 @@ func (w *DefaultOutputWriter) Write(templateRoot, outputDir string, vars map[str
 
 // processFile processes a single file from the template.
 // Text files are rendered through the template engine; binary files are copied as-is.
-func (w *DefaultOutputWriter) processFile(srcPath, destPath string, ctx template.Context, d fs.DirEntry) error {
+//
+// Uses fd-based operations to prevent TOCTOU race conditions: the file is opened
+// and verified via Lstat + f.Stat + os.SameFile before reading, ensuring that the
+// file hasn't been swapped for a symlink between the directory walk and the read.
+func (w *DefaultOutputWriter) processFile(srcPath, destPath string, ctx template.Context, _ fs.DirEntry) error {
 	// Ensure parent directory exists
 	if err := os.MkdirAll(filepath.Dir(destPath), types.DirMode); err != nil {
 		return fmt.Errorf("failed to create parent directory: %w", err)
 	}
 
-	// Get source file info for permissions
-	srcInfo, err := d.Info()
-	if err != nil {
-		return fmt.Errorf("failed to get file info: %w", err)
-	}
-
-	// Sanitize file mode to remove dangerous permission bits
-	mode := sanitizeFileMode(srcInfo.Mode())
-
-	// Read file content to determine if it's text or binary
-	content, err := os.ReadFile(srcPath)
+	// TOCTOU-safe file open: verify the file is regular (not a symlink) using
+	// fd-based checks rather than relying on the stale DirEntry from WalkDir.
+	content, mode, err := openAndReadRegularFile(srcPath)
 	if err != nil {
 		return fmt.Errorf("failed to read file %s: %w", srcPath, err)
 	}
@@ -141,6 +141,54 @@ func (w *DefaultOutputWriter) processFile(srcPath, destPath string, ctx template
 
 	// Copy binary file as-is
 	return os.WriteFile(destPath, content, mode)
+}
+
+// openAndReadRegularFile opens a file with TOCTOU-safe symlink verification.
+// It performs: Lstat → Open → f.Stat → os.SameFile verification → Read.
+// Returns the file content and sanitized file mode, or an error if the file
+// is a symlink or was swapped between check and open.
+func openAndReadRegularFile(path string) ([]byte, fs.FileMode, error) {
+	// Step 1: Lstat to check the path without following symlinks
+	lstatInfo, err := os.Lstat(path)
+	if err != nil {
+		return nil, 0, fmt.Errorf("lstat: %w", err)
+	}
+	if lstatInfo.Mode().Type()&os.ModeSymlink != 0 {
+		return nil, 0, fmt.Errorf("symlink detected: %s", path)
+	}
+	if !lstatInfo.Mode().IsRegular() {
+		return nil, 0, fmt.Errorf("not a regular file: %s", path)
+	}
+
+	// Step 2: Open the file to get a file descriptor
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, 0, fmt.Errorf("open: %w", err)
+	}
+	defer f.Close()
+
+	// Step 3: Stat the file descriptor (not the path)
+	fstatInfo, err := f.Stat()
+	if err != nil {
+		return nil, 0, fmt.Errorf("fstat: %w", err)
+	}
+
+	// Step 4: Verify the file descriptor matches what Lstat saw.
+	// If the file was swapped between Lstat and Open, these won't match.
+	if !os.SameFile(lstatInfo, fstatInfo) {
+		return nil, 0, fmt.Errorf("file changed between check and open (possible TOCTOU attack): %s", path)
+	}
+
+	// Step 5: Read from the verified file descriptor
+	content, err := io.ReadAll(f)
+	if err != nil {
+		return nil, 0, fmt.Errorf("read: %w", err)
+	}
+
+	// Sanitize file mode to remove dangerous permission bits
+	mode := sanitizeFileMode(fstatInfo.Mode())
+
+	return content, mode, nil
 }
 
 // processTemplate processes a text file through the template engine.
@@ -224,27 +272,7 @@ func copyDir(src, dst string) error {
 // validatePathWithinDir ensures that path is within the base directory.
 // This prevents path traversal attacks where placeholders could escape the output dir.
 func validatePathWithinDir(path, baseDir string) error {
-	// Clean both paths to resolve any . or .. components
-	cleanPath := filepath.Clean(path)
-	cleanBase := filepath.Clean(baseDir)
-
-	// Get absolute paths
-	absPath, err := filepath.Abs(cleanPath)
-	if err != nil {
-		return fmt.Errorf("failed to resolve absolute path: %w", err)
-	}
-	absBase, err := filepath.Abs(cleanBase)
-	if err != nil {
-		return fmt.Errorf("failed to resolve absolute base: %w", err)
-	}
-
-	// Check if path starts with base
-	// Add separator to avoid matching partial directory names (e.g., /foo vs /foobar)
-	if !strings.HasPrefix(absPath, absBase+string(filepath.Separator)) && absPath != absBase {
-		return fmt.Errorf("path %q escapes base directory %q", absPath, absBase)
-	}
-
-	return nil
+	return fileutil.ValidatePathContainment(baseDir, path)
 }
 
 // sanitizeFileMode removes dangerous permission bits (setuid, setgid, sticky).

--- a/internal/scaffold/output_test.go
+++ b/internal/scaffold/output_test.go
@@ -694,6 +694,59 @@ func TestUT_BuildTemplateContext(t *testing.T) {
 	assert.Equal(t, "test", rootName)
 }
 
+// --- openAndReadRegularFile (TOCTOU protection) ---
+
+func TestUT_OpenAndReadRegularFile_RegularFile(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "regular.txt")
+	require.NoError(t, os.WriteFile(filePath, []byte("hello world"), 0o644))
+
+	content, mode, err := openAndReadRegularFile(filePath)
+	require.NoError(t, err)
+	assert.Equal(t, "hello world", string(content))
+	assert.Equal(t, fs.FileMode(0o644), mode&0o777)
+}
+
+func TestUT_OpenAndReadRegularFile_Symlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink tests unreliable on Windows")
+	}
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.txt")
+	require.NoError(t, os.WriteFile(target, []byte("secret"), 0o644))
+
+	link := filepath.Join(dir, "link.txt")
+	require.NoError(t, os.Symlink(target, link))
+
+	_, _, err := openAndReadRegularFile(link)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "symlink detected")
+}
+
+func TestUT_OpenAndReadRegularFile_NonExistent(t *testing.T) {
+	_, _, err := openAndReadRegularFile("/nonexistent/path/file.txt")
+	require.Error(t, err)
+}
+
+func TestUT_OpenAndReadRegularFile_SanitizesMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("file mode tests not reliable on Windows")
+	}
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "setuid.sh")
+	require.NoError(t, os.WriteFile(filePath, []byte("#!/bin/sh"), 0o755))
+	require.NoError(t, os.Chmod(filePath, fs.ModeSetuid|0o755))
+
+	_, mode, err := openAndReadRegularFile(filePath)
+	require.NoError(t, err)
+	// Setuid should be stripped
+	assert.Equal(t, fs.FileMode(0), mode&fs.ModeSetuid)
+	// Execute should be preserved
+	assert.NotEqual(t, fs.FileMode(0), mode&0o111)
+}
+
 // --- test helpers ---
 
 // testDirEntry wraps os.FileInfo to implement fs.DirEntry for tests.

--- a/internal/scaffold/processor.go
+++ b/internal/scaffold/processor.go
@@ -17,12 +17,28 @@ type PathProcessor interface {
 
 // DefaultPathProcessor implements PathProcessor using the Gonja template engine.
 type DefaultPathProcessor struct {
-	engine template.TemplateRenderer
+	engine               template.TemplateRenderer
+	allowRecursiveRender bool
+	derivedVarNames      map[string]bool // Variables whose defaults are template expressions
 }
 
 // NewPathProcessor creates a new path processor with the given template renderer.
 func NewPathProcessor(engine template.TemplateRenderer) *DefaultPathProcessor {
 	return &DefaultPathProcessor{engine: engine}
+}
+
+// SetAllowRecursiveRender controls whether user-provided variable values containing
+// template syntax are rendered. When false (default), template delimiters in
+// non-derived variable values are escaped to prevent SSTI attacks. Derived variables
+// (whose defaults are template expressions) are always rendered regardless.
+func (p *DefaultPathProcessor) SetAllowRecursiveRender(allow bool) {
+	p.allowRecursiveRender = allow
+}
+
+// SetDerivedVarNames sets the list of derived variable names. These variables
+// have template expressions as defaults and need recursive rendering to resolve.
+func (p *DefaultPathProcessor) SetDerivedVarNames(names map[string]bool) {
+	p.derivedVarNames = names
 }
 
 // placeholderDetectRegex detects if a string contains Jinja2-style template syntax.
@@ -70,16 +86,26 @@ const maxRenderIterations = 5
 // processSegment processes Jinja2 expressions in a single path segment.
 // Handles nested templates (when a variable's value contains another template expression)
 // by re-rendering until no more placeholders remain.
+//
+// When allowRecursiveRender is false, template delimiters in non-derived variable
+// values are escaped to prevent Server-Side Template Injection (SSTI).
 func (p *DefaultPathProcessor) processSegment(segment string, vars map[string]any) (string, error) {
 	// Quick check: if no {{ }} present, return as-is
 	if !placeholderDetectRegex.MatchString(segment) {
 		return segment, nil
 	}
 
+	// Build safe vars: escape template syntax in non-derived variable values
+	// when recursive render is disabled (default)
+	safeVars := vars
+	if !p.allowRecursiveRender {
+		safeVars = p.escapeNonDerivedVars(vars)
+	}
+
 	// Build context with both "vars" and "cookiecutter" namespaces
 	ctx := template.Context{
-		"vars":         vars,
-		"cookiecutter": vars, // Alias for compatibility
+		"vars":         safeVars,
+		"cookiecutter": safeVars, // Alias for compatibility
 	}
 
 	result := segment
@@ -104,6 +130,52 @@ func (p *DefaultPathProcessor) processSegment(segment string, vars map[string]an
 	}
 
 	return result, nil
+}
+
+// escapeNonDerivedVars returns a copy of vars where template delimiters in
+// non-derived string values are escaped with sentinel tokens. This prevents
+// user-provided values containing {{ }}, {% %}, or {# #} from being
+// interpreted as template code during rendering.
+func (p *DefaultPathProcessor) escapeNonDerivedVars(vars map[string]any) map[string]any {
+	safe := make(map[string]any, len(vars))
+	for k, v := range vars {
+		if p.derivedVarNames[k] {
+			// Derived variables retain their template expressions
+			safe[k] = v
+			continue
+		}
+		if s, ok := v.(string); ok {
+			safe[k] = escapeTemplateSyntax(s)
+		} else {
+			safe[k] = v
+		}
+	}
+	return safe
+}
+
+// Sentinel tokens used to escape template delimiters in user-provided values.
+const (
+	sentinelOpenExpr     = "\x00TAG_LBRACE2\x00"
+	sentinelCloseExpr    = "\x00TAG_RBRACE2\x00"
+	sentinelOpenStmt     = "\x00TAG_LBRACE_PCT\x00"
+	sentinelCloseStmt    = "\x00TAG_PCT_RBRACE\x00"
+	sentinelOpenComment  = "\x00TAG_LBRACE_HASH\x00"
+	sentinelCloseComment = "\x00TAG_HASH_RBRACE\x00"
+)
+
+// escapeTemplateSyntax replaces Jinja2 template delimiters in a string with
+// sentinel tokens that won't be interpreted by the template engine.
+func escapeTemplateSyntax(s string) string {
+	if !strings.Contains(s, "{{") && !strings.Contains(s, "{%") && !strings.Contains(s, "{#") {
+		return s
+	}
+	s = strings.ReplaceAll(s, "{{", sentinelOpenExpr)
+	s = strings.ReplaceAll(s, "}}", sentinelCloseExpr)
+	s = strings.ReplaceAll(s, "{%", sentinelOpenStmt)
+	s = strings.ReplaceAll(s, "%}", sentinelCloseStmt)
+	s = strings.ReplaceAll(s, "{#", sentinelOpenComment)
+	s = strings.ReplaceAll(s, "#}", sentinelCloseComment)
+	return s
 }
 
 // simpleVarRegex extracts simple variable names from {{ vars.name }} or {{ cookiecutter.name }} patterns.

--- a/internal/scaffold/processor_test.go
+++ b/internal/scaffold/processor_test.go
@@ -414,8 +414,10 @@ func TestUT_PathProcessor_ConditionalFilename(t *testing.T) {
 }
 
 func TestUT_PathProcessor_NestedTemplates(t *testing.T) {
-	// Test derived variables where a variable's value is itself a template expression
+	// Test derived variables where a variable's value is itself a template expression.
+	// These must be marked as derived for the SSTI protection to allow rendering.
 	processor := mustNewPathProcessor(t)
+	processor.SetDerivedVarNames(map[string]bool{"package_name": true})
 	vars := map[string]any{
 		"package_display_name": "My Cool Package",
 		// package_name's value is a template expression (like Cookiecutter derived variables)
@@ -504,22 +506,18 @@ func TestUT_PathProcessor_MockExecutorError(t *testing.T) {
 }
 
 // ============================================================================
-// SSTI REGRESSION TESTS (Ticket #65)
+// SSTI PROTECTION TESTS (Ticket #65, #71)
 //
-// These tests document the current behavior of recursive template rendering
-// in processSegment. The recursive rendering (up to 5 iterations) means that
-// user-controlled variable values containing template syntax will be executed.
+// These tests verify that user-provided variable values containing template
+// syntax are NOT interpreted as template code (SSTI prevention). Derived
+// variables (whose defaults are template expressions) are still rendered.
 //
-// This is a Server-Side Template Injection (SSTI) vulnerability.
-// When the S1 fix is applied (Phase 2.3), these tests should be updated:
-// - Tests marked "current behavior" should change expected results to show
-//   that user-provided template syntax is NO LONGER rendered.
+// Use --allow-recursive-render to restore the old (insecure) behavior.
 // ============================================================================
 
-func TestUT_ProcessSegment_RecursiveRendering_CurrentBehavior(t *testing.T) {
-	// SSTI REGRESSION: This test demonstrates that user-provided variable values
-	// containing template syntax are rendered by the recursive processSegment loop.
-	// After S1 fix: user-provided {{ }} in values should NOT be rendered.
+func TestUT_ProcessSegment_UserInput_NoRecursiveRender(t *testing.T) {
+	// SSTI FIX: User-provided variable values containing template syntax
+	// are NOT rendered when allowRecursiveRender is false (default).
 	processor := mustNewPathProcessor(t)
 
 	vars := map[string]any{
@@ -528,18 +526,16 @@ func TestUT_ProcessSegment_RecursiveRendering_CurrentBehavior(t *testing.T) {
 		"user_input": "{{ vars.project_name }}",
 	}
 
-	// Current behavior: the template in user_input is rendered, yielding "myproject"
+	// With SSTI protection: user_input's template syntax is escaped
 	result, err := processor.ProcessPath("{{ vars.user_input }}", vars)
 	require.NoError(t, err)
-	// SSTI: user_input's value "{{ vars.project_name }}" is rendered to "myproject"
-	assert.Equal(t, "myproject", result,
-		"SSTI: recursive rendering resolves template syntax in user-provided values")
+	// The template syntax in user_input should NOT be rendered
+	assert.NotEqual(t, "myproject", result,
+		"SSTI protection: user-provided template syntax should not be rendered")
 }
 
-func TestUT_ProcessSegment_NestedSSTI_CurrentBehavior(t *testing.T) {
-	// SSTI REGRESSION: Multi-level nested template injection.
-	// Variable A references Variable B's template expression, which in turn
-	// references Variable C's plain value.
+func TestUT_ProcessSegment_UserInput_NestedTemplates_NoRender(t *testing.T) {
+	// SSTI FIX: Multi-level nested template injection should NOT resolve.
 	processor := mustNewPathProcessor(t)
 
 	vars := map[string]any{
@@ -548,18 +544,68 @@ func TestUT_ProcessSegment_NestedSSTI_CurrentBehavior(t *testing.T) {
 		"level_a": "{{ vars.level_b }}",
 	}
 
-	// Current behavior: recursive rendering resolves through all levels
 	result, err := processor.ProcessPath("{{ vars.level_a }}", vars)
 	require.NoError(t, err)
-	// level_a → "{{ vars.level_b }}" → "{{ vars.level_c }}" → "final_value"
-	assert.Equal(t, "final_value", result,
-		"SSTI: multi-level recursive rendering resolves nested template expressions")
+	// Should NOT resolve through the chain
+	assert.NotEqual(t, "final_value", result,
+		"SSTI protection: nested template injection should not resolve")
+}
+
+func TestUT_ProcessSegment_AllowRecursiveRender_UserInput(t *testing.T) {
+	// When allowRecursiveRender is true, old (insecure) behavior is restored.
+	processor := mustNewPathProcessor(t)
+	processor.SetAllowRecursiveRender(true)
+
+	vars := map[string]any{
+		"project_name": "myproject",
+		"user_input":   "{{ vars.project_name }}",
+	}
+
+	result, err := processor.ProcessPath("{{ vars.user_input }}", vars)
+	require.NoError(t, err)
+	assert.Equal(t, "myproject", result,
+		"with --allow-recursive-render, template syntax in values IS rendered")
+}
+
+func TestUT_ProcessSegment_DerivedVariables_Render(t *testing.T) {
+	// Derived variables (template expressions as defaults) should still resolve
+	// even when allowRecursiveRender is false, because they are marked as derived.
+	processor := mustNewPathProcessor(t)
+	processor.SetDerivedVarNames(map[string]bool{"package_name": true})
+
+	vars := map[string]any{
+		"package_display_name": "My Cool Package",
+		"package_name":         "{{ vars.package_display_name.lower().replace(' ', '_').replace('-', '_') }}",
+	}
+
+	result, err := processor.ProcessPath("{{ vars.package_name }}", vars)
+	require.NoError(t, err)
+	assert.Equal(t, "my_cool_package", result,
+		"derived variables should still be rendered through recursive rendering")
+}
+
+func TestUT_ProcessSegment_DerivedVariables_Nested_Render(t *testing.T) {
+	// Derived variables that reference other derived variables should resolve.
+	processor := mustNewPathProcessor(t)
+	processor.SetDerivedVarNames(map[string]bool{"derived_a": true, "derived_b": true})
+
+	vars := map[string]any{
+		"base_name": "MyProject",
+		"derived_b": "{{ vars.base_name | lower }}",
+		"derived_a": "{{ vars.derived_b }}",
+	}
+
+	result, err := processor.ProcessPath("{{ vars.derived_a }}", vars)
+	require.NoError(t, err)
+	assert.Equal(t, "myproject", result,
+		"nested derived variables should resolve through recursive rendering")
 }
 
 func TestUT_ProcessSegment_RecursionLimit(t *testing.T) {
-	// Verify the recursion limit (maxRenderIterations = 5) prevents infinite loops.
-	// Create a chain of variables that would require more than 5 iterations to fully resolve.
+	// Verify the recursion limit (maxRenderIterations = 5) prevents infinite loops
+	// when allowRecursiveRender is true.
 	processor := mustNewPathProcessor(t)
+	processor.SetAllowRecursiveRender(true)
 
 	// Build a chain: v1 → v2 → v3 → v4 → v5 → v6 → "done"
 	// With 5 iterations max, the chain should stop before fully resolving.
@@ -575,14 +621,6 @@ func TestUT_ProcessSegment_RecursionLimit(t *testing.T) {
 	result, err := processor.ProcessPath("{{ vars.v1 }}", vars)
 	require.NoError(t, err)
 
-	// The chain requires 6 renders to fully resolve (v1→v2→v3→v4→v5→v6→done).
-	// With maxRenderIterations=5, we start with "{{ vars.v1 }}" and get 5 render passes:
-	// Pass 1: "{{ vars.v1 }}" → "{{ vars.v2 }}"
-	// Pass 2: "{{ vars.v2 }}" → "{{ vars.v3 }}"
-	// Pass 3: "{{ vars.v3 }}" → "{{ vars.v4 }}"
-	// Pass 4: "{{ vars.v4 }}" → "{{ vars.v5 }}"
-	// Pass 5: "{{ vars.v5 }}" → "{{ vars.v6 }}"
-	// Loop ends (5 iterations used). Result still contains template syntax.
 	assert.NotEqual(t, "done", result,
 		"recursion limit should prevent full resolution of a 6-level chain")
 	assert.Contains(t, result, "v6",
@@ -603,9 +641,10 @@ func TestUT_ProcessSegment_RecursionLimit(t *testing.T) {
 }
 
 func TestUT_ProcessSegment_CyclicReference(t *testing.T) {
-	// Verify that cyclic references (A→B, B→A) don't cause infinite loops.
-	// The recursion limit and the "no change" check should prevent this.
+	// Verify that cyclic references (A→B, B→A) don't cause infinite loops
+	// when allowRecursiveRender is true.
 	processor := mustNewPathProcessor(t)
+	processor.SetAllowRecursiveRender(true)
 
 	vars := map[string]any{
 		"a": "{{ vars.b }}",
@@ -615,14 +654,12 @@ func TestUT_ProcessSegment_CyclicReference(t *testing.T) {
 	result, err := processor.ProcessPath("{{ vars.a }}", vars)
 	require.NoError(t, err)
 	// Cyclic references should terminate without panic or infinite loop.
-	// The exact result is implementation-dependent but should be deterministic.
 	assert.NotEmpty(t, result, "cyclic reference should produce some output")
 	t.Logf("Cyclic reference test result: %q", result)
 }
 
-func TestUT_ProcessSegment_TemplateSyntaxInValue_NotPath(t *testing.T) {
-	// SSTI REGRESSION: Even when the template syntax in a variable value
-	// attempts to access something potentially dangerous, it still renders.
+func TestUT_ProcessSegment_MaliciousValue_Escaped(t *testing.T) {
+	// SSTI FIX: Template syntax in non-derived variable values is escaped.
 	processor := mustNewPathProcessor(t)
 
 	vars := map[string]any{
@@ -633,7 +670,20 @@ func TestUT_ProcessSegment_TemplateSyntaxInValue_NotPath(t *testing.T) {
 
 	result, err := processor.ProcessPath("{{ vars.malicious }}", vars)
 	require.NoError(t, err)
-	// Current behavior: the template in malicious is rendered
-	assert.Equal(t, "hello_injected", result,
-		"SSTI: template expressions in variable values are currently rendered")
+	// Template expressions in malicious should NOT be rendered
+	assert.NotEqual(t, "hello_injected", result,
+		"SSTI protection: template expressions in variable values should not be rendered")
+}
+
+func TestUT_ProcessSegment_InvalidTemplateSyntax_InValue(t *testing.T) {
+	// Values with malformed template syntax (e.g., {{{ or { { ) should remain literal.
+	processor := mustNewPathProcessor(t)
+
+	vars := map[string]any{
+		"weird": "{{{ not valid template",
+	}
+
+	result, err := processor.ProcessPath("{{ vars.weird }}", vars)
+	require.NoError(t, err)
+	assert.NotEmpty(t, result, "malformed template syntax should not cause errors")
 }

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -49,6 +49,7 @@ func NewScaffold(opts Options) (*Scaffold, error) {
 	// Create other components
 	collector := NewVariableCollector(prompter)
 	processor := NewPathProcessor(engine)
+	processor.SetAllowRecursiveRender(opts.AllowRecursiveRender)
 	writer := NewOutputWriter(engine, processor)
 
 	return &Scaffold{
@@ -74,6 +75,19 @@ func (s *Scaffold) Run(opts Options) error {
 	config, err := s.loadAndValidateConfig(opts.TemplateDir)
 	if err != nil {
 		return err
+	}
+
+	// Step 2b: Set derived variable names on the processor for SSTI protection.
+	// Derived variables have template expressions as defaults and need recursive
+	// rendering to resolve. Non-derived variables are escaped to prevent SSTI.
+	if processor, ok := s.Processor.(*DefaultPathProcessor); ok {
+		derivedNames := make(map[string]bool)
+		for name, def := range config.Vars {
+			if def.IsDerived() || def.IsPrivate(name) {
+				derivedNames[name] = true
+			}
+		}
+		processor.SetDerivedVarNames(derivedNames)
 	}
 
 	// Step 3: Collect variables

--- a/internal/scaffold/types.go
+++ b/internal/scaffold/types.go
@@ -208,18 +208,19 @@ func (v VariableDef) GetPrompt(name string) string {
 
 // Options represents scaffold command options.
 type Options struct {
-	TemplateDir string            // Path to template directory
-	OutputDir   string            // Output directory (-o flag)
-	ProjectName string            // Project name argument
-	ValuesFile  string            // Path to values JSON file (--values flag)
-	Meta        map[string]string // Individual variable overrides (-m/--meta flags)
-	NoInput     bool              // Skip interactive prompts (--no-input flag)
-	Force       bool              // Overwrite existing output (--force flag)
-	Replay      bool              // Use saved replay values (--replay flag)
-	NoSave      bool              // Don't save inputs for replay (--no-save flag)
-	TemplateRef string            // Original template reference (for replay ID generation)
-	AcceptHooks bool              // Accept hooks without prompting (--accept-hooks flag)
-	IsRemote    bool              // Whether the template source is remote
+	TemplateDir          string            // Path to template directory
+	OutputDir            string            // Output directory (-o flag)
+	ProjectName          string            // Project name argument
+	ValuesFile           string            // Path to values JSON file (--values flag)
+	Meta                 map[string]string // Individual variable overrides (-m/--meta flags)
+	NoInput              bool              // Skip interactive prompts (--no-input flag)
+	Force                bool              // Overwrite existing output (--force flag)
+	Replay               bool              // Use saved replay values (--replay flag)
+	NoSave               bool              // Don't save inputs for replay (--no-save flag)
+	TemplateRef          string            // Original template reference (for replay ID generation)
+	AcceptHooks          bool              // Accept hooks without prompting (--accept-hooks flag)
+	IsRemote             bool              // Whether the template source is remote
+	AllowRecursiveRender bool              // Allow recursive template rendering in variable values (--allow-recursive-render flag)
 }
 
 // CollectOptions contains options for variable collection.

--- a/internal/template/loader.go
+++ b/internal/template/loader.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/kaikenlabs/tag/internal/fileutil"
 	"github.com/nikolalohinski/gonja/v2/loaders"
 )
 
@@ -94,17 +95,7 @@ func (l *Loader) resolvePath(path string) (string, error) {
 	fullPath := filepath.Join(l.baseDir, cleanPath)
 
 	// Double-check the resolved path is within base directory
-	absBase, err := filepath.Abs(l.baseDir)
-	if err != nil {
-		return "", fmt.Errorf("invalid base directory: %w", err)
-	}
-	absPath, err := filepath.Abs(fullPath)
-	if err != nil {
-		return "", fmt.Errorf("invalid path: %w", err)
-	}
-
-	// Ensure the resolved path starts with the base directory
-	if !strings.HasPrefix(absPath, absBase+string(filepath.Separator)) && absPath != absBase {
+	if err := fileutil.ValidatePathContainment(l.baseDir, fullPath); err != nil {
 		return "", fmt.Errorf("path escapes base directory: %s", path)
 	}
 
@@ -182,6 +173,15 @@ func LoadTemplateFiles(dir string, suffix string) (map[string]string, error) {
 		if err != nil {
 			return err
 		}
+
+		// Skip symlinks to prevent loading files outside the template directory
+		if d.Type()&os.ModeSymlink != 0 {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
 		if d.IsDir() {
 			return nil
 		}

--- a/internal/template/loader_test.go
+++ b/internal/template/loader_test.go
@@ -181,6 +181,58 @@ func TestUT_Loader_Integration_WithEngine(t *testing.T) {
 	assert.Equal(t, "Hello, World!", result)
 }
 
+func TestUT_LoadTemplateFiles_SkipsSymlinks(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a real template file
+	err := os.WriteFile(filepath.Join(tmpDir, "real.tmpl"), []byte("real content"), 0o644)
+	require.NoError(t, err)
+
+	// Create a target file outside the template dir
+	outsideDir := t.TempDir()
+	outsideFile := filepath.Join(outsideDir, "secret.tmpl")
+	err = os.WriteFile(outsideFile, []byte("secret content"), 0o644)
+	require.NoError(t, err)
+
+	// Create a symlink to the outside file
+	symlinkPath := filepath.Join(tmpDir, "linked.tmpl")
+	err = os.Symlink(outsideFile, symlinkPath)
+	require.NoError(t, err)
+
+	templates, err := LoadTemplateFiles(tmpDir, "tmpl")
+	require.NoError(t, err)
+
+	// Should only contain the real file, not the symlinked one
+	assert.Len(t, templates, 1)
+	assert.Equal(t, "real content", templates["real.tmpl"])
+	assert.NotContains(t, templates, "linked.tmpl")
+}
+
+func TestUT_LoadTemplateFiles_SkipsSymlinkDirs(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a real template file
+	err := os.WriteFile(filepath.Join(tmpDir, "real.tmpl"), []byte("real content"), 0o644)
+	require.NoError(t, err)
+
+	// Create a directory outside with templates
+	outsideDir := t.TempDir()
+	err = os.WriteFile(filepath.Join(outsideDir, "secret.tmpl"), []byte("secret"), 0o644)
+	require.NoError(t, err)
+
+	// Create a symlink to the outside directory
+	symlinkDir := filepath.Join(tmpDir, "linked-dir")
+	err = os.Symlink(outsideDir, symlinkDir)
+	require.NoError(t, err)
+
+	templates, err := LoadTemplateFiles(tmpDir, "tmpl")
+	require.NoError(t, err)
+
+	// Should only contain the real file
+	assert.Len(t, templates, 1)
+	assert.Equal(t, "real content", templates["real.tmpl"])
+}
+
 func TestUT_Loader_PathTraversal_Rejected(t *testing.T) {
 	tmpDir := t.TempDir()
 	loader := NewLoader(tmpDir)

--- a/internal/writer/writer.go
+++ b/internal/writer/writer.go
@@ -5,9 +5,9 @@ import (
 	"io/fs"
 	"log/slog"
 	"os"
-	"path/filepath"
-	"strings"
 	"sync"
+
+	"github.com/kaikenlabs/tag/internal/fileutil"
 )
 
 const (
@@ -29,20 +29,7 @@ func New(dryRun bool) Write {
 // validatePathWithinDir ensures that path stays within the base directory.
 // This prevents path traversal attacks where template output paths could escape the working directory.
 func validatePathWithinDir(path, baseDir string) error {
-	absPath, err := filepath.Abs(filepath.Clean(path))
-	if err != nil {
-		return fmt.Errorf("failed to resolve absolute path: %w", err)
-	}
-	absBase, err := filepath.Abs(filepath.Clean(baseDir))
-	if err != nil {
-		return fmt.Errorf("failed to resolve absolute base: %w", err)
-	}
-
-	if !strings.HasPrefix(absPath, absBase+string(filepath.Separator)) && absPath != absBase {
-		return fmt.Errorf("path %q escapes base directory %q", absPath, absBase)
-	}
-
-	return nil
+	return fileutil.ValidatePathContainment(baseDir, path)
 }
 
 // WriteFile thin wrapper to decouple dependency of write file.


### PR DESCRIPTION
## Summary

- **#70**: Extract `ValidatePathContainment` to `internal/fileutil/` with symlink-aware resolution (replaces 3 duplicated implementations across writer, scaffold/output, commands/validate, and template/loader)
- **#71**: Fix SSTI vulnerability in recursive template rendering by escaping template syntax (`{{ }}`, `{% %}`, `{# #}`) in non-derived user-provided variable values via sentinel tokens. Adds `--allow-recursive-render` flag for backward compatibility
- **#72**: Fix TOCTOU race condition in scaffold output writer with fd-based file operations (`Lstat` → `Open` → `f.Stat` → `os.SameFile` → `io.ReadAll`)
- **#74**: Add symlink detection in `LoadTemplateFiles` + enforce HTTPS-only for remote ZIP template downloads (case-insensitive scheme check)

### Breaking Change
Template syntax in user-provided variable values is no longer rendered during path processing. Derived variables (whose defaults are template expressions) are still resolved. Use `--allow-recursive-render` to restore the previous behavior.

### Files changed (16)
- `internal/fileutil/path_containment.go` (new) - Central path containment validation
- `internal/fileutil/path_containment_test.go` (new) - Tests for path containment
- `internal/commands/scaffold.go` - Add `--allow-recursive-render` flag
- `internal/commands/validate.go` - Delegate to `fileutil.ValidatePathContainment`
- `internal/remote/zip.go` - HTTPS enforcement (case-insensitive)
- `internal/remote/zip_test.go` - HTTPS tests, TLS test servers
- `internal/scaffold/output.go` - TOCTOU-safe file operations, delegate path validation
- `internal/scaffold/output_test.go` - TOCTOU tests
- `internal/scaffold/processor.go` - SSTI sentinel escaping
- `internal/scaffold/processor_test.go` - SSTI protection tests
- `internal/scaffold/scaffold.go` - Wire derived var names + recursive render flag
- `internal/scaffold/types.go` - Add `AllowRecursiveRender` option
- `internal/template/loader.go` - Symlink detection in `LoadTemplateFiles`
- `internal/template/loader_test.go` - Symlink skip tests
- `internal/writer/writer.go` - Delegate to `fileutil.ValidatePathContainment`
- `CHANGELOG.md` - Document all changes

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] `go vet ./...` clean
- [x] `make lint` clean
- [x] New tests for `ValidatePathContainment` (path traversal, symlinks, non-existent paths)
- [x] New tests for SSTI protection (user input escaping, derived var rendering, malicious values)
- [x] New tests for TOCTOU-safe file operations (regular file, symlink rejection, mode sanitization)
- [x] New tests for symlink skip in `LoadTemplateFiles` (file symlinks, directory symlinks)
- [x] New test for HTTP URL rejection in ZIP fetcher
- [x] Integration tests updated to use TLS test servers

Closes #70, closes #71, closes #72, closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)