### PR TITLE
docs: fix stale TAG_REFERENCE.md link

### DIFF
--- a/docs/commands/new.md
+++ b/docs/commands/new.md
@@ -178,7 +178,7 @@ tag template new generator greet --in-bundle examples
 
 This creates generators at `.tag/_bundles/examples/hello/` and `.tag/_bundles/examples/greet/` instead of `.tag/hello/`. Self-contained bundles are distributable and don't depend on project-level generators.
 
-See [Self-Contained Bundles](../../TAG_REFERENCE.md#self-contained-bundles) in the TAG Reference for details.
+See [Self-Contained Bundles](../../.skill/SKILL.md#self-contained-bundles) in the TAG skill reference for details.
 
 ## --lib Flag
 


### PR DESCRIPTION
## Summary

- Fix broken link in `docs/commands/new.md` pointing to removed `TAG_REFERENCE.md`
- Now points to `.skill/SKILL.md#self-contained-bundles`

## Test plan

- [ ] Verify link resolves on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)