### PR TITLE
feat: add `tag update` self-update command

### DIFF
--- a/.skill/SKILL.md
+++ b/.skill/SKILL.md
@@ -166,6 +166,8 @@ my-project/
 | `tag lib ls` | List installed templates |
 | `tag lib rm <name>` | Remove template |
 | `tag lib update [name]` | Update from source |
+| `tag update` | Self-update to latest release |
+| `tag version [--check]` | Print version, check for updates |
 
 ### Key Flags
 

--- a/.skill/reference.md
+++ b/.skill/reference.md
@@ -304,3 +304,12 @@ tag cache list                         # Show cached templates
 tag cache clear                        # Clear expired entries
 tag cache clear --all                  # Clear entire cache
 ```
+
+### Self-Update
+
+```bash
+tag update                             # Download and install latest release
+tag version --check                    # Check if update available
+```
+
+Downloads the platform-appropriate binary from GitHub Releases, verifies its SHA256 checksum, and replaces the current binary in-place.

--- a/internal/commands/update.go
+++ b/internal/commands/update.go
@@ -1,0 +1,81 @@
+package commands
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/kaikenlabs/tag/internal/update"
+	"github.com/kaikenlabs/tag/pkg/app"
+)
+
+// UpdateCommand returns the CLI command for self-updating TAG.
+func UpdateCommand(version string) *cli.Command {
+	return &cli.Command{
+		Name:  "update",
+		Usage: "Update TAG to the latest version",
+		Description: `Downloads and installs the latest TAG release from GitHub.
+
+Checks the current version against the latest release, downloads the
+appropriate binary for the current platform, verifies its SHA256 checksum,
+and replaces the running binary in-place.
+
+Examples:
+  tag update`,
+		Action: func(c *cli.Context) error {
+			return updateAction(c, os.Stdout, version, defaultGitHubRepo)
+		},
+	}
+}
+
+func updateAction(c *cli.Context, w io.Writer, currentVersion, repoURL string) error {
+	fmt.Fprintln(w, "Checking for latest version...")
+
+	latest, err := fetchLatestVersion(c.Context, repoURL)
+	if err != nil {
+		return app.Errorf("failed to check for updates: %w", err)
+	}
+
+	current := strings.TrimPrefix(currentVersion, "v")
+	latestClean := strings.TrimPrefix(latest, "v")
+
+	if !isDevBuild(currentVersion) && current == latestClean {
+		fmt.Fprintf(w, "Already up to date! (v%s)\n", current)
+		return nil
+	}
+
+	if isDevBuild(currentVersion) {
+		fmt.Fprintf(w, "Development build detected, updating to latest release v%s...\n", latestClean)
+	} else {
+		fmt.Fprintf(w, "Updating tag v%s → v%s...\n", current, latestClean)
+	}
+
+	binaryPath, err := resolveBinaryPath()
+	if err != nil {
+		return app.Errorf("cannot determine binary path: %w", err)
+	}
+
+	updater := update.New(repoURL, w)
+	if err := updater.Update(c.Context, latest, binaryPath); err != nil {
+		return app.Errorf("update failed: %w", err)
+	}
+
+	fmt.Fprintf(w, "Successfully updated to v%s!\n", latestClean)
+
+	return nil
+}
+
+// resolveBinaryPath returns the real path of the currently running executable,
+// resolving any symlinks.
+func resolveBinaryPath() (string, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("find executable: %w", err)
+	}
+
+	return filepath.EvalSymlinks(exe)
+}

--- a/internal/commands/update_test.go
+++ b/internal/commands/update_test.go
@@ -1,0 +1,113 @@
+package commands
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+)
+
+func TestUT_UpdateAction_AlreadyUpToDate(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "https://github.com/kaikenlabs/tag/releases/tag/v1.0.0", http.StatusFound)
+	}))
+	defer srv.Close()
+
+	app := &cli.App{
+		Commands: []*cli.Command{
+			{
+				Name: "update",
+				Action: func(c *cli.Context) error {
+					var buf bytes.Buffer
+					err := updateAction(c, &buf, "v1.0.0", srv.URL)
+					require.NoError(t, err)
+					assert.Contains(t, buf.String(), "Already up to date!")
+					return nil
+				},
+			},
+		},
+	}
+	require.NoError(t, app.Run([]string{"app", "update"}))
+}
+
+func TestUT_UpdateAction_DevBuildProceeds(t *testing.T) {
+	// For dev builds, updateAction should NOT say "already up to date" — it should
+	// proceed to the update. We test that it at least reaches the "Development build"
+	// message and attempts to update (which will fail since we don't serve the archive).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/releases/latest" {
+			http.Redirect(w, r, "https://github.com/kaikenlabs/tag/releases/tag/v2.0.0", http.StatusFound)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	app := &cli.App{
+		Commands: []*cli.Command{
+			{
+				Name: "update",
+				Action: func(c *cli.Context) error {
+					var buf bytes.Buffer
+					err := updateAction(c, &buf, "dev", srv.URL)
+					// Will error because download fails, but should show dev build message.
+					assert.Contains(t, buf.String(), "Development build detected")
+					assert.Error(t, err)
+					return nil
+				},
+			},
+		},
+	}
+	require.NoError(t, app.Run([]string{"app", "update"}))
+}
+
+func TestUT_UpdateAction_UpdateAvailable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/releases/latest" {
+			http.Redirect(w, r, "https://github.com/kaikenlabs/tag/releases/tag/v2.0.0", http.StatusFound)
+			return
+		}
+		// Return 404 for archive/checksums — we only test the messaging here.
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	app := &cli.App{
+		Commands: []*cli.Command{
+			{
+				Name: "update",
+				Action: func(c *cli.Context) error {
+					var buf bytes.Buffer
+					err := updateAction(c, &buf, "v1.0.0", srv.URL)
+					// Will error because download fails, but should show update message.
+					assert.Contains(t, buf.String(), "Updating tag v1.0.0 → v2.0.0")
+					assert.Error(t, err)
+					return nil
+				},
+			},
+		},
+	}
+	require.NoError(t, app.Run([]string{"app", "update"}))
+}
+
+func TestUT_UpdateAction_FetchVersionError(t *testing.T) {
+	app := &cli.App{
+		Commands: []*cli.Command{
+			{
+				Name: "update",
+				Action: func(c *cli.Context) error {
+					var buf bytes.Buffer
+					err := updateAction(c, &buf, "v1.0.0", "http://127.0.0.1:1")
+					require.Error(t, err)
+					assert.Contains(t, err.Error(), "failed to check for updates")
+					return nil
+				},
+			},
+		},
+	}
+	require.NoError(t, app.Run([]string{"app", "update"}))
+}

--- a/internal/commands/version.go
+++ b/internal/commands/version.go
@@ -76,9 +76,7 @@ func versionCheckAction(ctx context.Context, w io.Writer, currentVersion, repoUR
 	}
 
 	fmt.Fprintf(w, "Update available: v%s → v%s\n\n", current, latestClean)
-	fmt.Fprintf(w, "  go install github.com/kaikenlabs/tag@v%s\n", latestClean)
-	fmt.Fprintf(w, "  # or\n")
-	fmt.Fprintf(w, "  curl -sSfL https://raw.githubusercontent.com/kaikenlabs/tag/main/install.sh | sh\n")
+	fmt.Fprintf(w, "  tag update\n")
 
 	return nil
 }

--- a/internal/commands/version_test.go
+++ b/internal/commands/version_test.go
@@ -107,7 +107,7 @@ func TestUT_VersionCheckAction_UpdateAvailable(t *testing.T) {
 	err := versionCheckAction(context.Background(), &buf, "v1.0.0", srv.URL)
 	require.NoError(t, err)
 	assert.Contains(t, buf.String(), "Update available: v1.0.0 → v2.0.0")
-	assert.Contains(t, buf.String(), "go install")
+	assert.Contains(t, buf.String(), "tag update")
 }
 
 func TestUT_VersionCheckAction_DevBuild(t *testing.T) {

--- a/internal/update/errors.go
+++ b/internal/update/errors.go
@@ -1,0 +1,32 @@
+package update
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Sentinel errors for update operations.
+var (
+	// ErrUnsupportedPlatform indicates the current OS/architecture is not supported.
+	ErrUnsupportedPlatform = errors.New("unsupported platform")
+
+	// ErrChecksumMismatch indicates the downloaded archive failed SHA256 verification.
+	ErrChecksumMismatch = errors.New("checksum mismatch")
+
+	// ErrBinaryNotFound indicates the binary was not found inside the archive.
+	ErrBinaryNotFound = errors.New("binary not found in archive")
+)
+
+// UpdateError represents an error during the update process.
+type UpdateError struct {
+	Op  string // "download", "verify", "extract", "replace"
+	Err error
+}
+
+func (e *UpdateError) Error() string {
+	return fmt.Sprintf("update %s: %v", e.Op, e.Err)
+}
+
+func (e *UpdateError) Unwrap() error {
+	return e.Err
+}

--- a/internal/update/extract.go
+++ b/internal/update/extract.go
@@ -1,0 +1,76 @@
+package update
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// maxBinarySize is the maximum allowed binary size (256 MB) to guard against decompression bombs.
+const maxBinarySize = 256 << 20
+
+// extractFromTarGz extracts the named binary from a tar.gz archive and writes it to destDir.
+// Returns the path to the extracted binary.
+func extractFromTarGz(archivePath, binaryName, destDir string) (string, error) {
+	f, err := os.Open(archivePath)
+	if err != nil {
+		return "", fmt.Errorf("open archive: %w", err)
+	}
+	defer f.Close()
+
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return "", fmt.Errorf("gzip reader: %w", err)
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return "", fmt.Errorf("read tar: %w", err)
+		}
+
+		// Match the binary name regardless of directory prefix in the archive.
+		if filepath.Base(hdr.Name) != binaryName {
+			continue
+		}
+
+		if hdr.Typeflag != tar.TypeReg {
+			continue
+		}
+
+		destPath := filepath.Join(destDir, binaryName)
+
+		out, err := os.OpenFile(destPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
+		if err != nil {
+			return "", fmt.Errorf("create output file: %w", err)
+		}
+
+		if _, err := io.Copy(out, io.LimitReader(tr, maxBinarySize)); err != nil {
+			out.Close()
+			return "", fmt.Errorf("extract binary: %w", err)
+		}
+
+		if err := out.Sync(); err != nil {
+			out.Close()
+			return "", fmt.Errorf("sync binary: %w", err)
+		}
+
+		if err := out.Close(); err != nil {
+			return "", fmt.Errorf("close binary: %w", err)
+		}
+
+		return destPath, nil
+	}
+
+	return "", fmt.Errorf("%w: %s", ErrBinaryNotFound, binaryName)
+}

--- a/internal/update/extract_test.go
+++ b/internal/update/extract_test.go
@@ -1,0 +1,89 @@
+package update
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUT_ExtractFromTarGz_Success(t *testing.T) {
+	archivePath := createTestTarGz(t, "tag", "hello-binary-content")
+	destDir := t.TempDir()
+
+	result, err := extractFromTarGz(archivePath, "tag", destDir)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(destDir, "tag"), result)
+
+	content, err := os.ReadFile(result)
+	require.NoError(t, err)
+	assert.Equal(t, "hello-binary-content", string(content))
+}
+
+func TestUT_ExtractFromTarGz_NestedPath(t *testing.T) {
+	// Binary inside a subdirectory in the archive (GoReleaser pattern).
+	archivePath := createTestTarGzWithPath(t, "tag_1.0.0_Darwin_arm64/tag", "binary-data")
+	destDir := t.TempDir()
+
+	result, err := extractFromTarGz(archivePath, "tag", destDir)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(result)
+	require.NoError(t, err)
+	assert.Equal(t, "binary-data", string(content))
+}
+
+func TestUT_ExtractFromTarGz_BinaryNotFound(t *testing.T) {
+	archivePath := createTestTarGz(t, "other-binary", "content")
+	destDir := t.TempDir()
+
+	_, err := extractFromTarGz(archivePath, "tag", destDir)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrBinaryNotFound)
+}
+
+func TestUT_ExtractFromTarGz_InvalidArchive(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "bad.tar.gz")
+	require.NoError(t, os.WriteFile(tmpFile, []byte("not a tar.gz"), 0o644))
+
+	_, err := extractFromTarGz(tmpFile, "tag", t.TempDir())
+	require.Error(t, err)
+}
+
+// createTestTarGz creates a tar.gz archive with a single file at the top level.
+func createTestTarGz(t *testing.T, name, content string) string {
+	t.Helper()
+	return createTestTarGzWithPath(t, name, content)
+}
+
+// createTestTarGzWithPath creates a tar.gz archive with a file at the given path.
+func createTestTarGzWithPath(t *testing.T, archivePath, content string) string {
+	t.Helper()
+
+	tarGzPath := filepath.Join(t.TempDir(), "test.tar.gz")
+
+	f, err := os.Create(tarGzPath)
+	require.NoError(t, err)
+	defer f.Close()
+
+	gw := gzip.NewWriter(f)
+	defer gw.Close()
+
+	tw := tar.NewWriter(gw)
+	defer tw.Close()
+
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name:     archivePath,
+		Size:     int64(len(content)),
+		Mode:     0o755,
+		Typeflag: tar.TypeReg,
+	}))
+	_, err = tw.Write([]byte(content))
+	require.NoError(t, err)
+
+	return tarGzPath
+}

--- a/internal/update/platform.go
+++ b/internal/update/platform.go
@@ -1,0 +1,42 @@
+package update
+
+import (
+	"fmt"
+	"runtime"
+)
+
+// PlatformInfo describes the target platform for binary downloads.
+type PlatformInfo struct {
+	OS         string // GoReleaser OS name (e.g., "Linux", "Darwin", "Windows")
+	Arch       string // GoReleaser arch name (e.g., "x86_64", "arm64")
+	ArchiveExt string // Archive extension (e.g., ".tar.gz", ".zip")
+}
+
+// DetectPlatform maps the current runtime OS and architecture to GoReleaser names.
+func DetectPlatform() (PlatformInfo, error) {
+	osMap := map[string]string{
+		"linux":  "Linux",
+		"darwin": "Darwin",
+	}
+
+	archMap := map[string]string{
+		"amd64": "x86_64",
+		"arm64": "arm64",
+	}
+
+	osName, ok := osMap[runtime.GOOS]
+	if !ok {
+		return PlatformInfo{}, fmt.Errorf("%w: OS %q", ErrUnsupportedPlatform, runtime.GOOS)
+	}
+
+	archName, ok := archMap[runtime.GOARCH]
+	if !ok {
+		return PlatformInfo{}, fmt.Errorf("%w: architecture %q", ErrUnsupportedPlatform, runtime.GOARCH)
+	}
+
+	return PlatformInfo{
+		OS:         osName,
+		Arch:       archName,
+		ArchiveExt: ".tar.gz",
+	}, nil
+}

--- a/internal/update/platform_test.go
+++ b/internal/update/platform_test.go
@@ -1,0 +1,53 @@
+package update
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUT_DetectPlatform_CurrentOS(t *testing.T) {
+	p, err := DetectPlatform()
+
+	switch runtime.GOOS {
+	case "linux", "darwin":
+		require.NoError(t, err)
+		assert.NotEmpty(t, p.OS)
+		assert.NotEmpty(t, p.Arch)
+		assert.Equal(t, ".tar.gz", p.ArchiveExt)
+	default:
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrUnsupportedPlatform)
+	}
+}
+
+func TestUT_DetectPlatform_OSMapping(t *testing.T) {
+	// We can only test the current platform, but we can verify the mapping is correct.
+	p, err := DetectPlatform()
+	if err != nil {
+		t.Skip("unsupported platform")
+	}
+
+	switch runtime.GOOS {
+	case "linux":
+		assert.Equal(t, "Linux", p.OS)
+	case "darwin":
+		assert.Equal(t, "Darwin", p.OS)
+	}
+}
+
+func TestUT_DetectPlatform_ArchMapping(t *testing.T) {
+	p, err := DetectPlatform()
+	if err != nil {
+		t.Skip("unsupported platform")
+	}
+
+	switch runtime.GOARCH {
+	case "amd64":
+		assert.Equal(t, "x86_64", p.Arch)
+	case "arm64":
+		assert.Equal(t, "arm64", p.Arch)
+	}
+}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -1,0 +1,242 @@
+package update
+
+import (
+	"bufio"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const httpTimeout = 60 * time.Second
+
+// Updater downloads and installs TAG binary updates from GitHub Releases.
+type Updater struct {
+	client     *http.Client
+	out        io.Writer
+	repoURL    string
+	binaryName string
+}
+
+// New creates an Updater for the given GitHub repository URL.
+func New(repoURL string, out io.Writer) *Updater {
+	return &Updater{
+		client: &http.Client{
+			Timeout: httpTimeout,
+		},
+		out:        out,
+		repoURL:    repoURL,
+		binaryName: "tag",
+	}
+}
+
+// Update downloads the specified version and replaces the binary at binaryPath.
+func (u *Updater) Update(ctx context.Context, version, binaryPath string) error {
+	platform, err := DetectPlatform()
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(u.out, "Downloading tag %s for %s/%s...\n", version, platform.OS, platform.Arch)
+
+	tmpDir, err := os.MkdirTemp("", "tag-update-*")
+	if err != nil {
+		return &UpdateError{Op: "download", Err: fmt.Errorf("create temp dir: %w", err)}
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Build asset URLs.
+	ver := strings.TrimPrefix(version, "v")
+	archiveName := fmt.Sprintf("tag_%s_%s_%s%s", ver, platform.OS, platform.Arch, platform.ArchiveExt)
+	archiveURL := fmt.Sprintf("%s/releases/download/%s/%s", u.repoURL, version, archiveName)
+	checksumsURL := fmt.Sprintf("%s/releases/download/%s/checksums.txt", u.repoURL, version)
+
+	// Download archive.
+	archivePath := filepath.Join(tmpDir, archiveName)
+	err = u.downloadFile(ctx, archiveURL, archivePath)
+	if err != nil {
+		return &UpdateError{Op: "download", Err: err}
+	}
+
+	// Download and verify checksum.
+	fmt.Fprintln(u.out, "Verifying checksum...")
+
+	checksumsPath := filepath.Join(tmpDir, "checksums.txt")
+	err = u.downloadFile(ctx, checksumsURL, checksumsPath)
+	if err != nil {
+		return &UpdateError{Op: "verify", Err: fmt.Errorf("download checksums: %w", err)}
+	}
+
+	err = verifyChecksum(archivePath, archiveName, checksumsPath)
+	if err != nil {
+		return &UpdateError{Op: "verify", Err: err}
+	}
+
+	// Extract binary.
+	fmt.Fprintln(u.out, "Installing...")
+
+	newBinaryPath, err := extractFromTarGz(archivePath, u.binaryName, tmpDir)
+	if err != nil {
+		return &UpdateError{Op: "extract", Err: err}
+	}
+
+	// Replace current binary.
+	err = replaceBinary(binaryPath, newBinaryPath)
+	if err != nil {
+		return &UpdateError{Op: "replace", Err: err}
+	}
+
+	return nil
+}
+
+// downloadFile downloads a URL to a local file path.
+func (u *Updater) downloadFile(ctx context.Context, url, dest string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+
+	resp, err := u.client.Do(req) //nolint:gosec // URL is constructed from trusted repo URL
+	if err != nil {
+		return fmt.Errorf("network request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status %d for %s", resp.StatusCode, url)
+	}
+
+	out, err := os.Create(dest)
+	if err != nil {
+		return fmt.Errorf("create file: %w", err)
+	}
+
+	if _, err := io.Copy(out, resp.Body); err != nil {
+		out.Close()
+		return fmt.Errorf("write file: %w", err)
+	}
+
+	if err := out.Sync(); err != nil {
+		out.Close()
+		return fmt.Errorf("sync file: %w", err)
+	}
+
+	return out.Close()
+}
+
+// verifyChecksum checks the SHA256 of archivePath against the entry in checksumsPath.
+func verifyChecksum(archivePath, archiveName, checksumsPath string) error {
+	expected, err := findChecksum(checksumsPath, archiveName)
+	if err != nil {
+		return err
+	}
+
+	actual, err := fileSHA256(archivePath)
+	if err != nil {
+		return fmt.Errorf("compute checksum: %w", err)
+	}
+
+	if actual != expected {
+		return fmt.Errorf("%w: expected %s, got %s", ErrChecksumMismatch, expected, actual)
+	}
+
+	return nil
+}
+
+// findChecksum parses a GoReleaser checksums.txt and returns the hash for the given filename.
+func findChecksum(checksumsPath, filename string) (string, error) {
+	f, err := os.Open(checksumsPath)
+	if err != nil {
+		return "", fmt.Errorf("open checksums: %w", err)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		// Format: "<hash>  <filename>" (two spaces between hash and filename).
+		parts := strings.Fields(scanner.Text())
+		if len(parts) == 2 && parts[1] == filename {
+			return parts[0], nil
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("read checksums: %w", err)
+	}
+
+	return "", fmt.Errorf("checksum not found for %s", filename)
+}
+
+// fileSHA256 computes the hex-encoded SHA256 hash of a file.
+func fileSHA256(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// replaceBinary safely replaces the binary at dst with the one at src.
+// Uses rename-to-backup strategy: rename current → .old, copy new, remove .old.
+// Restores the original on failure.
+func replaceBinary(dst, src string) error {
+	backup := dst + ".old"
+
+	// Remove any stale backup from a previous failed update.
+	os.Remove(backup)
+
+	if err := os.Rename(dst, backup); err != nil {
+		return fmt.Errorf("backup current binary: %w", err)
+	}
+
+	if err := copyFile(src, dst); err != nil {
+		// Restore from backup.
+		if restoreErr := os.Rename(backup, dst); restoreErr != nil {
+			return fmt.Errorf("replace failed (%w) and restore failed (%w)", err, restoreErr)
+		}
+		return fmt.Errorf("copy new binary: %w", err)
+	}
+
+	os.Remove(backup)
+
+	return nil
+}
+
+// copyFile copies src to dst, preserving executable permissions.
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
+	if err != nil {
+		return err
+	}
+
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		return err
+	}
+
+	if err := out.Sync(); err != nil {
+		out.Close()
+		return err
+	}
+
+	return out.Close()
+}

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -1,0 +1,253 @@
+package update
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUT_Update_Success(t *testing.T) {
+	// Create a fake binary to be "updated".
+	binaryDir := t.TempDir()
+	binaryPath := filepath.Join(binaryDir, "tag")
+	require.NoError(t, os.WriteFile(binaryPath, []byte("old-binary"), 0o755))
+
+	// Build a test archive.
+	archiveData := buildTestArchive(t, "tag", "new-binary-content")
+	checksum := sha256Hex(archiveData)
+
+	platform, err := DetectPlatform()
+	require.NoError(t, err)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/releases/download/v1.0.0/checksums.txt":
+			archiveName := fmt.Sprintf("tag_1.0.0_%s_%s.tar.gz", platform.OS, platform.Arch)
+			fmt.Fprintf(w, "%s  %s\n", checksum, archiveName)
+		case r.URL.Path == fmt.Sprintf("/releases/download/v1.0.0/tag_1.0.0_%s_%s.tar.gz", platform.OS, platform.Arch):
+			w.Write(archiveData)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	u := New(srv.URL, &buf)
+	err = u.Update(context.Background(), "v1.0.0", binaryPath)
+	require.NoError(t, err)
+
+	// Verify the binary was replaced.
+	content, err := os.ReadFile(binaryPath)
+	require.NoError(t, err)
+	assert.Equal(t, "new-binary-content", string(content))
+
+	// Verify output messages.
+	assert.Contains(t, buf.String(), "Downloading")
+	assert.Contains(t, buf.String(), "Verifying checksum")
+	assert.Contains(t, buf.String(), "Installing")
+}
+
+func TestUT_Update_ChecksumMismatch(t *testing.T) {
+	binaryDir := t.TempDir()
+	binaryPath := filepath.Join(binaryDir, "tag")
+	require.NoError(t, os.WriteFile(binaryPath, []byte("old-binary"), 0o755))
+
+	archiveData := buildTestArchive(t, "tag", "binary-content")
+
+	platform, err := DetectPlatform()
+	require.NoError(t, err)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/releases/download/v1.0.0/checksums.txt":
+			archiveName := fmt.Sprintf("tag_1.0.0_%s_%s.tar.gz", platform.OS, platform.Arch)
+			fmt.Fprintf(w, "%s  %s\n", "0000000000000000000000000000000000000000000000000000000000000000", archiveName)
+		case r.URL.Path == fmt.Sprintf("/releases/download/v1.0.0/tag_1.0.0_%s_%s.tar.gz", platform.OS, platform.Arch):
+			w.Write(archiveData)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	u := New(srv.URL, &buf)
+	err = u.Update(context.Background(), "v1.0.0", binaryPath)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrChecksumMismatch)
+
+	// Verify the original binary is still intact.
+	content, err := os.ReadFile(binaryPath)
+	require.NoError(t, err)
+	assert.Equal(t, "old-binary", string(content))
+}
+
+func TestUT_Update_DownloadFailure(t *testing.T) {
+	binaryDir := t.TempDir()
+	binaryPath := filepath.Join(binaryDir, "tag")
+	require.NoError(t, os.WriteFile(binaryPath, []byte("old-binary"), 0o755))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	u := New(srv.URL, &buf)
+	err := u.Update(context.Background(), "v1.0.0", binaryPath)
+	require.Error(t, err)
+
+	var updateErr *UpdateError
+	assert.ErrorAs(t, err, &updateErr)
+	assert.Equal(t, "download", updateErr.Op)
+}
+
+func TestUT_Update_BinaryNotInArchive(t *testing.T) {
+	binaryDir := t.TempDir()
+	binaryPath := filepath.Join(binaryDir, "tag")
+	require.NoError(t, os.WriteFile(binaryPath, []byte("old-binary"), 0o755))
+
+	// Archive with wrong binary name.
+	archiveData := buildTestArchive(t, "wrong-name", "content")
+	checksum := sha256Hex(archiveData)
+
+	platform, err := DetectPlatform()
+	require.NoError(t, err)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/releases/download/v1.0.0/checksums.txt":
+			archiveName := fmt.Sprintf("tag_1.0.0_%s_%s.tar.gz", platform.OS, platform.Arch)
+			fmt.Fprintf(w, "%s  %s\n", checksum, archiveName)
+		case r.URL.Path == fmt.Sprintf("/releases/download/v1.0.0/tag_1.0.0_%s_%s.tar.gz", platform.OS, platform.Arch):
+			w.Write(archiveData)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	u := New(srv.URL, &buf)
+	err = u.Update(context.Background(), "v1.0.0", binaryPath)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrBinaryNotFound)
+}
+
+func TestUT_ReplaceBinary_Success(t *testing.T) {
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "tag")
+	src := filepath.Join(dir, "tag-new")
+
+	require.NoError(t, os.WriteFile(dst, []byte("old"), 0o755))
+	require.NoError(t, os.WriteFile(src, []byte("new"), 0o755))
+
+	require.NoError(t, replaceBinary(dst, src))
+
+	content, err := os.ReadFile(dst)
+	require.NoError(t, err)
+	assert.Equal(t, "new", string(content))
+
+	// Backup should be cleaned up.
+	_, err = os.Stat(dst + ".old")
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestUT_ReplaceBinary_RestoresOnFailure(t *testing.T) {
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "tag")
+	src := filepath.Join(dir, "nonexistent") // Will fail to open.
+
+	require.NoError(t, os.WriteFile(dst, []byte("original"), 0o755))
+
+	err := replaceBinary(dst, src)
+	require.Error(t, err)
+
+	// Original should be restored.
+	content, err := os.ReadFile(dst)
+	require.NoError(t, err)
+	assert.Equal(t, "original", string(content))
+}
+
+func TestUT_VerifyChecksum_Success(t *testing.T) {
+	dir := t.TempDir()
+
+	content := []byte("test content")
+	archivePath := filepath.Join(dir, "archive.tar.gz")
+	require.NoError(t, os.WriteFile(archivePath, content, 0o644))
+
+	h := sha256.Sum256(content)
+	checksum := hex.EncodeToString(h[:])
+
+	checksumsPath := filepath.Join(dir, "checksums.txt")
+	require.NoError(t, os.WriteFile(checksumsPath, fmt.Appendf(nil, "%s  archive.tar.gz\n", checksum), 0o644))
+
+	err := verifyChecksum(archivePath, "archive.tar.gz", checksumsPath)
+	require.NoError(t, err)
+}
+
+func TestUT_VerifyChecksum_Mismatch(t *testing.T) {
+	dir := t.TempDir()
+
+	archivePath := filepath.Join(dir, "archive.tar.gz")
+	require.NoError(t, os.WriteFile(archivePath, []byte("content"), 0o644))
+
+	checksumsPath := filepath.Join(dir, "checksums.txt")
+	require.NoError(t, os.WriteFile(checksumsPath, []byte("0000000000000000000000000000000000000000000000000000000000000000  archive.tar.gz\n"), 0o644))
+
+	err := verifyChecksum(archivePath, "archive.tar.gz", checksumsPath)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrChecksumMismatch)
+}
+
+func TestUT_FindChecksum_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	checksumsPath := filepath.Join(dir, "checksums.txt")
+	require.NoError(t, os.WriteFile(checksumsPath, []byte("abc123  other-file.tar.gz\n"), 0o644))
+
+	_, err := findChecksum(checksumsPath, "missing.tar.gz")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "checksum not found")
+}
+
+// buildTestArchive creates a tar.gz archive in memory containing a single file.
+func buildTestArchive(t *testing.T, name, content string) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name:     name,
+		Size:     int64(len(content)),
+		Mode:     0o755,
+		Typeflag: tar.TypeReg,
+	}))
+	_, err := tw.Write([]byte(content))
+	require.NoError(t, err)
+
+	require.NoError(t, tw.Close())
+	require.NoError(t, gw.Close())
+
+	return buf.Bytes()
+}
+
+func sha256Hex(data []byte) string {
+	h := sha256.Sum256(data)
+	return hex.EncodeToString(h[:])
+}

--- a/main.go
+++ b/main.go
@@ -51,6 +51,7 @@ func main() {
 			commands.CacheCommand(),
 			commands.ConvertCommand(),
 			commands.VersionCommand(Version),
+			commands.UpdateCommand(Version),
 		},
 		Flags: []cli.Flag{
 			&cli.BoolFlag{


### PR DESCRIPTION
## Summary
- Adds `tag update` command that downloads the latest GitHub Release, verifies SHA256 checksum, and replaces the binary in-place using a safe rename-then-copy strategy with automatic rollback on failure
- Updates `tag version --check` to suggest `tag update` instead of manual `go install`/`curl` instructions
- New `internal/update/` package handles platform detection, archive download, checksum verification, tar.gz extraction, and binary replacement

## Test plan
- [x] Unit tests for platform detection (`platform_test.go`)
- [x] Unit tests for tar.gz extraction with real archives (`extract_test.go`)
- [x] Integration tests with `httptest.NewServer` for full update flow, checksum mismatch, download failure, and missing binary scenarios (`update_test.go`)
- [x] Command handler tests for already-up-to-date, dev build, update-available, and network error paths (`commands/update_test.go`)
- [x] Existing `version_test.go` updated and passing
- [x] `go test ./...` — all pass
- [x] `make lint` — no new issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)