### PR TITLE
fix: reparse trailing flags silently ignored after positional args

### DIFF
--- a/internal/commands/flags.go
+++ b/internal/commands/flags.go
@@ -1,10 +1,103 @@
 package commands
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/urfave/cli/v2"
 
 	"github.com/kaikenlabs/tag/internal/scaffold"
 )
+
+// reparseTrailingFlags rescans c.Args() for flag-like tokens that Go's flag
+// parser silently dropped (it stops at the first non-flag argument).
+// Recognised flags are applied via c.Set(); the remaining positional arguments
+// are returned.
+func reparseTrailingFlags(c *cli.Context, flags []cli.Flag) ([]string, error) {
+	args := c.Args().Slice()
+
+	// Build lookup tables:
+	// - boolFlags: names/aliases that are boolean (set to "true", no value consumed)
+	// - canonical: maps every name/alias → primary (first) name
+	//
+	// We always c.Set the canonical name because urfave/cli v2 registers
+	// separate flag.Value instances per name when Destination is nil,
+	// so setting an alias doesn't update the canonical name's value.
+	boolFlags := make(map[string]bool)
+	canonical := make(map[string]string)
+
+	for _, f := range flags {
+		names := f.Names()
+		if len(names) == 0 {
+			continue
+		}
+		primary := names[0]
+		for _, n := range names {
+			canonical[n] = primary
+		}
+		if _, ok := f.(*cli.BoolFlag); ok {
+			for _, n := range names {
+				boolFlags[n] = true
+			}
+		}
+	}
+
+	var positional []string
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+
+		// "--" terminates flag parsing; everything after is positional.
+		if arg == "--" {
+			positional = append(positional, args[i+1:]...)
+			break
+		}
+
+		// Not a flag → positional argument.
+		if !strings.HasPrefix(arg, "-") {
+			positional = append(positional, arg)
+			continue
+		}
+
+		// Strip leading dashes to get the flag name.
+		flagName := strings.TrimLeft(arg, "-")
+
+		// Handle --flag=value / -flag=value.
+		if name, val, ok := strings.Cut(flagName, "="); ok {
+			setName := canonical[name]
+			if setName == "" {
+				setName = name
+			}
+			if err := c.Set(setName, val); err != nil {
+				return nil, fmt.Errorf("setting flag %s: %w", name, err)
+			}
+			continue
+		}
+
+		// Resolve to canonical name for c.Set.
+		setName := canonical[flagName]
+		if setName == "" {
+			setName = flagName
+		}
+
+		// Boolean flag → set to "true".
+		if boolFlags[flagName] {
+			if err := c.Set(setName, "true"); err != nil {
+				return nil, fmt.Errorf("setting flag %s: %w", flagName, err)
+			}
+			continue
+		}
+
+		// Value flag → consume the next argument.
+		if i+1 >= len(args) {
+			return nil, fmt.Errorf("flag -%s requires a value", flagName)
+		}
+		i++
+		if err := c.Set(setName, args[i]); err != nil {
+			return nil, fmt.Errorf("setting flag %s: %w", flagName, err)
+		}
+	}
+	return positional, nil
+}
 
 // commonScaffoldFlags returns flags shared between the scaffold and run commands.
 func commonScaffoldFlags() []cli.Flag {

--- a/internal/commands/flags_test.go
+++ b/internal/commands/flags_test.go
@@ -1,0 +1,150 @@
+package commands
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+)
+
+// newTestContext creates a cli.Context with the given flags registered and args parsed.
+// Flags are parsed first (Go's flag package stops at the first non-flag), so all args
+// after the first positional arg become c.Args() — exactly the scenario we need to test.
+func newTestContext(t *testing.T, flags []cli.Flag, args []string) *cli.Context {
+	t.Helper()
+
+	app := &cli.App{Flags: flags}
+	set := flag.NewFlagSet("test", flag.ContinueOnError)
+	for _, f := range flags {
+		require.NoError(t, f.Apply(set))
+	}
+	// Parse: Go stops at the first non-flag token, so trailing flags end up in Args().
+	require.NoError(t, set.Parse(args))
+	return cli.NewContext(app, set, nil)
+}
+
+func TestUT_ReparseTrailingFlags(t *testing.T) {
+	// Shared flag definitions used across tests.
+	testFlags := func() []cli.Flag {
+		return []cli.Flag{
+			&cli.StringSliceFlag{Name: "meta", Aliases: []string{"m"}},
+			&cli.BoolFlag{Name: "no-input"},
+			&cli.BoolFlag{Name: "accept-hooks"},
+			&cli.BoolFlag{Name: "force", Aliases: []string{"f"}},
+			&cli.StringFlag{Name: "output", Aliases: []string{"o"}},
+			&cli.BoolFlag{Name: "no-save"},
+		}
+	}
+
+	tests := []struct {
+		name            string
+		args            []string // raw args (simulating what the user typed)
+		wantPositional  []string
+		wantMeta        []string
+		wantNoInput     bool
+		wantAcceptHooks bool
+		wantForce       bool
+		wantOutput      string
+		wantErr         string
+	}{
+		{
+			name:            "flags after positional args",
+			args:            []string{"my-template", "my-project", "-m", "key=val", "--no-input", "--accept-hooks"},
+			wantPositional:  []string{"my-template", "my-project"},
+			wantMeta:        []string{"key=val"},
+			wantNoInput:     true,
+			wantAcceptHooks: true,
+		},
+		{
+			name:           "flags before positional args (already parsed by Go)",
+			args:           []string{"-m", "key=val", "--no-input", "my-template"},
+			wantPositional: []string{"my-template"},
+			wantMeta:       []string{"key=val"},
+			wantNoInput:    true,
+		},
+		{
+			name:            "mixed flags and positional args",
+			args:            []string{"my-template", "-m", "a=1", "my-project", "--no-input", "--accept-hooks"},
+			wantPositional:  []string{"my-template", "my-project"},
+			wantMeta:        []string{"a=1"},
+			wantNoInput:     true,
+			wantAcceptHooks: true,
+		},
+		{
+			name:           "equals syntax",
+			args:           []string{"my-template", "--output=/tmp/out", "--force"},
+			wantPositional: []string{"my-template"},
+			wantOutput:     "/tmp/out",
+			wantForce:      true,
+		},
+		{
+			name:           "multiple meta flags",
+			args:           []string{"tpl", "proj", "-m", "a=1", "-m", "b=2"},
+			wantPositional: []string{"tpl", "proj"},
+			wantMeta:       []string{"a=1", "b=2"},
+		},
+		{
+			name:           "short alias for boolean flag",
+			args:           []string{"tpl", "-f"},
+			wantPositional: []string{"tpl"},
+			wantForce:      true,
+		},
+		{
+			name:           "short alias for value flag",
+			args:           []string{"tpl", "-o", "/tmp/x"},
+			wantPositional: []string{"tpl"},
+			wantOutput:     "/tmp/x",
+		},
+		{
+			name:           "double-dash stops flag parsing",
+			args:           []string{"tpl", "--", "--no-input", "-m", "x=y"},
+			wantPositional: []string{"tpl", "--no-input", "-m", "x=y"},
+		},
+		{
+			name:           "no trailing flags (positional only)",
+			args:           []string{"tpl", "proj"},
+			wantPositional: []string{"tpl", "proj"},
+		},
+		{
+			name:    "value flag missing argument",
+			args:    []string{"tpl", "-o"},
+			wantErr: "flag -o requires a value",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flags := testFlags()
+			c := newTestContext(t, flags, tt.args)
+
+			positional, err := reparseTrailingFlags(c, flags)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantPositional, positional)
+
+			if len(tt.wantMeta) > 0 {
+				assert.Equal(t, tt.wantMeta, c.StringSlice("meta"))
+			}
+			if tt.wantNoInput {
+				assert.True(t, c.Bool("no-input"))
+			}
+			if tt.wantAcceptHooks {
+				assert.True(t, c.Bool("accept-hooks"))
+			}
+			if tt.wantForce {
+				assert.True(t, c.Bool("force"))
+			}
+			if tt.wantOutput != "" {
+				assert.Equal(t, tt.wantOutput, c.String("output"))
+			}
+		})
+	}
+}

