### PR TITLE
docs: add TAG authoring skill for AI agents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,11 +13,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
   - Reserve Write/Edit for new files or non-code files (config, docs, memory)
 4. Use sequential thinking MCP for complex thinking operations.
 5. Use ref MCP server to look for documentation on well known libraries.
-6. After implementing code changes, check if `TAG_REFERENCE.md` and `TAG_RECIPES.md` need updating:
-  - New/changed CLI commands, flags, or environment variables → update TAG_REFERENCE.md
-  - New/changed user-facing behavior (exit codes, prompts, output) → update TAG_REFERENCE.md
-  - New usage patterns or workflow examples → update TAG_RECIPES.md
-  - Flag alias changes or renamed options → update both files
+6. After implementing code changes, check if the TAG skill files need updating:
+  - New/changed CLI commands, flags, or environment variables → update `skill/SKILL.md` and `skill/reference.md`
+  - New/changed user-facing behavior (exit codes, prompts, output) → update `skill/SKILL.md` or `skill/reference.md`
+  - New usage patterns or workflow examples → update `skill/recipes.md`
+  - Flag alias changes or renamed options → update `skill/SKILL.md` and `skill/reference.md`
 
 ## Project Overview
 
@@ -272,6 +272,10 @@ if err != nil {
 
 ## Documentation
 
+- `skill/` - TAG authoring skill (for AI agents and external consumers)
+  - `skill/SKILL.md` - Core reference: decision tree, generator/bundle anatomy, CLI quick reference, pitfalls
+  - `skill/reference.md` - Full syntax, filters, variable system, hooks, remote templates
+  - `skill/recipes.md` - Real-world patterns and examples (CRUD bundles, inject patterns, scaffolds)
 - `docs/` - User-facing documentation
   - `docs/commands/` - Command reference (scaffold, generate, convert)
   - `docs/templates/` - Template authoring guides (syntax, filters, hooks)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ A powerful code generation and project scaffolding CLI for developers.
 
 TAG combines the project bootstrapping capabilities of [Cookiecutter](https://cookiecutter.readthedocs.io/) with incremental code generation, supporting both full project scaffolding from templates and adding code to existing projects.
 
-If you are an AI coding assistant, or you are looking for a quick reference, please read the [TAG quick reference doc](TAG_REFERENCE.md) and the [TAG recipes doc](TAG_RECIPES.md) files.
+## Mandatory for AI assistants
+
+Please read the [TAG skill](skill/SKILL.md) file.
 
 ## Features
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: tag-authoring
+description: Create and manage TAG templates, generators, bundles, and scaffold configurations. Use when creating project templates, writing code generators, setting up bundles, converting Cookiecutter templates, or scaffolding new projects with TAG.
+---
+
+# TAG Authoring
+
+TAG is a CLI for two workflows: **scaffolding** (creating projects from templates) and **code generation** (evolving projects with generators/bundles).
+
+**Mental model**: Scaffold creates the project. Generators evolve it.
+
+## Quick Start
+
+```bash
+# Scaffold a new project
+tag scaffold gh:user/template my-project
+
+# Initialize generators in an existing project
+tag template init
+tag template new generator service
+tag generate service payment
+
+# Run a bundle (multiple generators)
+tag generate resource product
+```
+
+## Decision Tree
+
+```
+Preview a template?
+  → tag template info <template>
+
+Create a new project?
+  → tag scaffold <template> [project-name]
+  → tag scaffold                              (no args = interactive picker)
+
+Generate code in existing project?
+  Single file? → generator
+  Multiple related files? → bundle
+  Distributable package? → self-contained bundle
+
+Convert Cookiecutter?
+  → tag convert cookiecutter <src> -o <dst>
+  → Or just scaffold directly (auto-detects)
+```
+
+## Generator Anatomy
+
+A generator is a directory under `.tag/` containing template files with frontmatter + body.
+
+Files keep their **natural extension** (`.go`, `.ts`, `.py`) — NOT `.tmpl`.
+
+```
+---
+to: app/services/{{ name | snake }}.go
+---
+package services
+
+type {{ name | pascal }}Service struct{}
+```
+
+### Frontmatter Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `to` | Yes | Output path. Supports `{{ name }}`, `{{ vars.x }}`, filters. |
+| `inject` | No | `true` to inject into existing file |
+| `before` | No | Marker string — inject BEFORE this line. Requires `inject: true`. |
+| `after` | No | Marker string — inject AFTER this line. Requires `inject: true`. |
+| `append` | No | `true` to append to end of file |
+| `desc` | No | Description for `tag generate list` |
+| `notes` | No | Message displayed after generation |
+
+**Frontmatter is NOT YAML** — simple `key: value` line parser. No nesting, no arrays.
+
+### Actions
+
+- **Create** (default): Write new file. Overwrites if exists.
+- **Inject**: Insert at marker (`after:` or `before:` with `inject: true`).
+- **Append**: Add to end of file (`append: true`).
+
+Execution order: Create → Inject → Append (files exist before injection).
+
+### Variables
+
+- `{{ name }}` — the CLI argument from `tag generate <gen> <name>`
+- `{{ vars.x }}` — meta values from `--meta`/`-m` flags or `.tagconfig.json`
+- **Never bare names**: `{{ project_name }}` does NOT work. Always `{{ vars.project_name }}`.
+
+### Name Shortcuts
+
+| Shortcut | Equivalent | Example (`name = "user_service"`) |
+|----------|------------|-----------------------------------|
+| `{{ n.snake }}` | `{{ name \| snake }}` | `user_service` |
+| `{{ n.pascal }}` | `{{ name \| pascal }}` | `UserService` |
+| `{{ n.camel }}` | `{{ name \| camel }}` | `userService` |
+| `{{ n.kebab }}` | `{{ name \| kebab }}` | `user-service` |
+| `{{ n.plural }}` | `{{ name \| plural }}` | `user_services` |
+| `{{ n.singular }}` | `{{ name \| singular }}` | `user_service` |
+| `{{ n.past }}` | `{{ name \| past }}` | `user_serviced` |
+
+## Bundle Anatomy
+
+Bundles run multiple generators sequentially. Stored as JSON in `.tag/_bundles/`.
+
+```json
+{
+  "name": "resource",
+  "generators": [
+    { "name": "model" },
+    { "name": "service" },
+    { "name": "handler" }
+  ]
+}
+```
+
+Generators and bundles are **auto-resolved** — no `--bundle` flag needed.
+
+### Self-Contained Bundles
+
+Generators live inside the bundle directory (not root `.tag/`). Distributable and isolated.
+
+```json
+{ "name": "examples", "self_contained": true, "generators": [...] }
+```
+
+```bash
+tag template new bundle examples --self-contained
+tag template new generator hello --in-bundle examples
+tag generate examples world
+```
+
+## Scaffold Templates
+
+For full template syntax, variable types, hooks, and remote references, see [reference.md](reference.md).
+
+For real-world patterns (CRUD bundles, React components, inject patterns), see [recipes.md](recipes.md).
+
+## Project Structure
+
+```
+my-project/
+├── .tag/
+│   ├── _shared/             # Shared fragments ({% include "file.tmpl" %})
+│   ├── _bundles/            # Bundle definitions
+│   │   └── resource.json
+│   ├── my-generator/        # Generator directory
+│   │   └── my-generator.go  # Template file
+│   └── ...
+└── .tagconfig.json          # Created by scaffold (template origin)
+```
+
+## CLI Quick Reference
+
+| Command | Description |
+|---------|-------------|
+| `tag scaffold [template] [name]` | Create project (no args = picker) |
+| `tag generate <gen-or-bundle> <name>` | Run generator or bundle |
+| `tag generate list` | List generators and bundles |
+| `tag template init` | Initialize `.tag/` structure |
+| `tag template new generator <name>` | Create generator (`--in-bundle`, `--lib`) |
+| `tag template new bundle <name>` | Create bundle (`--self-contained`, `--lib`) |
+| `tag template info <template>` | Show template details |
+| `tag convert cookiecutter <src> -o <dst>` | Convert Cookiecutter template |
+| `tag lib add <ref>` | Install template to library |
+| `tag lib ls` | List installed templates |
+| `tag lib rm <name>` | Remove template |
+| `tag lib update [name]` | Update from source |
+
+### Key Flags
+
+| Flag | Commands | Description |
+|------|----------|-------------|
+| `-m key=value` | scaffold, generate | Set variable values |
+| `--values <file>` | scaffold | Load variables from JSON |
+| `--no-input` | scaffold | Skip prompts |
+| `--replay` | scaffold | Reuse saved inputs |
+| `--accept-hooks` | scaffold | Run hooks without prompting |
+| `-l` / `--lib` | template new | Target library template |
+| `-B` / `--in-bundle` | template new generator | Create inside bundle |
+| `-s` / `--self-contained` | template new bundle | Self-contained bundle |
+| `--dry-run` / `-d` | generate, convert | Preview without writing |
+| `--force` | scaffold | Overwrite existing output |
+
+## Pitfalls
+
+- **Gonja, not Jinja2**: No `{% do %}` tag. No `tojson`/`wordwrap`/`batch` filters. TAG registers its own filter set.
+- **Namespace rules**: Generators use `{{ name }}` + `{{ vars.x }}`. Scaffolds use only `{{ vars.x }}`.
+- **Frontmatter is not YAML**: Simple line parser. No nesting, no arrays, no multi-line.
+- **File extensions**: Keep natural extensions (`.go`, `.ts`). Never `.tmpl`.
+- **Derived variable ordering**: If A depends on B, B must appear first in `tag.template.json`.
+- **Empty output**: If template body renders empty, file is still created as empty.
+- **Include resolution**: `{% include %}` resolves by basename — `_shared/header.tmpl` → `"header.tmpl"`.

--- a/skill/recipes.md
+++ b/skill/recipes.md
@@ -1,0 +1,433 @@
+# TAG Recipes
+
+Real-world patterns and examples for TAG template authoring.
+
+## Recipe 1: CRUD Generator Bundle
+
+Generate model, repository, handler, and route injection for a new resource.
+
+**Generators** (each in `.tag/<name>/<name>.go`):
+
+**Model** — `.tag/model/model.go`:
+```
+---
+to: internal/models/{{ name | snake }}.go
+desc: Create a database model struct
+---
+package models
+
+import "time"
+
+type {{ name | pascal }} struct {
+	ID        int64     `json:"id" db:"id"`
+	CreatedAt time.Time `json:"created_at" db:"created_at"`
+	UpdatedAt time.Time `json:"updated_at" db:"updated_at"`
+}
+```
+
+**Repository** — `.tag/repository/repository.go`:
+```
+---
+to: internal/repository/{{ name | snake }}_repository.go
+desc: Create a repository with FindByID
+---
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"myapp/internal/models"
+)
+
+type {{ name | pascal }}Repository struct {
+	db *sql.DB
+}
+
+func New{{ name | pascal }}Repository(db *sql.DB) *{{ name | pascal }}Repository {
+	return &{{ name | pascal }}Repository{db: db}
+}
+
+func (r *{{ name | pascal }}Repository) FindByID(ctx context.Context, id int64) (*models.{{ name | pascal }}, error) {
+	var m models.{{ name | pascal }}
+	err := r.db.QueryRowContext(ctx, "SELECT id, created_at, updated_at FROM {{ name | snake | plural }} WHERE id = $1", id).
+		Scan(&m.ID, &m.CreatedAt, &m.UpdatedAt)
+	if err != nil {
+		return nil, err
+	}
+	return &m, nil
+}
+```
+
+**Handler** — `.tag/handler/handler.go`:
+```
+---
+to: internal/handler/{{ name | snake }}_handler.go
+desc: Create an HTTP handler
+---
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"myapp/internal/repository"
+)
+
+type {{ name | pascal }}Handler struct {
+	repo *repository.{{ name | pascal }}Repository
+}
+
+func New{{ name | pascal }}Handler(repo *repository.{{ name | pascal }}Repository) *{{ name | pascal }}Handler {
+	return &{{ name | pascal }}Handler{repo: repo}
+}
+
+func (h *{{ name | pascal }}Handler) Get(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"resource": "{{ name | snake }}"})
+}
+```
+
+**Route injection** — `.tag/route-inject/route-inject.go`:
+```
+---
+to: internal/router/router.go
+inject: true
+after: "// ROUTES"
+desc: Inject route registration
+---
+	{{ name | camel }}Handler := handler.New{{ name | pascal }}Handler({{ name | camel }}Repo)
+	r.Get("/{{ name | kebab | plural }}", {{ name | camel }}Handler.Get)
+```
+
+**Bundle** — `.tag/_bundles/resource.json`:
+```json
+{
+  "name": "resource",
+  "generators": [
+    { "name": "model" },
+    { "name": "repository" },
+    { "name": "handler" },
+    { "name": "route-inject" }
+  ]
+}
+```
+
+**Usage**: `tag generate resource product` creates all 4 files.
+
+---
+
+## Recipe 2: React Component Generator
+
+Multi-file generator creating component, styles, test, and barrel export.
+
+**Component** — `.tag/component/component.tsx`:
+```
+---
+to: src/components/{{ name | pascal }}/{{ name | pascal }}.tsx
+---
+import React from 'react';
+import styles from './{{ name | pascal }}.module.css';
+
+interface {{ name | pascal }}Props {
+  children?: React.ReactNode;
+}
+
+export const {{ name | pascal }}: React.FC<{{ name | pascal }}Props> = ({ children }) => {
+  return <div className={styles.container}>{children}</div>;
+};
+
+export default {{ name | pascal }};
+```
+
+**Styles** — `.tag/component/styles.tsx`:
+```
+---
+to: src/components/{{ name | pascal }}/{{ name | pascal }}.module.css
+---
+.container {
+  /* {{ name | pascal }} styles */
+}
+```
+
+**Test** — `.tag/component/test.tsx`:
+```
+---
+to: src/components/{{ name | pascal }}/{{ name | pascal }}.test.tsx
+---
+import { render, screen } from '@testing-library/react';
+import { {{ name | pascal }} } from './{{ name | pascal }}';
+
+describe('{{ name | pascal }}', () => {
+  it('renders children', () => {
+    render(<{{ name | pascal }}>Hello</{{ name | pascal }}>);
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+  });
+});
+```
+
+**Index** — `.tag/component/index.tsx`:
+```
+---
+to: src/components/{{ name | pascal }}/index.ts
+---
+export { {{ name | pascal }} } from './{{ name | pascal }}';
+export type { {{ name | pascal }}Props } from './{{ name | pascal }}';
+```
+
+**Usage**: `tag generate component sidebar` creates the full component directory.
+
+---
+
+## Recipe 3: Inject Patterns
+
+### Registry injection
+
+Pre-existing file with marker:
+```go
+var handlers = map[string]Handler{
+	// HANDLERS
+}
+```
+
+Generator injects before marker:
+```
+---
+to: internal/registry/registry.go
+inject: true
+before: "// HANDLERS"
+---
+	"{{ name | kebab }}": New{{ name | pascal }}Handler(),
+```
+
+### Import injection
+
+```
+---
+to: internal/registry/registry.go
+inject: true
+after: "import ("
+---
+	"myapp/internal/handler/{{ name | snake }}"
+```
+
+### Multi-point injection
+
+One generator directory, multiple files targeting different injection points:
+```
+.tag/feature/
+├── create.go        # Creates the main file
+├── inject-route.go  # Injects route registration
+└── inject-import.go # Injects import statement
+```
+
+---
+
+## Recipe 4: Meta Variables for Customization
+
+Override defaults with `--meta` flags:
+
+```
+---
+to: {{ vars.package | default("internal/services") }}/{{ name | snake }}.go
+---
+package {{ vars.package | default("services") | split("/") | last }}
+
+type {{ name | pascal }}Service struct{}
+```
+
+```bash
+tag generate service auth                       # → internal/services/auth.go
+tag generate service auth -m package=pkg/svc    # → pkg/svc/auth.go
+```
+
+---
+
+## Recipe 5: Shared Template Fragments
+
+`.tag/_shared/header.tmpl`:
+```
+// Code generated by TAG. DO NOT EDIT.
+// Source: {{ name }}
+```
+
+Used in generators:
+```
+---
+to: internal/services/{{ name | snake }}.go
+---
+{% include "header.tmpl" %}
+
+package services
+
+type {{ name | pascal }}Service struct{}
+```
+
+`{% include %}` resolves by **basename**.
+
+---
+
+## Recipe 6: Go Service Scaffold Template
+
+Full scaffold with variables, conditionals, hooks, and bundled generators.
+
+**tag.template.json**:
+```json
+{
+  "name": "go-service",
+  "description": "Go microservice with HTTP server",
+  "version": "1.0.0",
+  "vars": {
+    "project_name": "my-service",
+    "go_module": {
+      "type": "string",
+      "prompt": "Go module path",
+      "required": true
+    },
+    "port": { "type": "number", "default": 8080 },
+    "use_docker": { "type": "boolean", "default": true },
+    "_slug": "{{ vars.project_name | snake }}"
+  },
+  "hooks": {
+    "post_scaffold": [
+      "cd {{ vars.project_name | snake }} && go mod tidy",
+      "cd {{ vars.project_name | snake }} && git init"
+    ]
+  }
+}
+```
+
+**Conditional file** — `{{ vars.project_name | snake }}/Dockerfile`:
+```dockerfile
+{% if vars.use_docker %}FROM golang:1.23-alpine AS builder
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -o /server ./cmd/server
+
+FROM alpine:3.19
+COPY --from=builder /server /server
+EXPOSE {{ vars.port }}
+CMD ["/server"]
+{% endif %}
+```
+
+**Bundled generator** — `_generators/endpoint/endpoint.go`:
+```
+---
+to: internal/handler/{{ name | snake }}.go
+---
+package handler
+
+import "net/http"
+
+func {{ name | pascal }}Handler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+```
+
+**Usage**:
+```bash
+tag lib add ./go-service-template
+tag scaffold go-service my-api
+cd my-api && tag generate endpoint users
+```
+
+---
+
+## Recipe 7: Self-Contained Bundles
+
+Distributable bundle with generators inside:
+
+```bash
+tag template new bundle examples --self-contained
+tag template new generator hello --in-bundle examples
+tag template new generator greet --in-bundle examples
+```
+
+Creates:
+```
+.tag/_bundles/examples/
+├── examples.json         # {"self_contained": true, ...}
+├── _shared/              # Bundle-scoped shared templates
+├── hello/hello.go
+└── greet/greet.go
+```
+
+`tag generate examples world` runs all generators with `name="world"`.
+
+Works with `--lib` to add bundles to library templates.
+
+---
+
+## Recipe 8: Converting Cookiecutter Templates
+
+```bash
+# Direct scaffold (auto-detects and converts on the fly)
+tag scaffold gh:user/cookiecutter-django my-project
+
+# Explicit conversion
+tag convert cookiecutter ./cc-template -o ./tag-template
+
+# Add to library (auto-converts)
+tag lib add gh:user/cookiecutter-flask --as flask
+```
+
+Conversion maps: `cookiecutter.json` → `tag.template.json`, `{{ cookiecutter.var }}` → `{{ vars.var }}`.
+
+---
+
+## Recipe 9: Non-Interactive / CI Scaffolding
+
+```bash
+# All variables via flags
+tag scaffold gh:user/template my-project \
+  --no-input --accept-hooks \
+  -m project_name=my-project \
+  -m author="CI Bot" \
+  -m license=MIT
+
+# Or via values file
+tag scaffold gh:user/template my-project \
+  --no-input --accept-hooks \
+  --values values.json
+
+# Replay previous inputs
+tag scaffold gh:user/template another-project --replay
+```
+
+---
+
+## Recipe 10: .tagignore for Template Authoring
+
+Exclude development artifacts from scaffolded output:
+
+```
+# AI assistants
+.serena/
+CLAUDE.md
+.mcp.json
+.cursor/
+
+# IDE
+.vscode/
+.idea/
+
+# Dev artifacts
+*.log
+tmp/
+docs/internal/
+```
+
+Template layout:
+```
+my-template/
+├── tag.template.json
+├── .tagignore              ← Controls exclusions
+├── .serena/                ← NOT copied to output
+├── CLAUDE.md               ← NOT copied to output
+├── {{ vars.project_name }}/
+│   ├── main.go
+│   └── README.md
+└── _generators/
+    └── handler/handler.go
+```

--- a/skill/reference.md
+++ b/skill/reference.md
@@ -1,0 +1,306 @@
+# TAG Reference
+
+Detailed reference for template syntax, variable system, hooks, and remote templates.
+
+## Template Syntax
+
+TAG uses **Gonja** (Go port of Jinja2). Templates use `{{ vars.* }}` namespace.
+
+### Filters
+
+#### Case Transforms
+
+| Filter | Input | Output |
+|--------|-------|--------|
+| `snake` | `UserService` | `user_service` |
+| `pascal` | `user_service` | `UserService` |
+| `camel` | `user_service` | `userService` |
+| `kebab` | `user_service` | `user-service` |
+| `lower` | `UserService` | `userservice` |
+| `upper` | `UserService` | `USERSERVICE` |
+| `title` | `user service` | `User Service` |
+
+Aliases: `snake_case`, `pascal_case`, `camel_case`, `kebab_case`
+
+#### Inflection
+
+| Filter | Input | Output |
+|--------|-------|--------|
+| `plural` / `pluralize` | `service` | `services` |
+| `singular` / `singularize` | `services` | `service` |
+| `past` / `past_tense` | `OrderCancel` | `OrderCancelled` |
+| `humanize` | `user_service` | `User service` |
+| `titleize` | `user_service` | `User Service` |
+| `ordinalize` | `3` | `3rd` |
+
+The `past` filter handles irregular verbs, consonant doubling, and preserves casing style.
+
+#### String Operations
+
+| Filter | Signature | Description |
+|--------|-----------|-------------|
+| `replace` | `replace(old, new)` | Replace all occurrences |
+| `split` | `split(delim?)` | Split string (default: whitespace) |
+| `join` | `join(sep?)` | Join list to string |
+| `trim` | `trim(cutset?)` | Trim whitespace or cutset |
+| `contains` | `contains(substr)` | Returns boolean |
+| `hasprefix` | `hasprefix(prefix)` | Returns boolean |
+| `hassuffix` | `hassuffix(suffix)` | Returns boolean |
+| `default` | `default(value)` | Fallback if nil/empty |
+| `truncate` | `truncate(len, ellipsis?)` | Truncate with "..." |
+
+### String Methods
+
+Python-style method calls on strings:
+
+```jinja2
+{{ vars.name.lower() }}
+{{ vars.name.upper() }}
+{{ vars.name.replace("old", "new") }}
+{{ vars.name.replace("a", "b", 1) }}    {# with count #}
+{{ vars.name.startswith("prefix") }}
+```
+
+### Control Structures
+
+```jinja2
+{% if vars.use_docker %}...{% endif %}
+{% for item in vars.features %}...{% endfor %}
+{% if vars.db == "postgres" %}...{% elif vars.db == "mysql" %}...{% else %}...{% endif %}
+```
+
+### Includes
+
+Shared fragments in `_shared/` resolve by basename:
+
+```jinja2
+{% include "header.tmpl" %}   {# resolves _shared/header.tmpl #}
+```
+
+### Whitespace Control
+
+```jinja2
+{%- if condition -%}    {# strips surrounding whitespace #}
+{{- value -}}
+```
+
+### Comments
+
+```jinja2
+{# This won't appear in output #}
+```
+
+## Scaffold Template Configuration
+
+### tag.template.json
+
+```json
+{
+  "name": "my-template",
+  "description": "A Go web service template",
+  "version": "1.0.0",
+  "vars": {
+    "project_name": "my-project",
+    "author": {
+      "type": "string",
+      "prompt": "Who is the author?",
+      "required": true
+    },
+    "license": {
+      "type": "choice",
+      "prompt": "Select a license",
+      "options": ["MIT", "Apache-2.0", "GPL-3.0"],
+      "default": "MIT"
+    },
+    "use_docker": {
+      "type": "boolean",
+      "prompt": "Include Docker support?",
+      "default": true
+    },
+    "port": {
+      "type": "number",
+      "default": 8080
+    },
+    "_slug": "{{ vars.project_name | snake }}"
+  },
+  "hooks": {
+    "pre_scaffold": ["echo 'Starting...'"],
+    "post_scaffold": ["go mod tidy", "git init"]
+  }
+}
+```
+
+### Variable Definition Formats
+
+**Short form** — just a default value:
+
+```json
+{ "vars": { "project_name": "my-project", "use_docker": true, "port": 8080 } }
+```
+
+**Long form** — full definition:
+
+```json
+{
+  "vars": {
+    "author": {
+      "type": "string",
+      "prompt": "Who is the author?",
+      "default": "Anonymous",
+      "required": true,
+      "secret": false
+    }
+  }
+}
+```
+
+### Variable Types
+
+| Type | JSON type | Prompt behavior |
+|------|-----------|-----------------|
+| `string` | `"value"` | Text input |
+| `boolean` | `true`/`false` | Yes/No confirmation |
+| `number` | `123` | Numeric input |
+| `choice` | requires `options` | Selection from list |
+
+### Special Variable Kinds
+
+**Private** (prefix `_`): Not prompted, internal use.
+
+```json
+{ "_internal_slug": "{{ vars.project_name | snake }}" }
+```
+
+**Derived**: Default contains `{{ vars.* }}`. Not prompted, computed from other variables.
+
+```json
+{
+  "display_name": "My Package",
+  "package_name": "{{ vars.display_name | lower | replace(' ', '_') }}"
+}
+```
+
+Only `display_name` is prompted; `package_name` is computed.
+
+### Variable Resolution Priority
+
+From lowest to highest:
+
+1. Default values from `tag.template.json`
+2. Replay values (`--replay`)
+3. Values file (`--values`)
+4. Interactive prompts (if TTY)
+5. `--meta` / `-m` flags (highest priority)
+
+### Path Placeholders
+
+Directory and file names support template expressions:
+
+```
+{{ vars.project_name | snake }}/
+  {{ vars.project_name | snake }}_test.go
+```
+
+### .tagignore
+
+Excludes files from scaffold output using gitignore syntax. Place in template root.
+
+```
+# Exclude authoring tools
+.serena/
+CLAUDE.md
+.mcp.json
+.vscode/
+*.log
+```
+
+- Standard gitignore patterns (globs, `**/`, negation with `!`)
+- `.tagignore` itself is always excluded from output
+- Directories matching a pattern are pruned entirely
+
+### Bundled Generators
+
+Templates can include generators in `_generators/` — copied to scaffolded project's `.tag/`.
+
+## Hooks
+
+### Phases
+
+| Phase | Working dir | When | On failure |
+|-------|-------------|------|------------|
+| `pre_scaffold` | Template dir | Before generation | Fatal — stops |
+| `post_scaffold` | Output dir | After generation | Warning only |
+| `pre_generate` | Project dir | Before codegen | Fatal |
+| `post_generate` | Project dir | After codegen | Fatal |
+
+### Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `TAG_TEMPLATE_DIR` | Absolute path to template directory |
+| `TAG_OUTPUT_DIR` | Absolute path to project root |
+| `TAG_PROJECT_NAME` | Value of `project_name` variable |
+| `TAG_VAR_<NAME>` | Each variable as `TAG_VAR_` + UPPER_SNAKE |
+
+### Execution Rules
+
+- Commands support `{{ vars.* }}` expressions (rendered before execution)
+- Parsed with POSIX shell quoting (shlex) — no pipes/redirects by default
+- For shell features: `sh -c 'echo hello | grep hello'`
+- Script files auto-detected by extension (`.py` → python, `.sh` → sh)
+- Shebangs respected if executable bit set
+- 5-minute timeout, 1MB output limit
+
+### Confirmation Behavior
+
+- Interactive: User prompted to confirm
+- `--accept-hooks`: Run without prompting
+- `--no-input` without `--accept-hooks`: Hooks skipped
+
+## Remote Templates
+
+### Reference Formats
+
+| Format | Example |
+|--------|---------|
+| GitHub shorthand | `gh:user/repo` |
+| GitLab shorthand | `gl:user/repo` |
+| Bitbucket shorthand | `bb:user/repo` |
+| With version | `gh:user/repo@v1.0.0` |
+| With subpath | `gh:user/repo/templates/go-api` |
+| Version + subpath | `gh:user/repo@v2.0.0/templates/go-api` |
+| HTTPS URL | `https://github.com/user/repo.git` |
+| SSH URL | `git@github.com:user/repo.git` |
+| Zip URL | `https://example.com/template.zip` |
+| Local path | `./my-template` or `/absolute/path` |
+
+### Authentication
+
+| Provider | Env var | Method |
+|----------|---------|--------|
+| GitHub | `GITHUB_TOKEN` | Basic auth (`x-access-token`) |
+| GitLab | `GITLAB_TOKEN` | Basic auth (`x-access-token`) |
+| Bitbucket | `BITBUCKET_TOKEN` | Bearer token |
+| SSH | SSH agent or default keys | SSH key |
+
+### Library Management
+
+```bash
+tag lib add gh:user/template           # Install
+tag lib add gh:user/template --as name # Custom name
+tag lib ls                             # List
+tag lib edit my-template               # Open in editor
+tag lib update my-template             # Re-fetch
+tag lib update                         # Update all
+tag lib rm my-template                 # Remove
+```
+
+Cookiecutter templates are auto-detected and converted when added.
+
+### Cache Management
+
+```bash
+tag cache list                         # Show cached templates
+tag cache clear                        # Clear expired entries
+tag cache clear --all                  # Clear entire cache
+```


### PR DESCRIPTION
## Summary

- Add `skill/` directory with structured TAG authoring skill (SKILL.md + reference.md + recipes.md) consolidating TAG_REFERENCE.md and TAG_RECIPES.md into a multi-file skill format optimized for AI agent consumption
- Update CLAUDE.md rule #6 and Documentation section to reference new skill files
- Update README.md AI assistant pointer to the new skill

## Details

Consolidates ~1,481 lines from TAG_REFERENCE.md and TAG_RECIPES.md into 932 lines (~37% reduction) across three files with progressive disclosure:
- **SKILL.md** (193 lines): Decision tree, generator/bundle anatomy, CLI quick reference, pitfalls
- **reference.md** (306 lines): Full syntax, filters, variable system, hooks, remote templates
- **recipes.md** (433 lines): 10 real-world patterns (CRUD bundles, inject patterns, scaffolds, CI usage)

## Test plan

- [x] Verify skill files render correctly on GitHub
- [x] Verify no broken links in CLAUDE.md or README.md
- [x] Confirm old TAG_REFERENCE.md and TAG_RECIPES.md can be removed in a follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)