### PR TITLE
docs: update TAG_REFERENCE.md and TAG_RECIPES.md for Sprints 1-4

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
   - Reserve Write/Edit for new files or non-code files (config, docs, memory)
 4. Use sequential thinking MCP for complex thinking operations.
 5. Use ref MCP server to look for documentation on well known libraries.
+6. After implementing code changes, check if `TAG_REFERENCE.md` and `TAG_RECIPES.md` need updating:
+  - New/changed CLI commands, flags, or environment variables → update TAG_REFERENCE.md
+  - New/changed user-facing behavior (exit codes, prompts, output) → update TAG_REFERENCE.md
+  - New usage patterns or workflow examples → update TAG_RECIPES.md
+  - Flag alias changes or renamed options → update both files
 
 ## Project Overview
 

--- a/TAG_RECIPES.md
+++ b/TAG_RECIPES.md
@@ -555,8 +555,8 @@ This creates `.tag/_bundles/examples/examples.json` with `"self_contained": true
 ### Step 2: Add generators inside the bundle
 
 ```bash
-tag template new generator hello --in-bundle examples -k mypackage
-tag template new generator greet --in-bundle examples -k mypackage
+tag template new generator hello --in-bundle examples -p mypackage
+tag template new generator greet --in-bundle examples -p mypackage
 ```
 
 This creates generators at `.tag/_bundles/examples/hello/hello.go` and `.tag/_bundles/examples/greet/greet.go` instead of the usual `.tag/hello/`.

--- a/TAG_REFERENCE.md
+++ b/TAG_REFERENCE.md
@@ -659,6 +659,8 @@ Cookiecutter templates are **auto-detected and converted** when added to the lib
 | `tag lib rm <name>` | Remove template from library |
 | `tag lib update [name]` | Update template(s) from source |
 | `tag lib edit <name>` | Open template in editor |
+| `tag cache clear [--all]` | Clear expired (or all) cached remote templates |
+| `tag cache list` | List cached remote templates |
 | `tag version [--check]` | Print version, check for updates |
 
 ### Common flags
@@ -677,7 +679,29 @@ Cookiecutter templates are **auto-detected and converted** when added to the lib
 | `-B` / `--in-bundle` | template new generator | Create generator inside a bundle directory |
 | `-s` / `--self-contained` | template new bundle | Create bundle with `self_contained: true` |
 | `--update` / `-u` | scaffold, template info | Force refresh of cached remote templates |
+| `-p` / `--package` | template new generator | Package name for the generator (default: "mypackage") |
 | `--dry-run` / `-d` | generate, convert | Preview without writing files |
+
+### Environment variables
+
+| Variable | Description |
+|----------|-------------|
+| `GITHUB_TOKEN` | Authentication for GitHub remote templates |
+| `GITLAB_TOKEN` | Authentication for GitLab remote templates |
+| `BITBUCKET_TOKEN` | Authentication for Bitbucket remote templates |
+| `NO_COLOR` | Disable colored output when set to any non-empty value (per [no-color.org](https://no-color.org/)) |
+
+### Exit codes
+
+TAG uses semantic exit codes for scripting and CI integration:
+
+| Code | Meaning |
+|------|---------|
+| `0` | Success |
+| `1` | General application error |
+| `2` | Usage/argument error (missing args, invalid flags) |
+| `3` | Resource not found (template, library entry) |
+| `130` | Interrupted by user (Ctrl+C / SIGINT) |
 
 ## Pitfalls & Gotchas
 


### PR DESCRIPTION
## Summary

- Bring `TAG_REFERENCE.md` and `TAG_RECIPES.md` up to date with all user-facing changes from Sprints 1-4
- Add mandatory CLAUDE.md rule to keep these docs updated after code changes

## Changes

### TAG_REFERENCE.md
- Add `tag cache clear [--all]` and `tag cache list` to Essential commands table (Sprint 3)
- Add `--package / -p` flag to Common flags table (Sprint 4)
- Add Environment variables section: `GITHUB_TOKEN`, `GITLAB_TOKEN`, `BITBUCKET_TOKEN`, `NO_COLOR` (Sprint 1)
- Add Exit codes section: 0, 1, 2, 3, 130 with semantic meanings (Sprint 2)

### TAG_RECIPES.md
- Fix `-k` → `-p` flag alias in Recipe 9: Self-Contained Bundles (Sprint 4)

### CLAUDE.md
- Add mandatory rule #6: check and update `TAG_REFERENCE.md` and `TAG_RECIPES.md` after implementing code changes

## Test plan

- [x] No code changes — docs only
- [x] `go build ./...` passes
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)