--- a/internal/commands/run.go
+++ b/internal/commands/run.go
@@ -40,19 +40,24 @@ EXAMPLES:
 }
 
 func runAction(c *cli.Context) error {
+	positional, err := reparseTrailingFlags(c, commonScaffoldFlags())
+	if err != nil {
+		return app.Errorf("invalid flags: %w", err)
+	}
+
 	lib, err := newLocalLibrary()
 	if err != nil {
 		return app.Errorf("failed to initialize library: %w", err)
 	}
 
-	templateName, err := resolveTemplateName(c, lib)
+	templateName, err := resolveTemplateName(c, lib, positional)
 	if err != nil {
 		return err
 	}
 
 	projectName := ""
-	if c.NArg() >= 2 {
-		projectName = c.Args().Get(1)
+	if len(positional) >= 2 {
+		projectName = positional[1]
 	}
 
 	// Get entry first — provides both path and source in one lookup
@@ -94,11 +99,11 @@ func runAction(c *cli.Context) error {
 	return nil
 }
 
-// resolveTemplateName determines the template name from args or interactive picker.
-func resolveTemplateName(c *cli.Context, lib *library.Library) (string, error) {
+// resolveTemplateName determines the template name from positional args or interactive picker.
+func resolveTemplateName(c *cli.Context, lib *library.Library, positional []string) (string, error) {
 	switch {
-	case c.NArg() >= 1:
-		return c.Args().Get(0), nil
+	case len(positional) >= 1:
+		return positional[0], nil
 	case scaffold.IsTTY() && !c.Bool("no-input"):
 		return pickTemplate(lib)
 	default:

--- a/internal/commands/scaffold.go
+++ b/internal/commands/scaffold.go
@@ -65,23 +65,27 @@ Examples:
 
   # Scaffold without saving replay data
   tag scaffold gh:user/template test-project --no-save`,
-		Flags: append(commonScaffoldFlags(), &cli.BoolFlag{
-			Name:    "update",
-			Aliases: []string{"u"},
-			Usage:   "Force refresh of cached remote templates",
-		}),
+		Flags:  scaffoldFlags(),
 		Action: scaffoldAction,
 	}
 }
 
 func scaffoldAction(c *cli.Context) error {
+	positional, err := reparseTrailingFlags(c, scaffoldFlags())
+	if err != nil {
+		return app.Errorf("invalid flags: %w", err)
+	}
+
 	// Validate arguments
-	if c.NArg() < 1 {
+	if len(positional) < 1 {
 		return app.Errorf("template path is required\n\nUsage: tag scaffold <template> [project-name]")
 	}
 
-	templateRef := c.Args().Get(0)
-	projectName := c.Args().Get(1) // May be empty
+	templateRef := positional[0]
+	projectName := ""
+	if len(positional) >= 2 {
+		projectName = positional[1]
+	}
 
 	// Resolve template reference (handles both local and remote)
 	resolver, err := remote.NewResolver()
@@ -127,6 +131,15 @@ func scaffoldAction(c *cli.Context) error {
 	}
 
 	return nil
+}
+
+// scaffoldFlags returns the full set of flags for the scaffold command.
+func scaffoldFlags() []cli.Flag {
+	return append(commonScaffoldFlags(), &cli.BoolFlag{
+		Name:    "update",
+		Aliases: []string{"u"},
+		Usage:   "Force refresh of cached remote templates",
+	})
 }
 
 // handleCookiecutterDetection handles the case when a Cookiecutter template is detected.


### PR DESCRIPTION
## Summary

- Go's `flag.FlagSet.Parse()` stops at the first non-flag argument, causing urfave/cli v2 to silently ignore flags placed after positional args (e.g. `tag run my-template proj -m key=val --accept-hooks`)
- Added `reparseTrailingFlags()` helper that rescans `c.Args()` for unparsed flag tokens and applies them via `c.Set()`, returning only true positional args
- Applied to both `run` and `scaffold` commands
- Aliases are mapped to canonical names since urfave/cli v2 registers separate `flag.Value` instances per name

## Test plan

- [x] Unit tests for `reparseTrailingFlags` covering: trailing flags, leading flags, mixed ordering, `--flag=value`, multiple `-m` flags, short aliases, `--` terminator, missing value error
- [ ] Manual: `./tag run <template> <name> -m key=val --no-input --accept-hooks`
- [ ] Manual: `./tag scaffold ./template <name> -m key=val --no-input --accept-hooks`
- [ ] Manual: flags before positional args still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)