### PR TITLE
refactor: code quality improvements across 6 phases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ bin
 .serena
 .claude
 claudedocs
+tag

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,8 @@ main.go                         CLI entry point (urfave/cli/v2)
     │       ├── loader.go           - Template file loader
     │       ├── context.go          - Template context building
     │       ├── metadata.go         - Template metadata handling
+    │       ├── interfaces.go       - TemplateRenderer interface
+    │       ├── errors.go           - Error types and sentinels
     │       └── types.go            - Type definitions
     │
     ├── internal/remote/        Remote template resolution

--- a/internal/commands/generate.go
+++ b/internal/commands/generate.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/kaikenlabs/tag/internal/types/flags"
 	"github.com/kaikenlabs/tag/pkg/app"
@@ -16,52 +15,16 @@ import (
 	"github.com/kaikenlabs/tag/internal/engine"
 	"github.com/kaikenlabs/tag/internal/scaffold"
 	"github.com/kaikenlabs/tag/internal/template"
-	"github.com/kaikenlabs/tag/internal/writer"
 	"github.com/urfave/cli/v2"
 )
 
 // newEngine is a function variable that creates a new engine.
 // It can be replaced in tests to inject a mock generator.
-var newEngine = func(dryRun bool, dirPath string, sharedPath string, fileSuffix string) (engine.Generator, error) {
-	if dryRun {
-		slog.Info(chalk.Cyan("DRYRUN MODE"))
-	}
+var newEngine = engine.NewGenerator
 
-	// 1. Create template engine
-	tmplEngine, err := template.NewEngine()
-	if err != nil {
-		return nil, fmt.Errorf("cannot create template engine: %w", err)
-	}
-
-	// 2. Load primary templates
-	templates, err := engine.LoadTemplateFiles(dirPath, fileSuffix)
-	if err != nil {
-		return nil, fmt.Errorf("cannot load templates: %w", err)
-	}
-
-	// 3. Load shared templates (non-fatal)
-	sharedTemplates, sharedErr := engine.LoadTemplateFiles(sharedPath, fileSuffix)
-	if sharedErr != nil {
-		slog.Debug("shared templates not loaded", "path", sharedPath, "error", sharedErr)
-	}
-
-	// 4. Wire shared templates into loader if any were loaded
-	if len(sharedTemplates) > 0 {
-		loader := template.CreateMemoryLoaderFromMap(sharedTemplates)
-		tmplEngine.SetLoader(loader)
-		slog.Debug("loaded shared templates", "count", len(sharedTemplates))
-	}
-
-	// 5. Create parser and writer with injected dependencies
-	parser := engine.NewParserWithExecutor(tmplEngine, templates, sharedTemplates)
-	w, err := writer.New(dryRun) //nolint:staticcheck // only available constructor; result used as FileWriter interface
-	if err != nil {
-		return nil, fmt.Errorf("cannot create writer: %w", err)
-	}
-
-	core := engine.NewCore(parser, &w)
-	return &core, nil
-}
+// newBundleEngine is a function variable that creates an engine with a shared template engine.
+// It can be replaced in tests to inject a mock generator.
+var newBundleEngine = engine.NewGeneratorWithEngine
 
 func GenerateCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
@@ -155,10 +118,35 @@ func generateBundle(c *cli.Context, cfg *config.Config, generatorName, targetNam
 		return app.Errorf("cannot decode bundle file: %w", err)
 	}
 
+	// Create shared template engine for all generators in the bundle.
+	// This avoids re-creating the engine (and its cache) for each generator.
+	tmplEngine, err := template.NewEngine()
+	if err != nil {
+		return app.Errorf("cannot create template engine: %w", err)
+	}
+
+	dryRun := c.Bool(flags.DryRunFlag)
+	sharedPath := filepath.Join(cfg.Env.Path, c.Path(flags.SharedPathFlag))
+
 	slog.Info(chalk.Green("running bundle"), "bundle", generatorName, "target", targetName)
 	for _, generator := range bundle.Generators {
-		if err := generateTemplate(c, cfg, generator.Name, targetName, args, true); err != nil {
-			return err
+		genDirPath := filepath.Join(cfg.Env.Path, generator.Name)
+
+		if err := ValidatePathContainment(cfg.Env.Path, genDirPath); err != nil {
+			return app.Errorf("path safety check failed: %w", err)
+		}
+		if _, err := os.ReadDir(genDirPath); err != nil {
+			return app.Errorf("generator %s not found in: %s", generator.Name, cfg.Env.Path)
+		}
+
+		gen, err := newBundleEngine(tmplEngine, dryRun, genDirPath, sharedPath, cfg.Env.Extension)
+		if err != nil {
+			return app.Errorf("error creating engine: %w", err)
+		}
+
+		err = gen.Generate(engine.Data{Name: targetName, Args: args, MetaArgs: c.StringSlice(flags.MetaFlag)})
+		if err != nil {
+			return app.Errorf("error when generating template: %w", err)
 		}
 	}
 
@@ -219,15 +207,7 @@ func runHooks(hooks [][]string, phase scaffold.HookPhase) error {
 
 	results, err := scaffold.RunArgvHooks(phase, hooks, dir, nil)
 
-	// Print output from executed hooks
-	for _, result := range results {
-		if result.Output != "" {
-			fmt.Print(result.Output)
-			if !strings.HasSuffix(result.Output, "\n") {
-				fmt.Println()
-			}
-		}
-	}
+	scaffold.PrintHookResults(results)
 
 	if err != nil {
 		return app.Errorf("hook failed: %w", err)

--- a/internal/commands/generate_test.go
+++ b/internal/commands/generate_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/kaikenlabs/tag/internal/engine"
 	"github.com/kaikenlabs/tag/internal/scaffold"
+	"github.com/kaikenlabs/tag/internal/template"
 	"github.com/kaikenlabs/tag/internal/types/flags"
 	"github.com/kaikenlabs/tag/pkg/app"
 	"github.com/stretchr/testify/assert"
@@ -312,8 +313,8 @@ Hello {{ .Name }}`
 	})
 
 	var generateCalls int
-	originalNewEngine := newEngine
-	newEngine = func(dryRun bool, dirPath string, sharedPath string, fileSuffix string) (engine.Generator, error) {
+	originalBundleEngine := newBundleEngine
+	newBundleEngine = func(tmplEngine *template.Engine, dryRun bool, dirPath string, sharedPath string, fileSuffix string) (engine.Generator, error) {
 		mock := &mockGenerator{
 			GenerateFunc: func(data engine.Data) error {
 				generateCalls++
@@ -322,7 +323,7 @@ Hello {{ .Name }}`
 		}
 		return mock, nil
 	}
-	t.Cleanup(func() { newEngine = originalNewEngine })
+	t.Cleanup(func() { newBundleEngine = originalBundleEngine })
 
 	err := generateAction(ctx, cfg)
 
@@ -355,8 +356,8 @@ Hello {{ .Name }}`
 	})
 
 	var generateCalls int
-	originalNewEngine := newEngine
-	newEngine = func(dryRun bool, dirPath string, sharedPath string, fileSuffix string) (engine.Generator, error) {
+	originalBundleEngine := newBundleEngine
+	newBundleEngine = func(tmplEngine *template.Engine, dryRun bool, dirPath string, sharedPath string, fileSuffix string) (engine.Generator, error) {
 		mock := &mockGenerator{
 			GenerateFunc: func(data engine.Data) error {
 				generateCalls++
@@ -365,7 +366,7 @@ Hello {{ .Name }}`
 		}
 		return mock, nil
 	}
