### PR TITLE
refactor: Phase 3 type unification (#75, #77, #78)

### DIFF
--- a/internal/commands/bundle.go
+++ b/internal/commands/bundle.go
@@ -84,7 +84,7 @@ func bundleAction(c *cli.Context, cfg *config.Config) error {
 func getBundleTemplate(name string) ([]byte, error) {
 	newBundle := engine.Bundle{
 		Name: name,
-		Generators: []engine.Generators{
+		Generators: []engine.GeneratorRef{
 			{
 				Name: "myGenerator",
 			},

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/kaikenlabs/tag/internal/chalk"
 	"github.com/kaikenlabs/tag/internal/parser"
+	"github.com/kaikenlabs/tag/internal/template"
 	"github.com/kaikenlabs/tag/internal/writer"
 )
 
@@ -56,13 +57,13 @@ func (c *Core) Generate(data Data) error {
 	for _, item := range parsedOutput {
 		var action string
 		switch item.Action {
-		case parser.ActionAppend:
+		case template.ActionAppend:
 			if err := c.fwr.AppendFile(item.To, item.Output); err != nil {
 				slog.Error("cannot append to file", "file", item.To, "error", err)
 				return err
 			}
 			action = chalk.Yellow("modified")
-		case parser.ActionInject:
+		case template.ActionInject:
 			if err := c.fwr.InjectIntoFile(item.To, item.Output, writer.Inject{
 				Matcher: item.InjectMatcher,
 				Clause:  writer.InjectClause(item.InjectClause),

--- a/internal/engine/types.go
+++ b/internal/engine/types.go
@@ -16,11 +16,12 @@ type Data struct {
 	MetaArgs []string
 }
 
-type Generators struct {
+// GeneratorRef is a reference to a generator by name within a bundle configuration.
+type GeneratorRef struct {
 	Name string `json:"name" yaml:"name"`
 }
 
 type Bundle struct {
-	Name       string       `json:"name" yaml:"name"`
-	Generators []Generators `json:"generators" yaml:"generators"`
+	Name       string         `json:"name" yaml:"name"`
+	Generators []GeneratorRef `json:"generators" yaml:"generators"`
 }

--- a/internal/formats/cases.go
+++ b/internal/formats/cases.go
@@ -44,13 +44,11 @@ func CaseCamel(str string) string {
 
 // parseAgainstMatchers run matchers against a string + transform
 func parseAgainstMatchers(str, sep string) string {
-	expression := fmt.Sprintf("${1}%s${2}", sep)
 	if matchSymbol.Match([]byte(str)) {
-		return matchSymbol.ReplaceAllString(str, expression)
+		return matchSymbol.ReplaceAllString(str, sep)
 	}
-	tmp := matchFirstCap.ReplaceAllString(str, expression)
-
-	return tmp
+	expression := fmt.Sprintf("${1}%s${2}", sep)
+	return matchFirstCap.ReplaceAllString(str, expression)
 }
 
 // lowercaseFirst converts the first letter to lower case

--- a/internal/formats/cases_test.go
+++ b/internal/formats/cases_test.go
@@ -151,3 +151,129 @@ func TestCaseKebab(t *testing.T) {
 		})
 	}
 }
+
+func TestUT_CaseSnake_SymbolEdgeCases(t *testing.T) {
+	tests := []struct {
+		name string
+		str  string
+		want string
+	}{
+		{
+			name: "multiple spaces",
+			str:  "hello world foo",
+			want: "hello_world_foo",
+		},
+		{
+			name: "mixed hyphens and spaces",
+			str:  "hello-world foo",
+			want: "hello_world_foo",
+		},
+		{
+			name: "mixed underscores and hyphens",
+			str:  "hello_world-foo",
+			want: "hello_world_foo",
+		},
+		{
+			name: "consecutive hyphens",
+			str:  "hello--world",
+			want: "hello__world",
+		},
+		{
+			name: "leading space",
+			str:  " hello",
+			want: "_hello",
+		},
+		{
+			name: "trailing space",
+			str:  "hello ",
+			want: "hello_",
+		},
+		{
+			name: "single word no symbols",
+			str:  "hello",
+			want: "hello",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, CaseSnake(tt.str))
+		})
+	}
+}
+
+func TestUT_CasePascal_SymbolEdgeCases(t *testing.T) {
+	tests := []struct {
+		name string
+		str  string
+		want string
+	}{
+		{
+			name: "multiple underscores",
+			str:  "hello_world_foo",
+			want: "HelloWorldFoo",
+		},
+		{
+			name: "mixed hyphens and spaces",
+			str:  "hello-world foo",
+			want: "HelloWorldFoo",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, CasePascal(tt.str))
+		})
+	}
+}
+
+func TestUT_CaseCamel_SymbolEdgeCases(t *testing.T) {
+	tests := []struct {
+		name string
+		str  string
+		want string
+	}{
+		{
+			name: "multiple underscores",
+			str:  "hello_world_foo",
+			want: "helloWorldFoo",
+		},
+		{
+			name: "with hyphens",
+			str:  "hello-world-foo",
+			want: "helloWorldFoo",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, CaseCamel(tt.str))
+		})
+	}
+}
+
+func TestUT_CaseKebab_SymbolEdgeCases(t *testing.T) {
+	tests := []struct {
+		name string
+		str  string
+		want string
+	}{
+		{
+			name: "from spaces",
+			str:  "hello world foo",
+			want: "hello-world-foo",
+		},
+		{
+			name: "from underscores",
+			str:  "hello_world_foo",
+			want: "hello-world-foo",
+		},
+		{
+			name: "consecutive spaces",
+			str:  "hello  world",
+			want: "hello--world",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, CaseKebab(tt.str))
+		})
+	}
+}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -128,8 +128,8 @@ func (te *TemplateEngine) parseTemplate(tmplName, tmplContent string, input Inpu
 		To:     metadata.To,
 		Output: parsedBody,
 		ParseData: ParseData{
-			Action:        convertAction(metadata.Action),
-			InjectClause:  convertInjectClause(metadata.InjectClause),
+			Action:        metadata.Action,
+			InjectClause:  metadata.InjectClause,
 			InjectMatcher: metadata.InjectMatcher,
 			Notes:         metadata.Notes,
 			Meta:          mergeMetadata(input.Meta, metadata.Extra),
@@ -209,30 +209,6 @@ func mergeMetadata(cliMeta map[string]string, templateMeta map[string]string) ma
 	return result
 }
 
-// convertAction converts template.Action to parser.ParseActions.
-func convertAction(action template.Action) ParseActions {
-	switch action {
-	case template.ActionAppend:
-		return ActionAppend
-	case template.ActionInject:
-		return ActionInject
-	default:
-		return ActionCreate
-	}
-}
-
-// convertInjectClause converts template.InjectClause to parser.InjectClause.
-func convertInjectClause(clause template.InjectClause) InjectClause {
-	switch clause {
-	case template.InjectBefore:
-		return InjectBefore
-	case template.InjectAfter:
-		return InjectAfter
-	default:
-		return ""
-	}
-}
-
 // withTemplates loads templates from a directory.
 func withTemplates(dirPath string, fileSuffix string) (map[string]string, error) {
 	rootTemplates := map[string]string{}
@@ -264,11 +240,11 @@ func orderTemplateData(data []TemplateData) []TemplateData {
 
 	for _, tmp := range data {
 		switch tmp.Action {
-		case ActionCreate:
+		case template.ActionCreate:
 			create = append(create, tmp)
-		case ActionInject:
+		case template.ActionInject:
 			inject = append(inject, tmp)
-		case ActionAppend:
+		case template.ActionAppend:
 			app = append(app, tmp)
 		}
 	}

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -236,7 +236,7 @@ content
 
 	data, err := te.Parse(InputData{Name: "test"})
 	require.NoError(t, err)
-	assert.Equal(t, ActionCreate, data[0].Action)
+	assert.Equal(t, template.ActionCreate, data[0].Action)
 }
 
 func TestUT_Parse_ActionAppend(t *testing.T) {
@@ -252,7 +252,7 @@ appended content
 
 	data, err := te.Parse(InputData{Name: "test"})
 	require.NoError(t, err)
-	assert.Equal(t, ActionAppend, data[0].Action)
+	assert.Equal(t, template.ActionAppend, data[0].Action)
 }
 
 func TestUT_Parse_ActionInjectAfter(t *testing.T) {
@@ -269,8 +269,8 @@ injected content
 
 	data, err := te.Parse(InputData{Name: "test"})
 	require.NoError(t, err)
-	assert.Equal(t, ActionInject, data[0].Action)
-	assert.Equal(t, InjectAfter, data[0].InjectClause)
+	assert.Equal(t, template.ActionInject, data[0].Action)
+	assert.Equal(t, template.InjectAfter, data[0].InjectClause)
 	assert.Equal(t, "// marker", data[0].InjectMatcher)
 }
 
@@ -288,8 +288,8 @@ injected content
 
 	data, err := te.Parse(InputData{Name: "test"})
 	require.NoError(t, err)
-	assert.Equal(t, ActionInject, data[0].Action)
-	assert.Equal(t, InjectBefore, data[0].InjectClause)
+	assert.Equal(t, template.ActionInject, data[0].Action)
+	assert.Equal(t, template.InjectBefore, data[0].InjectClause)
 	assert.Equal(t, "// marker", data[0].InjectMatcher)
 }
 
@@ -375,9 +375,9 @@ create`,
 	require.Len(t, data, 3)
 
 	// Should be ordered: Create, Inject, Append
-	assert.Equal(t, ActionCreate, data[0].Action)
-	assert.Equal(t, ActionInject, data[1].Action)
-	assert.Equal(t, ActionAppend, data[2].Action)
+	assert.Equal(t, template.ActionCreate, data[0].Action)
+	assert.Equal(t, template.ActionInject, data[1].Action)
+	assert.Equal(t, template.ActionAppend, data[2].Action)
 }
 
 func TestUT_Parse_JinjaConditional(t *testing.T) {
@@ -472,7 +472,7 @@ func TestUT_NewWithExecutor_ParsesTemplate(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, data, 1)
 	assert.Equal(t, "output/service.go", data[0].To)
-	assert.Equal(t, ActionCreate, data[0].Action)
+	assert.Equal(t, template.ActionCreate, data[0].Action)
 	assert.Equal(t, "generated code", string(data[0].Output))
 }
 

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -22,43 +22,14 @@ type TemplateData struct {
 	ParseData
 }
 
-// ParseActions represents the type of file operation.
-type ParseActions string
-
-const (
-	ActionCreate ParseActions = "Create"
-	ActionAppend ParseActions = "Append"
-	ActionInject ParseActions = "Inject"
-)
-
-// InjectClause represents where to inject content.
-type InjectClause string
-
-const (
-	InjectBefore InjectClause = "Before"
-	InjectAfter  InjectClause = "After"
-)
-
 // ParseData holds the parsing configuration and user input.
 type ParseData struct {
-	Action        ParseActions
-	InjectClause  InjectClause
+	Action        template.Action       // File operation: Create, Append, or Inject
+	InjectClause  template.InjectClause // Before or After (for inject action)
 	InjectMatcher string
 	Args          string            // Free-form arguments string
-	N             NameOptions       // Pre-computed name variants (deprecated, use template context)
 	Meta          map[string]string // User-provided metadata from --meta flags
 	Notes         string
-}
-
-// NameOptions contains pre-computed name variants.
-// Deprecated: Use template.NameOptions and the "n" context namespace instead.
-type NameOptions struct {
-	PascalCase string
-	CamelCase  string
-	SnakeCase  string
-	KebabCase  string
-	LowerCase  string
-	UpperCase  string
 }
 
 // InputData represents the input provided by the engine for template parsing.


### PR DESCRIPTION
## Summary

Phase 3 of the Consolidated Refactoring Plan (Epic #63) — **Type Unification**.

- **#75**: Remove duplicated `ParseActions`, `InjectClause`, `NameOptions` types from `parser/types.go`. Use `template.Action` and `template.InjectClause` as the single source of truth. Delete `convertAction()` and `convertInjectClause()` conversion functions. Remove deprecated `ParseData.N` field.
- **#76**: Already completed in PR #85 — closed as resolved.
- **#77**: Rename `engine.Generators` struct to `engine.GeneratorRef` (original `Generator` name was taken by existing interface in `engine/interfaces.go`).
- **#78**: Fix `parseAgainstMatchers` regex — use separator directly in symbol branch instead of `expression` with undefined `${1}`/`${2}` backreferences. Add edge-case tests for case conversions with symbol inputs.

Closes #75, closes #77, closes #78.

## Test plan

- [x] `go test ./...` — all tests pass
- [x] `go vet ./...` — clean
- [x] `golangci-lint run` — no new issues (19 pre-existing issues in untouched files)
- [x] Edge-case tests added for `formats/cases.go` symbol handling
- [x] Parser tests updated to use `template.*` type constants
- [x] Codex and Gemini code review — both approved with no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)