### PR TITLE
fix: skip prompting for variables provided via --meta flag

### DIFF
--- a/internal/scaffold/variables.go
+++ b/internal/scaffold/variables.go
@@ -116,8 +116,11 @@ func (c *DefaultVariableCollector) Collect(config *TemplateConfig, opts Options)
 				continue
 			}
 
-			// Skip if explicitly provided via replay or values file
+			// Skip if explicitly provided via replay, values file, or --meta flag
 			if explicitlyProvided[name] {
+				continue
+			}
+			if _, hasMeta := opts.Meta[name]; hasMeta {
 				continue
 			}
 

--- a/internal/scaffold/variables_test.go
+++ b/internal/scaffold/variables_test.go
@@ -344,6 +344,72 @@ func TestUT_VariableCollector_DerivedVarsWithMethodCalls(t *testing.T) {
 	assert.Equal(t, 1, mockPrompter.CallCount["Input"])
 }
 
+func TestUT_VariableCollector_MetaSkipsPrompt(t *testing.T) {
+	// Variables provided via --meta flag should NOT be prompted in interactive mode
+	mockPrompter := NewMockPrompter()
+	mockPrompter.InputResults["Enter value for prompted_var"] = "prompted_value"
+	collector := NewVariableCollector(mockPrompter)
+
+	config := &TemplateConfig{
+		Vars: map[string]VariableDef{
+			"meta_var":     {Type: VarTypeString, Default: "default"},
+			"prompted_var": {Type: VarTypeString, Default: "default"},
+		},
+	}
+
+	opts := Options{
+		Meta: map[string]string{
+			"meta_var": "from_meta",
+		},
+		IsTTY: true,
+	}
+
+	vars, err := collector.Collect(config, opts)
+	require.NoError(t, err)
+
+	// meta_var should come from --meta (not prompted)
+	assert.Equal(t, "from_meta", vars["meta_var"])
+	// prompted_var should be prompted since it wasn't in --meta
+	assert.Equal(t, "prompted_value", vars["prompted_var"])
+	// Only one prompt should have happened (prompted_var only)
+	assert.Equal(t, 1, mockPrompter.CallCount["Input"])
+}
+
+func TestUT_VariableCollector_MetaSkipsPromptAllTypes(t *testing.T) {
+	// Verify --meta skips prompts for boolean, number, and choice types too
+	mockPrompter := NewMockPrompter()
+	collector := NewVariableCollector(mockPrompter)
+
+	config := &TemplateConfig{
+		Vars: map[string]VariableDef{
+			"bool_var":   {Type: VarTypeBoolean, Default: false},
+			"number_var": {Type: VarTypeNumber, Default: float64(0)},
+			"choice_var": {Type: VarTypeChoice, Options: []string{"a", "b"}, Default: "a"},
+		},
+	}
+
+	opts := Options{
+		Meta: map[string]string{
+			"bool_var":   "true",
+			"number_var": "42",
+			"choice_var": "b",
+		},
+		IsTTY: true,
+	}
+
+	vars, err := collector.Collect(config, opts)
+	require.NoError(t, err)
+
+	assert.Equal(t, true, vars["bool_var"])
+	assert.Equal(t, float64(42), vars["number_var"])
+	assert.Equal(t, "b", vars["choice_var"])
+	// No prompts should have happened
+	assert.Equal(t, 0, mockPrompter.CallCount["Input"])
+	assert.Equal(t, 0, mockPrompter.CallCount["Confirm"])
+	assert.Equal(t, 0, mockPrompter.CallCount["Number"])
+	assert.Equal(t, 0, mockPrompter.CallCount["Select"])
+}
+
 func TestUT_VariableCollector_TypeCoercion(t *testing.T) {
 	mockPrompter := NewMockPrompter()
 	collector := NewVariableCollector(mockPrompter)


### PR DESCRIPTION
## Summary
- Variables passed with `-m`/`--meta` were still being interactively prompted because the prompting loop in `Collect()` only checked replay and values-file sources (`explicitlyProvided` map). The meta overrides were applied in Step 5 (after prompting in Step 4), making the prompts redundant.
- Added a check in the prompt loop to also skip variables present in `opts.Meta`.
- Added two unit tests covering string, boolean, number, and choice variable types.

## Test plan
- [x] `TestUT_VariableCollector_MetaSkipsPrompt` — meta-supplied string var skips prompting, other vars still prompted
- [x] `TestUT_VariableCollector_MetaSkipsPromptAllTypes` — all types (bool, number, choice) skip prompting when supplied via meta
- [x] Full scaffold test suite passes
- [x] Manual: `tag scaffold <template> <name> -m key=value` no longer prompts for `key`

🤖 Generated with [Claude Code](https://claude.com/claude-code)