### PR TITLE
fix: show bundle descriptions in generate list

### DIFF
--- a/internal/commands/generate_list.go
+++ b/internal/commands/generate_list.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/kaikenlabs/tag/internal/chalk"
 	"github.com/kaikenlabs/tag/internal/config"
+	"github.com/kaikenlabs/tag/internal/engine"
 	"github.com/kaikenlabs/tag/internal/scaffold"
 	"github.com/kaikenlabs/tag/internal/template"
 	"github.com/kaikenlabs/tag/internal/types"
@@ -179,7 +181,36 @@ func scanGenerators(dir string) []generatorInfo {
 
 // scanBundles scans a bundles directory for bundle definitions.
 func scanBundles(dir string) []generatorInfo {
-	return scanDirEntries(dir, false)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+
+	var result []generatorInfo
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if strings.HasPrefix(name, "_") || strings.HasPrefix(name, ".") {
+			continue
+		}
+
+		info := generatorInfo{Name: name}
+
+		// Read description from bundle manifest (<name>/<name>.json).
+		manifestPath := filepath.Join(dir, name, name+types.BundleExtension)
+		data, readErr := os.ReadFile(manifestPath)
+		if readErr == nil {
+			var bundle engine.Bundle
+			if jsonErr := json.Unmarshal(data, &bundle); jsonErr == nil {
+				info.Description = bundle.Description
+			}
+		}
+
+		result = append(result, info)
+	}
+	return result
 }
 
 // readFrontmatterDesc reads the first template file in a generator directory

--- a/internal/commands/generate_test.go
+++ b/internal/commands/generate_test.go
@@ -931,6 +931,24 @@ func TestUT_GenerateList_WithBundles(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestUT_GenerateList_BundleDescriptionShown(t *testing.T) {
+	tmpDir := setupTempDir(t)
+
+	// Create a generator so the list is non-empty.
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "component"), 0o750))
+
+	// Create a bundle with a description field.
+	createBundle(t, tmpDir, "feature", `{"name":"feature","description":"Scaffolds a full feature","generators":[{"name":"component"}]}`)
+
+	cfg := createTestConfig(t, tmpDir)
+
+	var buf bytes.Buffer
+	err := generateList(cfg, &buf)
+
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "Scaffolds a full feature")
+}
+
 func TestUT_GenerateList_NoConfig(t *testing.T) {
 	err := generateList(nil, io.Discard)
 

--- a/internal/engine/types.go
+++ b/internal/engine/types.go
@@ -25,6 +25,7 @@ type GeneratorRef struct {
 
 type Bundle struct {
 	Name          string         `json:"name" yaml:"name"`
+	Description   string         `json:"description,omitempty" yaml:"description,omitempty"`
 	SelfContained bool           `json:"self_contained,omitempty" yaml:"self_contained,omitempty"`
 	Generators    []GeneratorRef `json:"generators" yaml:"generators"`
 }


### PR DESCRIPTION
## Summary
- `tag generate list` was not showing descriptions for bundles, only for generators
- `scanBundles` passed `readDescription=false` to `scanDirEntries`, so descriptions were silently skipped
- Added `Description` field to `engine.Bundle` struct and replaced `scanBundles` with a dedicated implementation that reads the bundle manifest JSON

## Test plan
- [x] Added `TestUT_GenerateList_BundleDescriptionShown` — creates a bundle with a description and verifies it appears in output
- [x] All existing tests pass
- [x] Manual: run `tag generate list` in a project with bundles that have `"description"` in their manifest

🤖 Generated with [Claude Code](https://claude.com/claude-code)