### PR TITLE
feat: Sprint 2 — Security & UX Core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **BREAKING**: Template syntax (`{{ }}`, `{% %}`, `{# #}`) in user-provided variable values is no longer rendered during path processing. This prevents Server-Side Template Injection (SSTI) attacks. Derived variables (whose defaults are template expressions) are still resolved. Use `--allow-recursive-render` to restore the previous behavior if your templates rely on recursive rendering of user input.
+- **BREAKING**: `config.CreateConfigFile` no longer accepts `*cli.Context`; it takes a `CreateConfigOptions` struct instead, decoupling the config package from the CLI framework (#145)
+- Semantic exit codes: usage errors return exit code 2, not-found errors return 3, interrupted (Ctrl-C) returns 130 (#143)
 
 ### Added
 
 - `--allow-recursive-render` flag for `tag scaffold` to opt in to the previous recursive rendering behavior
+- SSTI mitigation for file content rendering — template syntax in user-provided variable values is escaped before content rendering, not just path processing (#142)
+- Semantic exit codes via `ExitCoder` interface: 0 (OK), 1 (general), 2 (usage), 3 (not found), 130 (interrupted) (#143)
+- Rich help text for `tag generate` command with arguments, flags, and examples (#144)
+- Generate hooks now receive scaffold variables as `TAG_VAR_*` environment variables and `TAG_PROJECT_NAME` (#146)
 - Unified path containment validation via `fileutil.ValidatePathContainment` with symlink resolution
 - Symlink detection in template file loading (`LoadTemplateFiles`)
 - HTTPS enforcement for remote ZIP template URLs (HTTP rejected)
@@ -21,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Fix SSTI vulnerability in file content rendering — extends existing path protection to template body output (#142)
 - Fix SSTI vulnerability in path processor recursive rendering (#71)
 - Fix TOCTOU race condition in symlink check during scaffolding (#72)
 - Add symlink detection in template loader (#74)

--- a/docs/commands/generate.md
+++ b/docs/commands/generate.md
@@ -260,6 +260,17 @@ Hooks defined in `.tagconfig.json` run automatically:
 
 Generate hooks use direct argv execution (no shell interpretation), which is safer than shell-based execution. Each hook has a **5-minute timeout** and output is limited to **1 MB**.
 
+### Hook Environment Variables
+
+Generate hooks receive scaffold-time variables (from `.tagconfig.json`) as environment variables:
+
+| Variable | Description |
+|----------|-------------|
+| `TAG_PROJECT_NAME` | Value of the `project_name` variable (if set) |
+| `TAG_VAR_<NAME>` | Each scaffold variable as `TAG_VAR_` + uppercase name |
+
+This allows hooks to access project context — for example, a post-generation formatter can read `TAG_VAR_PROJECT_NAME` to determine the project name. See the [Hooks Guide](../templates/hooks.md#generate-hooks) for details.
+
 ## Frontmatter Reference
 
 The `---` block at the top of every generator file controls how and where the output is written. Lines starting with `#` are treated as comments and ignored.

--- a/docs/templates/hooks.md
+++ b/docs/templates/hooks.md
@@ -466,6 +466,49 @@ Python hooks are executed using the system's `python3` (or `python`) interpreter
 
 > **Note**: TAG tries `python3` first, then `python`. If neither is installed, the hook will fail with a clear "command not found" error.
 
+## Generate Hooks
+
+The `tag generate` command also supports pre and post hooks, defined in `.tagconfig.json` under `hooks.pre` and `hooks.post`. These hooks run before and after code generation, similar to scaffold hooks.
+
+### Environment Variables
+
+Generate hooks receive scaffold-time variables as environment variables:
+
+| Environment Variable | Description |
+|---------------------|-------------|
+| `TAG_PROJECT_NAME` | Value of the `project_name` variable (if set) |
+| `TAG_VAR_<NAME>` | Each scaffold variable as `TAG_VAR_` + uppercase name |
+
+Variable names follow the same transformation rules as scaffold hooks (uppercase, non-alphanumeric characters become underscores).
+
+> **Note**: Generate hooks do **not** receive `TAG_TEMPLATE_DIR` or `TAG_OUTPUT_DIR` — those are scaffold-specific.
+
+### Example
+
+```json
+{
+  "hooks": {
+    "post": [
+      ["gofmt", "-w", "."],
+      ["goimports", "-w", "."]
+    ]
+  }
+}
+```
+
+```bash
+# In a post-generation hook script:
+echo "Formatting code for $TAG_PROJECT_NAME..."
+```
+
+### Skipping Hooks
+
+Use `--no-hooks` to skip hook execution:
+
+```bash
+tag generate model User --no-hooks
+```
+
 ## See Also
 
 - [Template Authoring](authoring.md) - Complete template guide

--- a/internal/commands/bundle.go
+++ b/internal/commands/bundle.go
@@ -44,7 +44,7 @@ func templateNewBundleCommand(cfg *config.Config) *cli.Command {
 
 func bundleAction(c *cli.Context, cfg *config.Config) error {
 	if c.Args().Len() == 0 {
-		return app.Errorf("please provide the bundle name")
+		return app.UsageErrorf("please provide the bundle name")
 	}
 	bundleName := c.Args().Get(0)
 

--- a/internal/commands/convert.go
+++ b/internal/commands/convert.go
@@ -76,7 +76,7 @@ EXAMPLES:
 func convertCookiecutterAction(c *cli.Context) error {
 	// Validate arguments
 	if c.NArg() < 1 {
-		return app.Errorf("source template is required\n\nUsage: tag convert cookiecutter <source>")
+		return app.UsageErrorf("source template is required\n\nUsage: tag convert cookiecutter <source>")
 	}
 
 	source := c.Args().Get(0)

--- a/internal/commands/generate.go
+++ b/internal/commands/generate.go
@@ -30,6 +30,26 @@ func GenerateCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
 		Name:  "generate",
 		Usage: "Run a generator or bundle",
+		Description: `Run a generator or bundle to create or modify files in an existing project.
+
+TAG auto-resolves generators from the library template first, then falls back
+to the local .tag/ directory. Bundles run multiple generators in sequence.
+
+ARGUMENTS
+  <bundle-or-generator>  Name of the generator or bundle to run
+  <name>                 Entity name passed as {{ name }} in templates
+
+FLAGS
+  --meta, -m key=value   Override template variables (repeatable)
+  --no-hooks             Skip pre/post hooks defined in .tagconfig.json
+  --dry-run, -d          Preview changes without writing files (global flag)
+
+EXAMPLES
+  tag generate model User
+  tag generate api-endpoint users --meta package=handlers
+  tag generate crud Product --no-hooks
+  tag generate crud Product --dry-run
+  tag generate list                    # List available generators and bundles`,
 		Subcommands: []*cli.Command{
 			generateListCommand(cfg),
 		},
@@ -69,7 +89,7 @@ func generateAction(c *cli.Context, cfg *config.Config) error {
 	}
 
 	if c.Args().Len() < 2 {
-		return app.Errorf("please provide the generator/bundle and the name")
+		return app.UsageErrorf("please provide the generator/bundle and the name")
 	}
 
 	generatorOrBundleName := c.Args().Get(0)
@@ -96,7 +116,7 @@ func generateAction(c *cli.Context, cfg *config.Config) error {
 
 func generateBundle(c *cli.Context, cfg *config.Config, generatorName, targetName, bundlePath string) error {
 	if !c.Bool("no-hooks") {
-		if err := runHooks(cfg.Hooks.Pre, hooks.HookPhasePreGen); err != nil {
+		if err := runHooks(cfg.Hooks.Pre, hooks.HookPhasePreGen, cfg.Variables); err != nil {
 			return err
 		}
 	}
@@ -159,14 +179,14 @@ func generateBundle(c *cli.Context, cfg *config.Config, generatorName, targetNam
 	}
 
 	if !c.Bool("no-hooks") {
-		return runHooks(cfg.Hooks.Post, hooks.HookPhasePostGen)
+		return runHooks(cfg.Hooks.Post, hooks.HookPhasePostGen, cfg.Variables)
 	}
 	return nil
 }
 
 func generateTemplate(c *cli.Context, cfg *config.Config, generatorName, targetName, dirPath, sharedPath string) error {
 	if !c.Bool("no-hooks") {
-		if err := runHooks(cfg.Hooks.Pre, hooks.HookPhasePreGen); err != nil {
+		if err := runHooks(cfg.Hooks.Pre, hooks.HookPhasePreGen, cfg.Variables); err != nil {
 			return err
 		}
 	}
@@ -189,12 +209,12 @@ func generateTemplate(c *cli.Context, cfg *config.Config, generatorName, targetN
 	}
 
 	if !c.Bool("no-hooks") {
-		return runHooks(cfg.Hooks.Post, hooks.HookPhasePostGen)
+		return runHooks(cfg.Hooks.Post, hooks.HookPhasePostGen, cfg.Variables)
 	}
 	return nil
 }
 
-func runHooks(hookCmds [][]string, phase hooks.HookPhase) error {
+func runHooks(hookCmds [][]string, phase hooks.HookPhase, vars map[string]any) error {
 	if len(hookCmds) == 0 {
 		return nil
 	}
@@ -204,7 +224,12 @@ func runHooks(hookCmds [][]string, phase hooks.HookPhase) error {
 		return app.Errorf("failed to get working directory: %w", err)
 	}
 
-	results, err := hooks.RunArgvHooks(phase, hookCmds, dir, nil)
+	var env []string
+	if len(vars) > 0 {
+		env = hooks.BuildVarEnv(vars, os.Stderr)
+	}
+
+	results, err := hooks.RunArgvHooks(phase, hookCmds, dir, env)
 
 	hooks.PrintHookResults(results, os.Stdout)
 

--- a/internal/commands/generate_resolve.go
+++ b/internal/commands/generate_resolve.go
@@ -59,13 +59,13 @@ func resolveGeneratorPaths(cfg *config.Config, name string) (genDir, sharedDir s
 
 	// 3. Not found
 	if cfg.HasTemplateOrigin() {
-		return "", "", app.Errorf("%w", &GeneratorNotFoundError{
+		return "", "", app.NotFoundErrorf("%w", &GeneratorNotFoundError{
 			Generator: name,
 			Template:  cfg.Template.Name,
 			Source:    cfg.Template.Source,
 		})
 	}
-	return "", "", app.Errorf("%w", &GeneratorNotFoundError{
+	return "", "", app.NotFoundErrorf("%w", &GeneratorNotFoundError{
 		Generator: name,
 		LocalPath: cfg.Env.Path,
 	})
@@ -138,7 +138,7 @@ func resolveBundlePath(cfg *config.Config, bundleName, bundleSubDir string) (str
 		}
 	}
 
-	return "", app.Errorf("cannot open bundle file: bundle %q not found", bundleName)
+	return "", app.NotFoundErrorf("cannot open bundle file: bundle %q not found", bundleName)
 }
 
 // resolveBundleFromLibrary attempts to find a bundle file in the library template.

--- a/internal/commands/generate_test.go
+++ b/internal/commands/generate_test.go
@@ -374,12 +374,12 @@ Hello {{ .Name }}`
 }
 
 func TestUT_RunHooks_EmptyHooks(t *testing.T) {
-	err := runHooks([][]string{}, hooks.HookPhasePreGen)
+	err := runHooks([][]string{}, hooks.HookPhasePreGen, nil)
 	require.NoError(t, err)
 }
 
 func TestUT_RunHooks_NilHooks(t *testing.T) {
-	err := runHooks(nil, hooks.HookPhasePreGen)
+	err := runHooks(nil, hooks.HookPhasePreGen, nil)
 	require.NoError(t, err)
 }
 
@@ -399,7 +399,7 @@ func TestUT_RunHooks_ValidHook(t *testing.T) {
 	t.Cleanup(func() { _ = os.Chdir(oldDir) })
 
 	// Use relative path with ./ prefix to indicate it's a local file
-	err = runHooks([][]string{{"./test-hook.sh"}}, hooks.HookPhasePreGen)
+	err = runHooks([][]string{{"./test-hook.sh"}}, hooks.HookPhasePreGen, nil)
 	require.NoError(t, err)
 }
 
@@ -418,7 +418,7 @@ func TestUT_RunHooks_FailingHook(t *testing.T) {
 	t.Cleanup(func() { _ = os.Chdir(oldDir) })
 
 	// Use relative path with ./ prefix to indicate it's a local file
-	err = runHooks([][]string{{"./failing-hook.sh"}}, hooks.HookPhasePreGen)
+	err = runHooks([][]string{{"./failing-hook.sh"}}, hooks.HookPhasePreGen, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "hook failed")
 }
@@ -444,7 +444,7 @@ func TestUT_RunHooks_StopsOnFailure(t *testing.T) {
 	t.Cleanup(func() { _ = os.Chdir(oldDir) })
 
 	// Use relative paths with ./ prefix to indicate they are local files
-	err = runHooks([][]string{{"./hook1.sh"}, {"./hook2.sh"}}, hooks.HookPhasePreGen)
+	err = runHooks([][]string{{"./hook1.sh"}, {"./hook2.sh"}}, hooks.HookPhasePreGen, nil)
 	require.Error(t, err)
 
 	// Verify second hook didn't run
@@ -461,13 +461,13 @@ func TestUT_RunHooks_NonexistentCommand(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = os.Chdir(oldDir) })
 
-	err = runHooks([][]string{{"nonexistent-command-xyz"}}, hooks.HookPhasePreGen)
+	err = runHooks([][]string{{"nonexistent-command-xyz"}}, hooks.HookPhasePreGen, nil)
 	require.Error(t, err)
 }
 
 func TestUT_RunHooks_PathCommand(t *testing.T) {
 	// Test that PATH commands work (e.g., "echo" should be found in PATH)
-	err := runHooks([][]string{{"echo", "hello"}}, hooks.HookPhasePreGen)
+	err := runHooks([][]string{{"echo", "hello"}}, hooks.HookPhasePreGen, nil)
 	require.NoError(t, err)
 }
 
@@ -486,7 +486,7 @@ func TestUT_RunHooks_RelativePathCommand(t *testing.T) {
 	t.Cleanup(func() { _ = os.Chdir(oldDir) })
 
 	// Relative path should resolve from working directory
-	err = runHooks([][]string{{"./myscript.sh"}}, hooks.HookPhasePreGen)
+	err = runHooks([][]string{{"./myscript.sh"}}, hooks.HookPhasePreGen, nil)
 	require.NoError(t, err)
 }
 

--- a/internal/commands/info.go
+++ b/internal/commands/info.go
@@ -55,7 +55,7 @@ Examples:
 
 func infoAction(c *cli.Context) error {
 	if c.NArg() < 1 {
-		return app.Errorf("template reference is required\n\nUsage: tag template info <template>")
+		return app.UsageErrorf("template reference is required\n\nUsage: tag template info <template>")
 	}
 
 	ref := c.Args().Get(0)

--- a/internal/commands/init.go
+++ b/internal/commands/init.go
@@ -36,7 +36,11 @@ func initAction(c *cli.Context) error {
 		return app.Errorf("cannot initialise tag's bundle path: %w", err)
 	}
 
-	if err := config.CreateConfigFile(c); err != nil {
+	if err := config.CreateConfigFile(config.CreateConfigOptions{
+		TagPath:    c.String(flags.PathFlag),
+		SharedPath: c.String(flags.SharedPathFlag),
+		BundlePath: c.String(flags.BundlePathFlag),
+	}); err != nil {
 		return app.Errorf("cannot create the config file at %s: %w", dirPath, err)
 	}
 

--- a/internal/commands/library.go
+++ b/internal/commands/library.go
@@ -92,7 +92,7 @@ func libAddCommand() *cli.Command {
 		},
 		Action: func(c *cli.Context) error {
 			if c.NArg() < 1 {
-				return app.Errorf("template reference is required\n\nUsage: tag lib add <ref>")
+				return app.UsageErrorf("template reference is required\n\nUsage: tag lib add <ref>")
 			}
 
 			lib, err := newLibrary()
@@ -196,7 +196,7 @@ func libRemoveCommand() *cli.Command {
 		BashComplete: completeLibraryTemplateNames,
 		Action: func(c *cli.Context) error {
 			if c.NArg() < 1 {
-				return app.Errorf("template name is required\n\nUsage: tag lib rm <name>")
+				return app.UsageErrorf("template name is required\n\nUsage: tag lib rm <name>")
 			}
 
 			lib, err := newLocalLibrary()
@@ -288,7 +288,7 @@ func libEditCommand() *cli.Command {
 		},
 		Action: func(c *cli.Context) error {
 			if c.NArg() < 1 {
-				return app.Errorf("template name is required\n\nUsage: tag lib edit <name>")
+				return app.UsageErrorf("template name is required\n\nUsage: tag lib edit <name>")
 			}
 
 			lib, err := newLocalLibrary()

--- a/internal/commands/new.go
+++ b/internal/commands/new.go
@@ -50,7 +50,7 @@ func templateNewGeneratorCommand(cfg *config.Config) *cli.Command {
 func newAction(c *cli.Context, cfg *config.Config) error {
 	generator := c.Args().Get(0)
 	if generator == "" {
-		return app.Errorf("please provide the generator name")
+		return app.UsageErrorf("please provide the generator name")
 	}
 
 	if err := ValidateNameSafe(generator); err != nil {

--- a/internal/commands/scaffold.go
+++ b/internal/commands/scaffold.go
@@ -232,7 +232,7 @@ func resolveTemplateName(c *cli.Context, lib *library.Library, positional []stri
 	case scaffold.IsTTY() && !c.Bool("no-input"):
 		return pickTemplate(lib)
 	default:
-		return "", app.Errorf("template argument required\n\nUsage: tag scaffold <template> [project-name]")
+		return "", app.UsageErrorf("template argument required\n\nUsage: tag scaffold <template> [project-name]")
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,10 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/urfave/cli/v2"
-
 	"github.com/kaikenlabs/tag/internal/types"
-	"github.com/kaikenlabs/tag/internal/types/flags"
 	"github.com/kaikenlabs/tag/pkg/app"
 )
 
@@ -71,12 +68,21 @@ func LoadConfigFile(dir string) (*Config, error) {
 	return &config, nil
 }
 
-func CreateConfigFile(c *cli.Context) error {
+// CreateConfigOptions holds the parameters for creating a config file,
+// decoupled from the CLI framework.
+type CreateConfigOptions struct {
+	TagPath    string
+	SharedPath string
+	BundlePath string
+}
+
+// CreateConfigFile writes a new .tagconfig.json with the given options.
+func CreateConfigFile(opts CreateConfigOptions) error {
 	cfg := Config{
 		Env: Env{
-			Path:       c.String(flags.PathFlag),
-			SharedPath: c.String(flags.SharedPathFlag),
-			BundlePath: c.String(flags.BundlePathFlag),
+			Path:       opts.TagPath,
+			SharedPath: opts.SharedPath,
+			BundlePath: opts.BundlePath,
 		},
 		Hooks: Hooks{
 			Pre:  [][]string{},

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -150,6 +150,32 @@ func TestUT_HasTemplateOrigin_NilConfig(t *testing.T) {
 	assert.False(t, cfg.HasTemplateOrigin())
 }
 
+func TestUT_CreateConfigFile(t *testing.T) {
+	// Change to temp dir so CreateConfigFile writes there
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+	tmpDir := t.TempDir()
+	require.NoError(t, os.Chdir(tmpDir))
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	err = CreateConfigFile(CreateConfigOptions{
+		TagPath:    ".tag",
+		SharedPath: "_shared",
+		BundlePath: "_bundles",
+	})
+	require.NoError(t, err)
+
+	cfg, err := LoadConfigFile(tmpDir)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	assert.Equal(t, ".tag", cfg.Env.Path)
+	assert.Equal(t, "_shared", cfg.Env.SharedPath)
+	assert.Equal(t, "_bundles", cfg.Env.BundlePath)
+	assert.Empty(t, cfg.Hooks.Pre)
+	assert.Empty(t, cfg.Hooks.Post)
+}
+
 func TestUT_CheckConfig_NilConfig(t *testing.T) {
 	err := CheckConfig(nil)
 	require.Error(t, err)

--- a/internal/hooks/hookenv.go
+++ b/internal/hooks/hookenv.go
@@ -41,6 +41,26 @@ func BuildHookEnv(vars map[string]any, templateDir, outputDir string, w io.Write
 	return env
 }
 
+// BuildVarEnv creates environment variables containing only TAG_VAR_* entries
+// and TAG_PROJECT_NAME. Unlike BuildHookEnv, it does not set TAG_TEMPLATE_DIR
+// or TAG_OUTPUT_DIR, making it suitable for generate hooks where those paths
+// are not applicable.
+func BuildVarEnv(vars map[string]any, w io.Writer) []string {
+	env := os.Environ()
+
+	if projectName, ok := vars["project_name"]; ok {
+		env = append(env, "TAG_PROJECT_NAME="+stringifyValue(projectName))
+	}
+
+	for name, value := range vars {
+		envKey := formatEnvKey(name)
+		envValue := sanitizeEnvValue(name, stringifyValue(value), w)
+		env = append(env, fmt.Sprintf("%s=%s", envKey, envValue))
+	}
+
+	return env
+}
+
 // formatEnvKey converts a variable name to an environment variable key.
 // Example: "project_name" -> "TAG_VAR_PROJECT_NAME"
 // Example: "use-docker" -> "TAG_VAR_USE_DOCKER"

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -862,6 +862,47 @@ func assertEnvNotContainsPrefix(t *testing.T, env []string, prefix string) {
 	}
 }
 
+// --- Unit Tests for BuildVarEnv ---
+
+func TestUT_BuildVarEnv_BasicVariables(t *testing.T) {
+	vars := map[string]any{
+		"project_name": "my_project",
+		"author":       "Jane",
+	}
+
+	env := BuildVarEnv(vars, io.Discard)
+
+	assertEnvContains(t, env, "TAG_PROJECT_NAME=my_project")
+	assertEnvContains(t, env, "TAG_VAR_PROJECT_NAME=my_project")
+	assertEnvContains(t, env, "TAG_VAR_AUTHOR=Jane")
+
+	// Should NOT contain TAG_TEMPLATE_DIR or TAG_OUTPUT_DIR
+	for _, e := range env {
+		assert.False(t, strings.HasPrefix(e, "TAG_TEMPLATE_DIR="),
+			"BuildVarEnv should not set TAG_TEMPLATE_DIR")
+		assert.False(t, strings.HasPrefix(e, "TAG_OUTPUT_DIR="),
+			"BuildVarEnv should not set TAG_OUTPUT_DIR")
+	}
+}
+
+func TestUT_BuildVarEnv_EmptyVars(t *testing.T) {
+	env := BuildVarEnv(map[string]any{}, io.Discard)
+
+	// Should still include system environment
+	assert.NotEmpty(t, env)
+
+	// No TAG_VAR_ entries
+	for _, e := range env {
+		assert.False(t, strings.HasPrefix(e, "TAG_VAR_"),
+			"empty vars should produce no TAG_VAR_ entries")
+	}
+}
+
+func TestUT_BuildVarEnv_NilVars(t *testing.T) {
+	env := BuildVarEnv(nil, io.Discard)
+	assert.NotEmpty(t, env, "nil vars should still include system env")
+}
+
 // filterTagEnv returns only TAG_ prefixed env vars for easier debugging
 func filterTagEnv(env []string) []string {
 	var result []string

--- a/internal/scaffold/output.go
+++ b/internal/scaffold/output.go
@@ -26,8 +26,10 @@ type OutputWriter interface {
 
 // DefaultOutputWriter implements OutputWriter.
 type DefaultOutputWriter struct {
-	engine        template.TemplateRenderer
-	pathProcessor PathProcessor
+	engine               template.TemplateRenderer
+	pathProcessor        PathProcessor
+	allowRecursiveRender bool
+	derivedVarNames      map[string]bool
 }
 
 // NewOutputWriter creates a new output writer.
@@ -38,6 +40,37 @@ func NewOutputWriter(engine template.TemplateRenderer, pathProcessor PathProcess
 	}
 }
 
+// SetAllowRecursiveRender controls whether user-provided variable values
+// containing template syntax are rendered in file content. When false (default),
+// template delimiters in non-derived variable values are escaped to prevent SSTI.
+func (w *DefaultOutputWriter) SetAllowRecursiveRender(allow bool) {
+	w.allowRecursiveRender = allow
+}
+
+// SetDerivedVarNames sets the derived variable names for SSTI protection.
+// Derived variables are always rendered through the template engine.
+func (w *DefaultOutputWriter) SetDerivedVarNames(names map[string]bool) {
+	w.derivedVarNames = names
+}
+
+// escapeNonDerivedVars returns a copy of vars where template delimiters in
+// non-derived string values are escaped with sentinel tokens, preventing SSTI.
+func (w *DefaultOutputWriter) escapeNonDerivedVars(vars map[string]any) map[string]any {
+	safe := make(map[string]any, len(vars))
+	for k, v := range vars {
+		if w.derivedVarNames[k] {
+			safe[k] = v
+			continue
+		}
+		if s, ok := v.(string); ok {
+			safe[k] = escapeTemplateSyntax(s)
+		} else {
+			safe[k] = v
+		}
+	}
+	return safe
+}
+
 // Ensure DefaultOutputWriter implements OutputWriter.
 var _ OutputWriter = (*DefaultOutputWriter)(nil)
 
@@ -45,8 +78,16 @@ var _ OutputWriter = (*DefaultOutputWriter)(nil)
 //
 //nolint:gocognit // file processing with multiple format-dependent branches
 func (w *DefaultOutputWriter) Write(templateRoot, outputDir string, vars map[string]any) error {
-	// Build template context
-	ctx := buildTemplateContext(vars)
+	// Escape non-derived variable values to prevent SSTI in file content.
+	// When allowRecursiveRender is false (default), template delimiters in
+	// user-provided values are replaced with sentinel tokens before rendering.
+	safeVars := vars
+	if !w.allowRecursiveRender {
+		safeVars = w.escapeNonDerivedVars(vars)
+	}
+
+	// Build template context with (possibly escaped) vars
+	ctx := buildTemplateContext(safeVars)
 
 	// Load .tagignore patterns (nil matcher if file absent or empty)
 	ignoreMatcher, err := loadIgnorePatterns(templateRoot)
@@ -269,6 +310,13 @@ func (w *DefaultOutputWriter) processTemplate(srcPath, destPath string, content 
 	result, err := tmpl.Execute(ctx)
 	if err != nil {
 		return NewFileProcessingError(srcPath, "failed to execute template", err)
+	}
+
+	// Restore escaped template delimiters back to their original form.
+	// This ensures user-provided values containing {{ }} appear literally
+	// in the output rather than being executed by the template engine.
+	if !w.allowRecursiveRender {
+		result = unescapeTemplateSyntax(result)
 	}
 
 	// Write output

--- a/internal/scaffold/output_test.go
+++ b/internal/scaffold/output_test.go
@@ -1213,6 +1213,157 @@ func TestUT_Write_TagIgnoreEmpty(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// --- SSTI protection ---
+
+func TestUT_Write_SSTIBlocked_TemplateSyntaxInVarIsLiteral(t *testing.T) {
+	writer := mustNewOutputWriter(t)
+
+	templateDir := t.TempDir()
+	outputDir := t.TempDir()
+
+	// Template file uses {{ vars.name }}
+	require.NoError(t, os.WriteFile(
+		filepath.Join(templateDir, "readme.txt"),
+		[]byte("Project: {{ vars.name }}"),
+		0o644,
+	))
+
+	// User provides template syntax as variable value (SSTI attack)
+	vars := map[string]any{"name": "{{ range(999) }}x{{ endfor }}"}
+	err := writer.Write(templateDir, outputDir, vars)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(filepath.Join(outputDir, "readme.txt"))
+	require.NoError(t, err)
+	// Template syntax should appear literally, NOT executed
+	assert.Equal(t, "Project: {{ range(999) }}x{{ endfor }}", string(content))
+}
+
+func TestUT_Write_SSTIBlocked_NormalVarsStillWork(t *testing.T) {
+	writer := mustNewOutputWriter(t)
+
+	templateDir := t.TempDir()
+	outputDir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(
+		filepath.Join(templateDir, "file.txt"),
+		[]byte("Hello {{ vars.name }}, version {{ vars.version }}"),
+		0o644,
+	))
+
+	vars := map[string]any{"name": "World", "version": "1.0"}
+	err := writer.Write(templateDir, outputDir, vars)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(filepath.Join(outputDir, "file.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "Hello World, version 1.0", string(content))
+}
+
+func TestUT_Write_SSTIBlocked_StmtAndCommentSyntax(t *testing.T) {
+	writer := mustNewOutputWriter(t)
+
+	templateDir := t.TempDir()
+	outputDir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(
+		filepath.Join(templateDir, "file.txt"),
+		[]byte("Value: {{ vars.input }}"),
+		0o644,
+	))
+
+	// User tries {% %} and {# #} injection
+	vars := map[string]any{"input": "{% if true %}pwned{% endif %}{# comment #}"}
+	err := writer.Write(templateDir, outputDir, vars)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(filepath.Join(outputDir, "file.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "Value: {% if true %}pwned{% endif %}{# comment #}", string(content))
+}
+
+func TestUT_Write_SSTIAllowRecursiveRender(t *testing.T) {
+	engine := mustNewEngine(t)
+	pathProcessor := NewPathProcessor(engine)
+	writer := NewOutputWriter(engine, pathProcessor)
+	writer.SetAllowRecursiveRender(true)
+
+	templateDir := t.TempDir()
+	outputDir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(
+		filepath.Join(templateDir, "file.txt"),
+		[]byte("{{ vars.expr }}"),
+		0o644,
+	))
+
+	// With allowRecursiveRender=true, values are NOT escaped (no sentinel tokens
+	// appear in the output). Gonja does not re-evaluate string values, so the
+	// template syntax in the value is output literally — but without any
+	// escape/unescape round-trip.
+	vars := map[string]any{"expr": "{{ 1 + 1 }}"}
+	err := writer.Write(templateDir, outputDir, vars)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(filepath.Join(outputDir, "file.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "{{ 1 + 1 }}", string(content))
+}
+
+func TestUT_Write_SSTIDerivedVarsNotEscaped(t *testing.T) {
+	engine := mustNewEngine(t)
+	pathProcessor := NewPathProcessor(engine)
+	writer := NewOutputWriter(engine, pathProcessor)
+	// Mark "greeting" as a derived variable — its value should not be escaped
+	writer.SetDerivedVarNames(map[string]bool{"greeting": true})
+
+	templateDir := t.TempDir()
+	outputDir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(
+		filepath.Join(templateDir, "file.txt"),
+		[]byte("{{ vars.greeting }}\nInput: {{ vars.input }}"),
+		0o644,
+	))
+
+	// "greeting" is derived (not escaped), "input" is user-provided (escaped)
+	vars := map[string]any{
+		"greeting": "Hello!",
+		"input":    "{{ malicious }}",
+	}
+	err := writer.Write(templateDir, outputDir, vars)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(filepath.Join(outputDir, "file.txt"))
+	require.NoError(t, err)
+	// greeting rendered normally, input appears literally (escaped then unescaped)
+	assert.Equal(t, "Hello!\nInput: {{ malicious }}", string(content))
+}
+
+// --- unescapeTemplateSyntax ---
+
+func TestUT_UnescapeTemplateSyntax_RoundTrip(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"expression delimiters", "{{ vars.name }}"},
+		{"statement delimiters", "{% if true %}yes{% endif %}"},
+		{"comment delimiters", "{# a comment #}"},
+		{"mixed", "{{ x }} {% if y %}{# z #}{% endif %}"},
+		{"no delimiters", "plain text"},
+		{"empty string", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			escaped := escapeTemplateSyntax(tt.input)
+			unescaped := unescapeTemplateSyntax(escaped)
+			assert.Equal(t, tt.input, unescaped, "round-trip should restore original")
+		})
+	}
+}
+
 // --- test helpers ---
 
 // testDirEntry wraps os.FileInfo to implement fs.DirEntry for tests.

--- a/internal/scaffold/processor.go
+++ b/internal/scaffold/processor.go
@@ -133,6 +133,12 @@ func (p *DefaultPathProcessor) processSegment(segment string, vars map[string]an
 		result = rendered
 	}
 
+	// Restore escaped template delimiters to their original form so that
+	// user-provided values containing {{ }} appear literally in paths.
+	if !p.allowRecursiveRender {
+		result = unescapeTemplateSyntax(result)
+	}
+
 	return result, nil
 }
 
@@ -179,5 +185,20 @@ func escapeTemplateSyntax(s string) string {
 	s = strings.ReplaceAll(s, "%}", sentinelCloseStmt)
 	s = strings.ReplaceAll(s, "{#", sentinelOpenComment)
 	s = strings.ReplaceAll(s, "#}", sentinelCloseComment)
+	return s
+}
+
+// unescapeTemplateSyntax reverses escapeTemplateSyntax, restoring sentinel
+// tokens back to their original Jinja2 template delimiters.
+func unescapeTemplateSyntax(s string) string {
+	if !strings.Contains(s, "\x00") {
+		return s
+	}
+	s = strings.ReplaceAll(s, sentinelOpenExpr, "{{")
+	s = strings.ReplaceAll(s, sentinelCloseExpr, "}}")
+	s = strings.ReplaceAll(s, sentinelOpenStmt, "{%")
+	s = strings.ReplaceAll(s, sentinelCloseStmt, "%}")
+	s = strings.ReplaceAll(s, sentinelOpenComment, "{#")
+	s = strings.ReplaceAll(s, sentinelCloseComment, "#}")
 	return s
 }

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -60,6 +60,7 @@ func NewScaffold(opts Options) (*Scaffold, error) {
 	processor := NewPathProcessor(engine)
 	processor.SetAllowRecursiveRender(opts.AllowRecursiveRender)
 	writer := NewOutputWriter(engine, processor)
+	writer.SetAllowRecursiveRender(opts.AllowRecursiveRender)
 
 	return &Scaffold{
 		validator:  validator,
@@ -132,14 +133,17 @@ func (s *Scaffold) loadConfig(ctx *runContext) error {
 		ctx.opts.TemplateVersion = config.Version
 	}
 
-	// Set derived variable names on the processor for SSTI protection.
-	if configurable, ok := s.processor.(SSTIConfigurable); ok {
-		derivedNames := make(map[string]bool)
-		for name, def := range config.Vars {
-			if def.IsDerived() || def.IsPrivate(name) {
-				derivedNames[name] = true
-			}
+	// Set derived variable names on the processor and writer for SSTI protection.
+	derivedNames := make(map[string]bool)
+	for name, def := range config.Vars {
+		if def.IsDerived() || def.IsPrivate(name) {
+			derivedNames[name] = true
 		}
+	}
+	if configurable, ok := s.processor.(SSTIConfigurable); ok {
+		configurable.SetDerivedVarNames(derivedNames)
+	}
+	if configurable, ok := s.writer.(SSTIConfigurable); ok {
 		configurable.SetDerivedVarNames(derivedNames)
 	}
 

--- a/main.go
+++ b/main.go
@@ -1,12 +1,15 @@
 package main
 
 import (
+	"errors"
 	"log/slog"
 	"os"
 
 	"github.com/kaikenlabs/tag/pkg/prettylog"
 
+	"github.com/kaikenlabs/tag/internal/scaffold"
 	"github.com/kaikenlabs/tag/internal/types/flags"
+	"github.com/kaikenlabs/tag/pkg/app"
 
 	"github.com/kaikenlabs/tag/internal/commands"
 	"github.com/kaikenlabs/tag/internal/config"
@@ -73,13 +76,35 @@ func main() {
 				EnvVars: []string{"TAG_BUNDLE_PATH"},
 			},
 		},
+		// Custom error handler to avoid urfave/cli printing errors (we use slog).
+		ExitErrHandler: handleExitError,
 	}
 	tag.Commands = append(tag.Commands, commands.CompletionCommand(tag))
 
 	if err := tag.Run(os.Args); err != nil {
+		exitCode := app.ExitGeneral
+
+		// Check for prompt cancellation (Ctrl+C) → exit 130
+		if errors.Is(err, scaffold.ErrPromptCancelled) {
+			os.Exit(app.ExitInterrupted)
+		}
+
+		// Extract exit code from CommandError
+		var cmdErr *app.CommandError
+		if errors.As(err, &cmdErr) {
+			exitCode = cmdErr.ExitCode()
+		}
+
 		slog.Error(err.Error())
-		os.Exit(1)
+		os.Exit(exitCode)
 	}
+}
+
+// handleExitError is the ExitErrHandler for urfave/cli. It prevents
+// the framework from printing errors or calling os.Exit, letting main()
+// handle error reporting and exit codes consistently.
+func handleExitError(_ *cli.Context, _ error) {
+	// Intentionally empty: errors are handled in main() after tag.Run() returns.
 }
 
 func setLogger() {

--- a/pkg/app/errors.go
+++ b/pkg/app/errors.go
@@ -5,11 +5,22 @@ import (
 	"fmt"
 )
 
+// Exit codes following POSIX conventions.
+const (
+	ExitOK          = 0   // Success
+	ExitGeneral     = 1   // General application error
+	ExitUsage       = 2   // Usage/argument error (missing args, invalid flags)
+	ExitNotFound    = 3   // Resource not found (template, library)
+	ExitInterrupted = 130 // Interrupted by SIGINT (Ctrl+C)
+)
+
 // CommandError represents an error that occurred during command execution.
 // It wraps an underlying cause error and provides a user-friendly message.
+// Implements cli.ExitCoder so urfave/cli can extract the exit code.
 type CommandError struct {
 	Message string
 	Cause   error
+	Code    int
 }
 
 // Error returns the error message.
@@ -22,12 +33,42 @@ func (e *CommandError) Unwrap() error {
 	return e.Cause
 }
 
-// Errorf creates a new CommandError with a formatted message.
+// ExitCode returns the exit code for this error. If Code is explicitly set,
+// it is returned. Otherwise defaults to ExitGeneral (1).
+// Implements the cli.ExitCoder interface.
+func (e *CommandError) ExitCode() int {
+	if e.Code != 0 {
+		return e.Code
+	}
+	return ExitGeneral
+}
+
+// Errorf creates a new CommandError with a formatted message and exit code 1.
 // It supports the %w verb for wrapping errors, similar to fmt.Errorf.
 func Errorf(format string, args ...any) error {
 	wrapped := fmt.Errorf(format, args...)
 	return &CommandError{
 		Message: wrapped.Error(),
 		Cause:   errors.Unwrap(wrapped),
+	}
+}
+
+// UsageErrorf creates a CommandError with exit code 2 (usage/argument error).
+func UsageErrorf(format string, args ...any) error {
+	wrapped := fmt.Errorf(format, args...)
+	return &CommandError{
+		Message: wrapped.Error(),
+		Cause:   errors.Unwrap(wrapped),
+		Code:    ExitUsage,
+	}
+}
+
+// NotFoundErrorf creates a CommandError with exit code 3 (resource not found).
+func NotFoundErrorf(format string, args ...any) error {
+	wrapped := fmt.Errorf(format, args...)
+	return &CommandError{
+		Message: wrapped.Error(),
+		Cause:   errors.Unwrap(wrapped),
+		Code:    ExitNotFound,
 	}
 }

--- a/pkg/app/errors_test.go
+++ b/pkg/app/errors_test.go
@@ -95,6 +95,58 @@ func TestUT_CommandError_ErrorsAs(t *testing.T) {
 	})
 }
 
+func TestUT_CommandError_ExitCode(t *testing.T) {
+	tests := []struct {
+		name string
+		code int
+		want int
+	}{
+		{"default code (0) returns 1", 0, ExitGeneral},
+		{"explicit code 2", ExitUsage, ExitUsage},
+		{"explicit code 3", ExitNotFound, ExitNotFound},
+		{"explicit code 130", ExitInterrupted, ExitInterrupted},
+		{"custom code 42", 42, 42},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := &CommandError{Message: "test", Code: tt.code}
+			assert.Equal(t, tt.want, err.ExitCode())
+		})
+	}
+}
+
+func TestUT_UsageErrorf(t *testing.T) {
+	err := UsageErrorf("missing argument: %s", "name")
+
+	cmdErr, ok := err.(*CommandError)
+	require.True(t, ok)
+	assert.Equal(t, ExitUsage, cmdErr.ExitCode())
+	assert.Equal(t, "missing argument: name", cmdErr.Message)
+}
+
+func TestUT_NotFoundErrorf(t *testing.T) {
+	err := NotFoundErrorf("template %q not found", "foo")
+
+	cmdErr, ok := err.(*CommandError)
+	require.True(t, ok)
+	assert.Equal(t, ExitNotFound, cmdErr.ExitCode())
+	assert.Equal(t, `template "foo" not found`, cmdErr.Message)
+}
+
+func TestUT_CommandError_ImplementsExitCoder(t *testing.T) {
+	// Verify CommandError has an ExitCode() int method
+	// (compatible with cli.ExitCoder interface)
+	err := &CommandError{Message: "test", Code: ExitUsage}
+
+	type exitCoder interface {
+		ExitCode() int
+	}
+
+	var ec exitCoder = err
+	assert.Equal(t, ExitUsage, ec.ExitCode())
+}
+
 func TestUT_Errorf_FormatsMessage(t *testing.T) {
 	tests := []struct {
 		name   string


### PR DESCRIPTION
## Summary

Implements Epic #131 (Sprint 2 — Security & UX Core) with 5 sub-tickets:

- **#142** (critical/security): SSTI mitigation for file content rendering — escapes template syntax in non-derived variable values before content rendering, unescapes after. Also fixes pre-existing path processor sentinel token leak.
- **#143** (medium/enhancement): Semantic exit codes via `ExitCoder` interface — 0 (OK), 1 (general), 2 (usage), 3 (not found), 130 (interrupted). Converts 9 argument-missing errors to `UsageErrorf`.
- **#144** (medium/docs): Rich help text for `tag generate` command with ARGUMENTS, FLAGS, and EXAMPLES sections.
- **#145** (medium/architecture): Decouples `config.CreateConfigFile` from `*cli.Context` with `CreateConfigOptions` struct.
- **#146** (medium/enhancement): Generate hooks now receive scaffold variables as `TAG_VAR_*` environment variables via new `BuildVarEnv` helper.

### Key changes

- `internal/scaffold/output.go` — SSTI escaping for file content (escape before render, unescape after)
- `internal/scaffold/processor.go` — Added `unescapeTemplateSyntax` + fix for sentinel token leak in paths
- `pkg/app/errors.go` — Exit code constants, `ExitCode()` method, `UsageErrorf`, `NotFoundErrorf`
- `main.go` — Custom `ExitErrHandler`, semantic exit code extraction
- `internal/hooks/hookenv.go` — `BuildVarEnv` for generate hook environment
- `internal/config/config.go` — `CreateConfigOptions` struct replaces `*cli.Context`

Closes #131, closes #142, closes #143, closes #144, closes #145, closes #146

## Test plan

- [x] All unit tests pass (`go test ./...`)
- [x] Lint clean (`make lint` — 0 issues)
- [x] SSTI content protection: 5 tests + round-trip test verify escape/unescape
- [x] Exit codes: table-driven tests for ExitCode, UsageErrorf, NotFoundErrorf, ExitCoder interface
- [x] Config decoupling: CreateConfigFile with options test
- [x] BuildVarEnv: basic, empty, nil vars tests
- [x] Existing tests updated for new `runHooks` signature (8 call sites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)