-	t.Cleanup(func() { newEngine = originalNewEngine })
+	t.Cleanup(func() { newBundleEngine = originalBundleEngine })
 
 	err := generateAction(ctx, cfg)
 

--- a/internal/commands/init.go
+++ b/internal/commands/init.go
@@ -28,14 +28,12 @@ func initAction(c *cli.Context) error {
 	slog.Info(chalk.Green("creating initial setup"), "path", c.String(flags.PathFlag))
 	dirPath := filepath.Join(".", c.String(flags.PathFlag), c.String(flags.SharedPathFlag), ".gitkeep")
 	if err := os.MkdirAll(filepath.Dir(dirPath), 0o750); err != nil {
-		slog.Error("error initialising tag's shared path", "error", err.Error())
-		return err
+		return app.Errorf("cannot initialise tag's shared path: %w", err)
 	}
 
 	dirPath = filepath.Join(".", c.String(flags.PathFlag), c.String(flags.BundlePathFlag), ".gitkeep")
 	if err := os.MkdirAll(filepath.Dir(dirPath), 0o750); err != nil {
-		slog.Error("error initialising tag's bundle path", "error", err.Error())
-		return err
+		return app.Errorf("cannot initialise tag's bundle path: %w", err)
 	}
 
 	if err := config.CreateConfigFile(c); err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,10 +37,10 @@ func CheckConfig(cfg *Config) error {
 }
 
 // LoadConfigFile loads the configuration from the config file.
-// Returns an empty config if the file doesn't exist, or an error if parsing fails.
+// Returns nil config if the file doesn't exist, or an error if parsing fails.
 func LoadConfigFile() (*Config, error) {
 	if _, err := os.Stat(File); err != nil {
-		return &Config{}, nil
+		return nil, nil
 	}
 	data, err := os.ReadFile(File)
 	if err != nil {

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -17,6 +17,54 @@ const (
 	emptyString           = ""
 )
 
+// NewGenerator creates a Generator with the standard pipeline.
+// It creates a new template engine, loads templates, and wires up the parser and writer.
+func NewGenerator(dryRun bool, dirPath, sharedPath, fileSuffix string) (Generator, error) {
+	tmplEngine, err := template.NewEngine()
+	if err != nil {
+		return nil, fmt.Errorf("cannot create template engine: %w", err)
+	}
+	return NewGeneratorWithEngine(tmplEngine, dryRun, dirPath, sharedPath, fileSuffix)
+}
+
+// NewGeneratorWithEngine creates a Generator using an existing template engine.
+// This allows sharing a template engine (and its cache) across multiple generators,
+// such as when running a bundle of generators.
+func NewGeneratorWithEngine(tmplEngine *template.Engine, dryRun bool, dirPath, sharedPath, fileSuffix string) (Generator, error) {
+	if dryRun {
+		slog.Info(chalk.Cyan("DRYRUN MODE"))
+	}
+
+	// Load primary templates
+	templates, err := LoadTemplateFiles(dirPath, fileSuffix)
+	if err != nil {
+		return nil, fmt.Errorf("cannot load templates: %w", err)
+	}
+
+	// Load shared templates (non-fatal)
+	sharedTemplates, sharedErr := LoadTemplateFiles(sharedPath, fileSuffix)
+	if sharedErr != nil {
+		slog.Debug("shared templates not loaded", "path", sharedPath, "error", sharedErr)
+	}
+
+	// Wire shared templates into loader if any were loaded
+	if len(sharedTemplates) > 0 {
+		loader := template.CreateMemoryLoaderFromMap(sharedTemplates)
+		tmplEngine.SetLoader(loader)
+		slog.Debug("loaded shared templates", "count", len(sharedTemplates))
+	}
+
+	// Create parser and writer with injected dependencies
+	parser := NewParserWithExecutor(tmplEngine, templates, sharedTemplates)
+	w, err := writer.New(dryRun) //nolint:staticcheck // only available constructor; result used as FileWriter interface
+	if err != nil {
+		return nil, fmt.Errorf("cannot create writer: %w", err)
+	}
+
+	core := NewCore(parser, &w)
+	return &core, nil
+}
+
 // NewCore creates a Core engine with injected dependencies.
 // This is the preferred constructor, enabling dependency injection for testing.
 func NewCore(parser TemplateParser, fwr writer.FileWriter) Core {

--- a/internal/remote/remote.go
+++ b/internal/remote/remote.go
@@ -212,11 +212,7 @@ func (r *Resolver) CleanupCache() error {
 
 // isZipFile checks if a path is a zip file.
 func isZipFile(path string) bool {
-	if len(path) < 4 {
-		return false
-	}
-	ext := path[len(path)-4:]
-	return ext == ".zip" || ext == ".ZIP"
+	return strings.EqualFold(filepath.Ext(path), ".zip")
 }
 
 // IsLocal checks if a reference string points to a local resource.

--- a/internal/scaffold/errors.go
+++ b/internal/scaffold/errors.go
@@ -72,27 +72,27 @@ func NewPathError(path, message string, err error) *PathError {
 	return &PathError{Path: path, Message: message, Err: err}
 }
 
-// TemplateError represents an error during template processing.
-type TemplateError struct {
+// FileProcessingError represents an error during template processing.
+type FileProcessingError struct {
 	File    string
 	Message string
 	Err     error
 }
 
-func (e *TemplateError) Error() string {
+func (e *FileProcessingError) Error() string {
 	if e.Err != nil {
 		return fmt.Sprintf("template %q: %s: %v", e.File, e.Message, e.Err)
 	}
 	return fmt.Sprintf("template %q: %s", e.File, e.Message)
 }
 
-func (e *TemplateError) Unwrap() error {
+func (e *FileProcessingError) Unwrap() error {
 	return e.Err
 }
 
-// NewTemplateError creates a new template error.
-func NewTemplateError(file, message string, err error) *TemplateError {
-	return &TemplateError{File: file, Message: message, Err: err}
+// NewFileProcessingError creates a new template error.
+func NewFileProcessingError(file, message string, err error) *FileProcessingError {
+	return &FileProcessingError{File: file, Message: message, Err: err}
 }
 
 // ErrCookiecutterDetected represents a Cookiecutter template detection.

--- a/internal/scaffold/hooks.go
+++ b/internal/scaffold/hooks.go
@@ -294,6 +294,18 @@ func ConfirmHooks(hooks *HooksConfig, acceptHooks, noInput bool, prompter Prompt
 	return confirmed, nil
 }
 
+// PrintHookResults prints the output of hook execution results to stdout.
+func PrintHookResults(results []HookResult) {
+	for _, result := range results {
+		if result.Output != "" {
+			fmt.Print(result.Output)
+			if !strings.HasSuffix(result.Output, "\n") {
+				fmt.Println()
+			}
+		}
+	}
+}
+
 // RunPreScaffoldHooks executes pre-scaffold hooks and returns an error if any fail.
 // Pre-scaffold hooks run in the template directory before any files are created.
 func RunPreScaffoldHooks(runner HookRunner, hooks *HooksConfig, templateDir string, env []string) error {
@@ -305,15 +317,7 @@ func RunPreScaffoldHooks(runner HookRunner, hooks *HooksConfig, templateDir stri
 
 	results, err := runner.Run(HookPhasePre, hooks.PreScaffold, templateDir, env)
 
-	// Print output from all executed commands for debugging context
-	for _, result := range results {
-		if result.Output != "" {
-			fmt.Print(result.Output)
-			if !strings.HasSuffix(result.Output, "\n") {
-				fmt.Println()
-			}
-		}
-	}
+	PrintHookResults(results)
 
 	return err
 }
@@ -330,15 +334,7 @@ func RunPostScaffoldHooks(runner HookRunner, hooks *HooksConfig, outputDir strin
 
 	results, err := runner.Run(HookPhasePost, hooks.PostScaffold, outputDir, env)
 
-	// Print output from all executed commands
-	for _, result := range results {
-		if result.Output != "" {
-			fmt.Print(result.Output)
-			if !strings.HasSuffix(result.Output, "\n") {
-				fmt.Println()
-			}
-		}
-	}
+	PrintHookResults(results)
 
 	if err != nil {
 		// Post-scaffold failures are warnings, not errors

--- a/internal/scaffold/output.go
+++ b/internal/scaffold/output.go
@@ -262,17 +262,17 @@ func (w *DefaultOutputWriter) processTemplate(srcPath, destPath string, content 
 	// Parse and execute template
 	tmpl, err := w.engine.ParseString(string(content))
 	if err != nil {
-		return NewTemplateError(srcPath, "failed to parse template", err)
+		return NewFileProcessingError(srcPath, "failed to parse template", err)
 	}
 
 	result, err := tmpl.Execute(ctx)
 	if err != nil {
-		return NewTemplateError(srcPath, "failed to execute template", err)
+		return NewFileProcessingError(srcPath, "failed to execute template", err)
 	}
 
 	// Write output
 	if err := os.WriteFile(destPath, []byte(result), mode); err != nil {
-		return NewTemplateError(srcPath, "failed to write output", err)
+		return NewFileProcessingError(srcPath, "failed to write output", err)
 	}
 
 	return nil

--- a/internal/scaffold/output_test.go
+++ b/internal/scaffold/output_test.go
@@ -549,7 +549,7 @@ func TestUT_ProcessFile_TemplateParseError(t *testing.T) {
 	err = writer.processFile(srcPath, destPath, ctx, newTestDirEntry(info))
 	require.Error(t, err)
 
-	var tmplErr *TemplateError
+	var tmplErr *FileProcessingError
 	assert.ErrorAs(t, err, &tmplErr)
 }
 
@@ -573,7 +573,7 @@ func TestUT_ProcessFile_TemplateExecuteError(t *testing.T) {
 	err = writer.processFile(srcPath, destPath, ctx, newTestDirEntry(info))
 	require.Error(t, err)
 
-	var tmplErr *TemplateError
+	var tmplErr *FileProcessingError
 	assert.ErrorAs(t, err, &tmplErr)
 }
 

--- a/internal/template/context.go
+++ b/internal/template/context.go
@@ -12,14 +12,14 @@ import (
 //   - "vars": user-defined variables (TAG namespace)
 //   - "cookiecutter": alias to vars (Cookiecutter compatibility)
 //   - "n": pre-computed name variants
-func NewContext(name string, vars map[string]any, nameOpts *NameOptions) Context {
+func NewContext(name string, vars map[string]any) Context {
 	return NewContextBuilder().
-		WithNameOptions(name, nameOpts).
+		WithName(name).
 		WithVars(vars).
 		Build()
 }
 
-// computeNameOptions creates NameOptions from a name string.
+// computeNameOptions creates name variant options from a name string.
 func computeNameOptions(name string) map[string]any {
 	return map[string]any{
 		"snake_case":  formats.CaseSnake(name),
@@ -28,18 +28,6 @@ func computeNameOptions(name string) map[string]any {
 		"kebab_case":  formats.CaseKebab(name),
 		"lower_case":  strings.ToLower(name),
 		"upper_case":  strings.ToUpper(name),
-	}
-}
-
-// NewNameOptions creates a NameOptions struct from a name string.
-func NewNameOptions(name string) NameOptions {
-	return NameOptions{
-		SnakeCase:  formats.CaseSnake(name),
-		PascalCase: formats.CasePascal(name),
-		CamelCase:  formats.CaseCamel(name),
-		KebabCase:  formats.CaseKebab(name),
-		LowerCase:  strings.ToLower(name),
-		UpperCase:  strings.ToUpper(name),
 	}
 }
 
@@ -81,24 +69,6 @@ func (b *ContextBuilder) WithName(name string) *ContextBuilder {
 	return b
 }
 
-// WithNameOptions adds the "name" key and "n" namespace from pre-computed NameOptions.
-func (b *ContextBuilder) WithNameOptions(name string, opts *NameOptions) *ContextBuilder {
-	b.ctx["name"] = name
-	if opts != nil {
-		b.ctx["n"] = map[string]any{
-			"snake_case":  opts.SnakeCase,
-			"pascal_case": opts.PascalCase,
-			"camel_case":  opts.CamelCase,
-			"kebab_case":  opts.KebabCase,
-			"lower_case":  opts.LowerCase,
-			"upper_case":  opts.UpperCase,
-		}
-	} else {
-		b.ctx["n"] = computeNameOptions(name)
-	}
-	return b
-}
-
 // WithMeta adds the "meta" namespace for backward compatibility.
 func (b *ContextBuilder) WithMeta(meta map[string]string) *ContextBuilder {
 	if meta != nil {
@@ -116,21 +86,3 @@ func (b *ContextBuilder) Build() Context {
 	return b.ctx
 }
 
-// Set adds or updates a value in the context.
-func (c Context) Set(key string, value any) {
-	c[key] = value
-}
-
-// Get retrieves a value from the context.
-func (c Context) Get(key string) (any, bool) {
-	v, ok := c[key]
-	return v, ok
-}
-
-// Merge combines another context into this one.
-// Values from the other context override existing values.
-func (c Context) Merge(other Context) {
-	for k, v := range other {
-		c[k] = v
-	}
-}

--- a/internal/template/context_test.go
+++ b/internal/template/context_test.go
@@ -13,7 +13,7 @@ func TestUT_NewContext_CreatesNamespace(t *testing.T) {
 		"author":       "John Doe",
 	}
 
-	ctx := NewContext("my-project", vars, nil)
+	ctx := NewContext("my-project", vars)
 
 	// Check name is set
 	assert.Equal(t, "my-project", ctx["name"])
@@ -30,7 +30,7 @@ func TestUT_NewContext_CookiecutterAlias(t *testing.T) {
 		"project_name": "my-project",
 	}
 
-	ctx := NewContext("my-project", vars, nil)
+	ctx := NewContext("my-project", vars)
 
 	// Check that cookiecutter points to the same data as vars
 	varsMap := ctx["vars"].(map[string]any)
@@ -43,31 +43,8 @@ func TestUT_NewContext_CookiecutterAlias(t *testing.T) {
 	assert.Equal(t, "new_value", cookiecutterMap["new_key"])
 }
 
-func TestUT_NewContext_NameOptions(t *testing.T) {
-	nameOpts := &NameOptions{
-		SnakeCase:  "my_project",
-		PascalCase: "MyProject",
-		CamelCase:  "myProject",
-		KebabCase:  "my-project",
-		LowerCase:  "my-project",
-		UpperCase:  "MY-PROJECT",
-	}
-
-	ctx := NewContext("my-project", nil, nameOpts)
-
-	nMap, ok := ctx["n"].(map[string]any)
-	require.True(t, ok, "n should be a map")
-
-	assert.Equal(t, "my_project", nMap["snake_case"])
-	assert.Equal(t, "MyProject", nMap["pascal_case"])
-	assert.Equal(t, "myProject", nMap["camel_case"])
-	assert.Equal(t, "my-project", nMap["kebab_case"])
-	assert.Equal(t, "my-project", nMap["lower_case"])
-	assert.Equal(t, "MY-PROJECT", nMap["upper_case"])
-}
-
-func TestUT_NewContext_ComputesNameOptionsWhenNil(t *testing.T) {
-	ctx := NewContext("MyProject", nil, nil)
+func TestUT_NewContext_ComputesNameOptions(t *testing.T) {
+	ctx := NewContext("MyProject", nil)
 
 	nMap, ok := ctx["n"].(map[string]any)
 	require.True(t, ok, "n should be a map")
@@ -82,52 +59,12 @@ func TestUT_NewContext_ComputesNameOptionsWhenNil(t *testing.T) {
 }
 
 func TestUT_NewContext_NilVarsCreatesEmptyMap(t *testing.T) {
-	ctx := NewContext("test", nil, nil)
+	ctx := NewContext("test", nil)
 
 	varsMap, ok := ctx["vars"].(map[string]any)
 	require.True(t, ok, "vars should be a map")
 	assert.NotNil(t, varsMap)
 	assert.Len(t, varsMap, 0)
-}
-
-func TestUT_NewNameOptions(t *testing.T) {
-	opts := NewNameOptions("MyProject")
-
-	assert.Equal(t, "my_project", opts.SnakeCase)
-	assert.Equal(t, "MyProject", opts.PascalCase)
-	assert.Equal(t, "myProject", opts.CamelCase)
-	assert.Equal(t, "my-project", opts.KebabCase)
-	assert.Equal(t, "myproject", opts.LowerCase)
-	assert.Equal(t, "MYPROJECT", opts.UpperCase)
-}
-
-func TestUT_Context_Set(t *testing.T) {
-	ctx := make(Context)
-	ctx.Set("key", "value")
-
-	assert.Equal(t, "value", ctx["key"])
-}
-
-func TestUT_Context_Get(t *testing.T) {
-	ctx := Context{"key": "value"}
-
-	val, ok := ctx.Get("key")
-	assert.True(t, ok)
-	assert.Equal(t, "value", val)
-
-	_, ok = ctx.Get("nonexistent")
-	assert.False(t, ok)
-}
-
-func TestUT_Context_Merge(t *testing.T) {
-	ctx1 := Context{"a": "1", "b": "2"}
-	ctx2 := Context{"b": "3", "c": "4"}
-
-	ctx1.Merge(ctx2)
-
-	assert.Equal(t, "1", ctx1["a"])
-	assert.Equal(t, "3", ctx1["b"]) // overridden
-	assert.Equal(t, "4", ctx1["c"])
 }
 
 func TestUT_Context_InTemplate(t *testing.T) {
@@ -136,7 +73,7 @@ func TestUT_Context_InTemplate(t *testing.T) {
 	t.Run("access vars namespace", func(t *testing.T) {
 		tmpl := `{{ vars.project_name }}`
 		vars := map[string]any{"project_name": "my-project"}
-		ctx := NewContext("test", vars, nil)
+		ctx := NewContext("test", vars)
 
 		result, err := engine.ExecuteToString(tmpl, ctx)
 		require.NoError(t, err)
@@ -146,7 +83,7 @@ func TestUT_Context_InTemplate(t *testing.T) {
 	t.Run("access cookiecutter namespace", func(t *testing.T) {
 		tmpl := `{{ cookiecutter.project_name }}`
 		vars := map[string]any{"project_name": "my-project"}
-		ctx := NewContext("test", vars, nil)
+		ctx := NewContext("test", vars)
 
 		result, err := engine.ExecuteToString(tmpl, ctx)
 		require.NoError(t, err)
@@ -155,7 +92,7 @@ func TestUT_Context_InTemplate(t *testing.T) {
 
 	t.Run("access n namespace", func(t *testing.T) {
 		tmpl := `{{ n.pascal_case }}`
-		ctx := NewContext("my-project", nil, nil)
+		ctx := NewContext("my-project", nil)
 
 		result, err := engine.ExecuteToString(tmpl, ctx)
 		require.NoError(t, err)
@@ -164,7 +101,7 @@ func TestUT_Context_InTemplate(t *testing.T) {
 
 	t.Run("access name directly", func(t *testing.T) {
 		tmpl := `{{ name }}`
-		ctx := NewContext("my-project", nil, nil)
+		ctx := NewContext("my-project", nil)
 
 		result, err := engine.ExecuteToString(tmpl, ctx)
 		require.NoError(t, err)

--- a/internal/template/engine.go
+++ b/internal/template/engine.go
@@ -1,9 +1,9 @@
 package template
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
+	"hash/fnv"
+	"strconv"
 	"sync"
 
 	"github.com/nikolalohinski/gonja/v2"
@@ -14,7 +14,7 @@ import (
 )
 
 // templateCache provides thread-safe caching of parsed Gonja templates.
-// Templates are keyed by SHA-256 hash of their content string.
+// Templates are keyed by FNV-1a hash of their content string.
 type templateCache struct {
 	mu    sync.RWMutex
 	items map[string]*exec.Template
@@ -34,10 +34,12 @@ func (c *templateCache) set(key string, tmpl *exec.Template) {
 	c.items[key] = tmpl
 }
 
-// contentHash computes a SHA-256 hash of the template content for use as a cache key.
+// contentHash computes an FNV-1a hash of the template content for use as a cache key.
+// FNV-1a is sufficient for cache keying (not security) and is significantly faster than SHA-256.
 func contentHash(content string) string {
-	h := sha256.Sum256([]byte(content))
-	return hex.EncodeToString(h[:])
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(content))
+	return strconv.FormatUint(h.Sum64(), 36)
 }
 
 // Engine wraps Gonja to provide a consistent template interface.

--- a/internal/template/engine_test.go
+++ b/internal/template/engine_test.go
@@ -30,7 +30,7 @@ func TestUT_Engine_ParseString_Simple(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, tmpl)
 
-	ctx := NewContext("World", nil, nil)
+	ctx := NewContext("World", nil)
 	result, err := tmpl.Execute(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, "Hello, World!", result)
@@ -42,7 +42,7 @@ func TestUT_Engine_ParseString_WithFilters(t *testing.T) {
 	tmpl, err := engine.ParseString("{{ name|upper }}")
 	require.NoError(t, err)
 
-	ctx := NewContext("hello", nil, nil)
+	ctx := NewContext("hello", nil)
 	result, err := tmpl.Execute(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, "HELLO", result)
@@ -88,7 +88,7 @@ func TestUT_Engine_ParseString_NestedAccess(t *testing.T) {
 	require.NoError(t, err)
 
 	vars := map[string]any{"project_name": "my-project"}
-	ctx := NewContext("test", vars, nil)
+	ctx := NewContext("test", vars)
 
 	result, err := tmpl.Execute(ctx)
 	require.NoError(t, err)
@@ -101,7 +101,7 @@ func TestUT_Engine_ParseString_FilterChain(t *testing.T) {
 	tmpl, err := engine.ParseString("{{ name|snake|upper }}")
 	require.NoError(t, err)
 
-	ctx := NewContext("HelloWorld", nil, nil)
+	ctx := NewContext("HelloWorld", nil)
 	result, err := tmpl.Execute(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, "HELLO_WORLD", result)
@@ -118,7 +118,7 @@ func TestUT_Engine_ParseString_SyntaxError(t *testing.T) {
 func TestUT_Engine_ExecuteToString(t *testing.T) {
 	engine := MustNewEngine()
 
-	ctx := NewContext("World", nil, nil)
+	ctx := NewContext("World", nil)
 	result, err := engine.ExecuteToString("Hello, {{ name }}!", ctx)
 	require.NoError(t, err)
 	assert.Equal(t, "Hello, World!", result)
@@ -151,7 +151,7 @@ func TestUT_Engine_ParseFile(t *testing.T) {
 	tmpl, err := engine.ParseFile("test.tmpl")
 	require.NoError(t, err)
 
-	ctx := NewContext("World", nil, nil)
+	ctx := NewContext("World", nil)
 	result, err := tmpl.Execute(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, "Hello, World!", result)
@@ -192,7 +192,7 @@ func ({{ n.camel_case }} *{{ n.pascal_case }}) Get{{ field|pascal }}() string {
 		"package_name": "models",
 		"fields":       []string{"name", "email", "phone"},
 	}
-	ctx := NewContext("User", vars, nil)
+	ctx := NewContext("User", vars)
 
 	result, err := engine.ExecuteToString(template, ctx)
 	require.NoError(t, err)

--- a/internal/template/errors.go
+++ b/internal/template/errors.go
@@ -12,9 +12,6 @@ var (
 
 	// ErrExecute indicates a template execution error.
 	ErrExecute = errors.New("template execution error")
-
-	// ErrFilter indicates a filter execution error.
-	ErrFilter = errors.New("filter error")
 )
 
 // TemplateError wraps template-related errors with additional context.
@@ -74,7 +71,3 @@ func NewExecuteError(template string, err error) error {
 	}
 }
 
-// NewFilterError creates a new filter error with context.
-func NewFilterError(filterName string, err error) error {
-	return fmt.Errorf("%w: %s: %v", ErrFilter, filterName, err)
-}

--- a/internal/template/filters.go
+++ b/internal/template/filters.go
@@ -11,6 +11,9 @@ import (
 	"golang.org/x/text/language"
 )
 
+// titleCaser is a cached English title caser to avoid allocation per filter call.
+var titleCaser = cases.Title(language.English)
+
 // RegisterFilters registers all custom filters with the given filter set.
 // Returns an error if any filter fails to register.
 func RegisterFilters(filters *exec.FilterSet) error {
@@ -140,7 +143,7 @@ func filterTitle(_ *exec.Evaluator, in *exec.Value, params *exec.VarArgs) *exec.
 	if err := params.Take(); err != nil {
 		return exec.AsValue(fmt.Errorf("title: %w", err))
 	}
-	return exec.AsValue(cases.Title(language.English).String(in.String()))
+	return exec.AsValue(titleCaser.String(in.String()))
 }
 
 // Inflection filters

--- a/internal/template/filters_test.go
+++ b/internal/template/filters_test.go
@@ -26,7 +26,7 @@ func TestUT_FilterSnake(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tmpl := `{{ name|snake }}`
-			ctx := NewContext(tt.input, nil, nil)
+			ctx := NewContext(tt.input, nil)
 			result, err := engine.ExecuteToString(tmpl, ctx)
 			require.NoError(t, err)
 			assert.Equal(t, tt.expected, result)
@@ -52,7 +52,7 @@ func TestUT_FilterPascal(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tmpl := `{{ name|pascal }}`
-			ctx := NewContext(tt.input, nil, nil)
+			ctx := NewContext(tt.input, nil)
 			result, err := engine.ExecuteToString(tmpl, ctx)
 			require.NoError(t, err)
 			assert.Equal(t, tt.expected, result)
@@ -77,7 +77,7 @@ func TestUT_FilterCamel(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tmpl := `{{ name|camel }}`
-			ctx := NewContext(tt.input, nil, nil)
+			ctx := NewContext(tt.input, nil)
 			result, err := engine.ExecuteToString(tmpl, ctx)
 			require.NoError(t, err)
 			assert.Equal(t, tt.expected, result)
@@ -101,7 +101,7 @@ func TestUT_FilterKebab(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tmpl := `{{ name|kebab }}`
-			ctx := NewContext(tt.input, nil, nil)
+			ctx := NewContext(tt.input, nil)
 			result, err := engine.ExecuteToString(tmpl, ctx)
 			require.NoError(t, err)
 			assert.Equal(t, tt.expected, result)
@@ -123,7 +123,7 @@ func TestUT_FilterLower(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
 			tmpl := `{{ name|lower }}`
-			ctx := NewContext(tt.input, nil, nil)
+			ctx := NewContext(tt.input, nil)
 			result, err := engine.ExecuteToString(tmpl, ctx)
 			require.NoError(t, err)
 			assert.Equal(t, tt.expected, result)
@@ -145,7 +145,7 @@ func TestUT_FilterUpper(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
 			tmpl := `{{ name|upper }}`
-			ctx := NewContext(tt.input, nil, nil)
+			ctx := NewContext(tt.input, nil)
 			result, err := engine.ExecuteToString(tmpl, ctx)
 			require.NoError(t, err)
 			assert.Equal(t, tt.expected, result)
@@ -167,7 +167,7 @@ func TestUT_FilterTitle(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
 			tmpl := `{{ name|title }}`
-			ctx := NewContext(tt.input, nil, nil)
+			ctx := NewContext(tt.input, nil)
 			result, err := engine.ExecuteToString(tmpl, ctx)
 			require.NoError(t, err)
 			assert.Equal(t, tt.expected, result)
@@ -191,7 +191,7 @@ func TestUT_FilterPlural(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
 			tmpl := `{{ name|plural }}`
-			ctx := NewContext(tt.input, nil, nil)
+			ctx := NewContext(tt.input, nil)
 			result, err := engine.ExecuteToString(tmpl, ctx)
 			require.NoError(t, err)
 			assert.Equal(t, tt.expected, result)
@@ -214,7 +214,7 @@ func TestUT_FilterSingular(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
 			tmpl := `{{ name|singular }}`
-			ctx := NewContext(tt.input, nil, nil)
+			ctx := NewContext(tt.input, nil)
 			result, err := engine.ExecuteToString(tmpl, ctx)
 			require.NoError(t, err)
 			assert.Equal(t, tt.expected, result)
@@ -243,7 +243,7 @@ func TestUT_FilterOrdinalize(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
 			tmpl := `{{ name|ordinalize }}`
-			ctx := NewContext(tt.input, nil, nil)
+			ctx := NewContext(tt.input, nil)
 			result, err := engine.ExecuteToString(tmpl, ctx)
 			require.NoError(t, err)
 			assert.Equal(t, tt.expected, result)
@@ -265,7 +265,7 @@ func TestUT_FilterTitleize(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
 			tmpl := `{{ name|titleize }}`
-			ctx := NewContext(tt.input, nil, nil)
+			ctx := NewContext(tt.input, nil)
 			result, err := engine.ExecuteToString(tmpl, ctx)
 			require.NoError(t, err)
 			assert.Equal(t, tt.expected, result)
@@ -287,7 +287,7 @@ func TestUT_FilterHumanize(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
 			tmpl := `{{ name|humanize }}`
-			ctx := NewContext(tt.input, nil, nil)
+			ctx := NewContext(tt.input, nil)
 			result, err := engine.ExecuteToString(tmpl, ctx)
 			require.NoError(t, err)
 			assert.Equal(t, tt.expected, result)
@@ -300,7 +300,7 @@ func TestUT_FilterSplit(t *testing.T) {
 
 	t.Run("split by comma", func(t *testing.T) {
 		tmpl := `{% for item in name|split(",") %}{{ item }};{% endfor %}`
-		ctx := NewContext("a,b,c", nil, nil)
+		ctx := NewContext("a,b,c", nil)
 		result, err := engine.ExecuteToString(tmpl, ctx)
 		require.NoError(t, err)
 		assert.Equal(t, "a;b;c;", result)
@@ -308,7 +308,7 @@ func TestUT_FilterSplit(t *testing.T) {
 
 	t.Run("split by whitespace default", func(t *testing.T) {
 		tmpl := `{% for item in name|split %}{{ item }};{% endfor %}`
-		ctx := NewContext("a b c", nil, nil)
+		ctx := NewContext("a b c", nil)
 		result, err := engine.ExecuteToString(tmpl, ctx)
 		require.NoError(t, err)
 		assert.Equal(t, "a;b;c;", result)
@@ -340,7 +340,7 @@ func TestUT_FilterContains(t *testing.T) {
 
 	t.Run("contains substring", func(t *testing.T) {
 		tmpl := `{% if name|contains("world") %}yes{% else %}no{% endif %}`
-		ctx := NewContext("hello world", nil, nil)
+		ctx := NewContext("hello world", nil)
 		result, err := engine.ExecuteToString(tmpl, ctx)
 		require.NoError(t, err)
 		assert.Equal(t, "yes", result)
@@ -348,7 +348,7 @@ func TestUT_FilterContains(t *testing.T) {
 
 	t.Run("does not contain", func(t *testing.T) {
 		tmpl := `{% if name|contains("xyz") %}yes{% else %}no{% endif %}`
-		ctx := NewContext("hello world", nil, nil)
+		ctx := NewContext("hello world", nil)
 		result, err := engine.ExecuteToString(tmpl, ctx)
 		require.NoError(t, err)
 		assert.Equal(t, "no", result)
@@ -360,7 +360,7 @@ func TestUT_FilterHasPrefix(t *testing.T) {
 
 	t.Run("has prefix", func(t *testing.T) {
 		tmpl := `{% if name|hasprefix("hello") %}yes{% else %}no{% endif %}`
-		ctx := NewContext("hello world", nil, nil)
+		ctx := NewContext("hello world", nil)
 		result, err := engine.ExecuteToString(tmpl, ctx)
 		require.NoError(t, err)
 		assert.Equal(t, "yes", result)
@@ -368,7 +368,7 @@ func TestUT_FilterHasPrefix(t *testing.T) {
 
 	t.Run("does not have prefix", func(t *testing.T) {
 		tmpl := `{% if name|hasprefix("world") %}yes{% else %}no{% endif %}`
-		ctx := NewContext("hello world", nil, nil)
+		ctx := NewContext("hello world", nil)
 		result, err := engine.ExecuteToString(tmpl, ctx)
 		require.NoError(t, err)
 		assert.Equal(t, "no", result)
@@ -380,7 +380,7 @@ func TestUT_FilterHasSuffix(t *testing.T) {
 
 	t.Run("has suffix", func(t *testing.T) {
 		tmpl := `{% if name|hassuffix("world") %}yes{% else %}no{% endif %}`
-		ctx := NewContext("hello world", nil, nil)
+		ctx := NewContext("hello world", nil)
 		result, err := engine.ExecuteToString(tmpl, ctx)
 		require.NoError(t, err)
 		assert.Equal(t, "yes", result)
@@ -388,7 +388,7 @@ func TestUT_FilterHasSuffix(t *testing.T) {
 
 	t.Run("does not have suffix", func(t *testing.T) {
 		tmpl := `{% if name|hassuffix("hello") %}yes{% else %}no{% endif %}`
-		ctx := NewContext("hello world", nil, nil)
+		ctx := NewContext("hello world", nil)
 		result, err := engine.ExecuteToString(tmpl, ctx)
 		require.NoError(t, err)
 		assert.Equal(t, "no", result)
@@ -400,7 +400,7 @@ func TestUT_FilterReplace(t *testing.T) {
 
 	t.Run("replace substring", func(t *testing.T) {
 		tmpl := `{{ name|replace("world", "universe") }}`
-		ctx := NewContext("hello world", nil, nil)
+		ctx := NewContext("hello world", nil)
 		result, err := engine.ExecuteToString(tmpl, ctx)
 		require.NoError(t, err)
 		assert.Equal(t, "hello universe", result)
@@ -408,7 +408,7 @@ func TestUT_FilterReplace(t *testing.T) {
 
 	t.Run("replace multiple occurrences", func(t *testing.T) {
 		tmpl := `{{ name|replace("o", "0") }}`
-		ctx := NewContext("hello world", nil, nil)
+		ctx := NewContext("hello world", nil)
 		result, err := engine.ExecuteToString(tmpl, ctx)
 		require.NoError(t, err)
 		assert.Equal(t, "hell0 w0rld", result)
@@ -420,7 +420,7 @@ func TestUT_FilterTrim(t *testing.T) {
 
 	t.Run("trim whitespace", func(t *testing.T) {
 		tmpl := `{{ name|trim }}`
-		ctx := NewContext("  hello world  ", nil, nil)
+		ctx := NewContext("  hello world  ", nil)
 		result, err := engine.ExecuteToString(tmpl, ctx)
 		require.NoError(t, err)
 		assert.Equal(t, "hello world", result)
@@ -428,7 +428,7 @@ func TestUT_FilterTrim(t *testing.T) {
 
 	t.Run("trim specific chars", func(t *testing.T) {
 		tmpl := `{{ name|trim("x") }}`
-		ctx := NewContext("xxxhelloxxx", nil, nil)
+		ctx := NewContext("xxxhelloxxx", nil)
 		result, err := engine.ExecuteToString(tmpl, ctx)
 		require.NoError(t, err)
 		assert.Equal(t, "hello", result)
@@ -440,7 +440,7 @@ func TestUT_FilterDefault(t *testing.T) {
 
 	t.Run("use default for empty", func(t *testing.T) {
 		tmpl := `{{ name|default("fallback") }}`
-		ctx := NewContext("", nil, nil)
+		ctx := NewContext("", nil)
 		result, err := engine.ExecuteToString(tmpl, ctx)
 		require.NoError(t, err)
 		assert.Equal(t, "fallback", result)
@@ -448,7 +448,7 @@ func TestUT_FilterDefault(t *testing.T) {
 
 	t.Run("use value when present", func(t *testing.T) {
 		tmpl := `{{ name|default("fallback") }}`
-		ctx := NewContext("hello", nil, nil)
+		ctx := NewContext("hello", nil)
 		result, err := engine.ExecuteToString(tmpl, ctx)
 		require.NoError(t, err)
 		assert.Equal(t, "hello", result)
@@ -460,7 +460,7 @@ func TestUT_FilterTruncate(t *testing.T) {
 
 	t.Run("truncate with ellipsis", func(t *testing.T) {
 		tmpl := `{{ name|truncate(5) }}`
-		ctx := NewContext("hello world", nil, nil)
+		ctx := NewContext("hello world", nil)
 		result, err := engine.ExecuteToString(tmpl, ctx)
 		require.NoError(t, err)
 		assert.Equal(t, "hello...", result)
@@ -468,7 +468,7 @@ func TestUT_FilterTruncate(t *testing.T) {
 
 	t.Run("truncate with custom ending", func(t *testing.T) {
 		tmpl := `{{ name|truncate(5, "!") }}`
-		ctx := NewContext("hello world", nil, nil)
+		ctx := NewContext("hello world", nil)
 		result, err := engine.ExecuteToString(tmpl, ctx)
 		require.NoError(t, err)
 		assert.Equal(t, "hello!", result)
@@ -476,7 +476,7 @@ func TestUT_FilterTruncate(t *testing.T) {
 
 	t.Run("no truncate when short enough", func(t *testing.T) {
 		tmpl := `{{ name|truncate(20) }}`
-		ctx := NewContext("hello", nil, nil)
+		ctx := NewContext("hello", nil)
 		result, err := engine.ExecuteToString(tmpl, ctx)
 		require.NoError(t, err)
 		assert.Equal(t, "hello", result)
@@ -485,7 +485,7 @@ func TestUT_FilterTruncate(t *testing.T) {
 	t.Run("truncate UTF-8 multi-byte characters correctly", func(t *testing.T) {
 		tmpl := `{{ name|truncate(3) }}`
 		// Use emoji which are multi-byte UTF-8 characters
-		ctx := NewContext("🎉🎊🎈🎁", nil, nil)
+		ctx := NewContext("🎉🎊🎈🎁", nil)
 		result, err := engine.ExecuteToString(tmpl, ctx)
 		require.NoError(t, err)
 		// Should truncate by rune count, not byte count
@@ -494,7 +494,7 @@ func TestUT_FilterTruncate(t *testing.T) {
 
 	t.Run("truncate CJK characters correctly", func(t *testing.T) {
 		tmpl := `{{ name|truncate(2) }}`
-		ctx := NewContext("你好世界", nil, nil)
+		ctx := NewContext("你好世界", nil)
 		result, err := engine.ExecuteToString(tmpl, ctx)
 		require.NoError(t, err)
 		assert.Equal(t, "你好...", result)
@@ -506,7 +506,7 @@ func TestUT_FilterChaining(t *testing.T) {
 
 	t.Run("snake then upper", func(t *testing.T) {
 		tmpl := `{{ name|snake|upper }}`
-		ctx := NewContext("HelloWorld", nil, nil)
+		ctx := NewContext("HelloWorld", nil)
 		result, err := engine.ExecuteToString(tmpl, ctx)
 		require.NoError(t, err)
 		assert.Equal(t, "HELLO_WORLD", result)
@@ -514,7 +514,7 @@ func TestUT_FilterChaining(t *testing.T) {
 
 	t.Run("plural then pascal", func(t *testing.T) {
 		tmpl := `{{ name|plural|pascal }}`
-		ctx := NewContext("user", nil, nil)
+		ctx := NewContext("user", nil)
 		result, err := engine.ExecuteToString(tmpl, ctx)
 		require.NoError(t, err)
 		assert.Equal(t, "Users", result)
@@ -526,7 +526,7 @@ func TestUT_FilterAliases(t *testing.T) {
 
 	t.Run("snake_case alias", func(t *testing.T) {
 		tmpl := `{{ name|snake_case }}`
-		ctx := NewContext("HelloWorld", nil, nil)
+		ctx := NewContext("HelloWorld", nil)
 		result, err := engine.ExecuteToString(tmpl, ctx)
 		require.NoError(t, err)
 		assert.Equal(t, "hello_world", result)
@@ -534,7 +534,7 @@ func TestUT_FilterAliases(t *testing.T) {
 
 	t.Run("pluralize alias", func(t *testing.T) {
 		tmpl := `{{ name|pluralize }}`
-		ctx := NewContext("user", nil, nil)
+		ctx := NewContext("user", nil)
 		result, err := engine.ExecuteToString(tmpl, ctx)
 		require.NoError(t, err)
 		assert.Equal(t, "users", result)

--- a/internal/template/loader_test.go
+++ b/internal/template/loader_test.go
@@ -175,7 +175,7 @@ func TestUT_Loader_Integration_WithEngine(t *testing.T) {
 	tmpl, err := engine.ParseFile("greeting.tmpl")
 	require.NoError(t, err)
 
-	ctx := NewContext("World", nil, nil)
+	ctx := NewContext("World", nil)
 	result, err := tmpl.Execute(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, "Hello, World!", result)

--- a/internal/template/metadata_test.go
+++ b/internal/template/metadata_test.go
@@ -397,7 +397,7 @@ func TestUT_RenderAndParseMetadata(t *testing.T) {
 	require.NoError(t, err)
 
 	metaRaw := "to: {{ name|snake }}/{{ name|snake }}.go\nappend: true"
-	ctx := NewContext("MyService", nil, nil)
+	ctx := NewContext("MyService", nil)
 
 	meta, err := engine.RenderAndParseMetadata(metaRaw, ctx)
 
@@ -411,7 +411,7 @@ func TestUT_RenderAndParseMetadata_WithVars(t *testing.T) {
 	require.NoError(t, err)
 
 	metaRaw := "to: {{ vars.output_dir }}/{{ name }}.go"
-	ctx := NewContext("handler", map[string]any{"output_dir": "pkg/handlers"}, nil)
+	ctx := NewContext("handler", map[string]any{"output_dir": "pkg/handlers"})
 
 	meta, err := engine.RenderAndParseMetadata(metaRaw, ctx)
 
@@ -424,7 +424,7 @@ func TestUT_RenderAndParseMetadata_WithNameOptions(t *testing.T) {
 	require.NoError(t, err)
 
 	metaRaw := "to: {{ n.snake_case }}/{{ n.pascal_case }}.go"
-	ctx := NewContext("user-service", nil, nil)
+	ctx := NewContext("user-service", nil)
 
 	meta, err := engine.RenderAndParseMetadata(metaRaw, ctx)
 
@@ -438,7 +438,7 @@ func TestUT_RenderAndParseMetadata_UndefinedVarReturnsEmpty(t *testing.T) {
 
 	// Undefined variable returns empty string in Gonja
 	metaRaw := "to: {{ undefined_var }}/file.go"
-	ctx := NewContext("test", nil, nil)
+	ctx := NewContext("test", nil)
 
 	meta, err := engine.RenderAndParseMetadata(metaRaw, ctx)
 
@@ -453,7 +453,7 @@ func TestUT_RenderAndParseMetadata_InvalidSyntax(t *testing.T) {
 
 	// Invalid Jinja2 syntax should error
 	metaRaw := "to: {{ name|invalid_filter }}/file.go"
-	ctx := NewContext("test", nil, nil)
+	ctx := NewContext("test", nil)
 
 	_, err = engine.RenderAndParseMetadata(metaRaw, ctx)
 

--- a/internal/template/types.go
+++ b/internal/template/types.go
@@ -7,17 +7,6 @@ package template
 // It provides data to templates through multiple namespaces.
 type Context map[string]any
 
-// NameOptions contains pre-computed name variants for convenience.
-// These are available in templates via the "n" namespace.
-type NameOptions struct {
-	SnakeCase  string
-	PascalCase string
-	CamelCase  string
-	KebabCase  string
-	LowerCase  string
-	UpperCase  string
-}
-
 // Template represents a parsed template ready for execution.
 type Template interface {
 	// Execute renders the template with the given context.

--- a/internal/writer/write_files.go
+++ b/internal/writer/write_files.go
@@ -2,7 +2,6 @@ package writer
 
 import (
 	"io/fs"
-	"log/slog"
 	"os"
 	"path/filepath"
 	"sync"
@@ -35,10 +34,5 @@ func (f *fileWrite) OpenFile(name string, flag int, perm fs.FileMode) (*os.File,
 }
 
 func (f *fileWrite) Write(file *os.File, b []byte) (n int, err error) {
-	defer func() {
-		if err := file.Close(); err != nil {
-			slog.Error("cannot close file", "file", file.Name(), "error", err)
-		}
-	}()
 	return file.Write(b)
 }

--- a/internal/writer/write_logs.go
+++ b/internal/writer/write_logs.go
@@ -28,5 +28,5 @@ func (f *fileLog) OpenFile(name string, flag int, perm fs.FileMode) (*os.File, e
 
 func (f *fileLog) Write(file *os.File, b []byte) (n int, err error) {
 	slog.Info("logging to console", "file", file.Name(), "data", fmt.Sprintf("\n%s", string(b)))
-	return 0, nil
+	return len(b), nil
 }

--- a/internal/writer/writer.go
+++ b/internal/writer/writer.go
@@ -69,6 +69,13 @@ func (w *Write) AppendFile(name string, data []byte) error {
 		slog.Error("cannot open file", "file", name, "error", err)
 		return err
 	}
+	if file != nil {
+		defer func() {
+			if err := file.Close(); err != nil {
+				slog.Error("cannot close file", "file", file.Name(), "error", err)
+			}
+		}()
+	}
 	if _, err := w.fs.Write(file, data); err != nil {
 		slog.Error("cannot append data to file", "file", file, "error", err)
 		return err


### PR DESCRIPTION
## Summary

- **Phase 1 - Dead code removal** (-102 lines net): Remove unused `NameOptions` struct, `NewNameOptions`, `WithNameOptions`, `Context.Set/Get/Merge`, `ErrFilter`, `NewFilterError`. Simplify `NewContext` to 2 params.
- **Phase 2 - Correctness fixes**: Fix `fileLog.Write` return value, move `file.Close()` to caller, wrap `initAction` errors with `app.Errorf`, fix `LoadConfigFile` nil return on missing file, fix `isZipFile` to use `filepath.Ext`.
- **Phase 3 - Engine assembly extraction**: Extract engine construction into `engine.NewGenerator()`/`NewGeneratorWithEngine()`. Bundle generators now share a single `template.Engine` and its cache (was creating N engines for N generators).
- **Phase 4 - API hygiene**: Extract `PrintHookResults` helper (was 3 duplicate sites), rename `scaffold.TemplateError` → `FileProcessingError` to avoid collision with `template.TemplateError`.
- **Phase 6 - Performance**: Replace SHA-256 with FNV-1a for cache keys, cache `cases.Title` caser at package level.

25 files changed, 202 insertions, 303 deletions. All tests pass, `go vet` clean.

## Test plan

- [x] `go test ./...` — all packages pass
- [x] `go vet ./...` — clean
- [x] `go build ./...` — compiles successfully
- [ ] Verify `tag generate` works for single generators
- [ ] Verify `tag generate --bundle` works with shared engine
- [ ] Verify `tag scaffold` still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)