### PR TITLE
feat: add `tag s` and `tag g` command aliases

### DIFF
--- a/.skill/SKILL.md
+++ b/.skill/SKILL.md
@@ -12,16 +12,16 @@ TAG is a CLI for two workflows: **scaffolding** (creating projects from template
 ## Quick Start
 
 ```bash
-# Scaffold a new project
+# Scaffold a new project (alias: tag s)
 tag scaffold gh:user/template my-project
 
 # Initialize generators in an existing project
 tag template init
 tag template new generator service
-tag generate service payment
+tag generate service payment        # alias: tag g service payment
 
 # Run a bundle (multiple generators)
-tag generate resource product
+tag generate resource product       # alias: tag g resource product
 ```
 
 ## Decision Tree
@@ -154,9 +154,9 @@ my-project/
 
 | Command | Description |
 |---------|-------------|
-| `tag scaffold [template] [name]` | Create project (no args = picker) |
-| `tag generate <gen-or-bundle> <name>` | Run generator or bundle |
-| `tag generate list` | List generators and bundles |
+| `tag scaffold [template] [name]` | Create project (no args = picker). Alias: `tag s` |
+| `tag generate <gen-or-bundle> <name>` | Run generator or bundle. Alias: `tag g` |
+| `tag generate list` | List generators and bundles. Alias: `tag g list` |
 | `tag template init` | Initialize `.tag/` structure |
 | `tag template new generator <name>` | Create generator (`--in-bundle`, `--lib`) |
 | `tag template new bundle <name>` | Create bundle (`--self-contained`, `--lib`) |

--- a/internal/commands/generate.go
+++ b/internal/commands/generate.go
@@ -28,8 +28,9 @@ var newBundleEngine = engine.NewGeneratorWithEngine
 
 func GenerateCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
-		Name:  "generate",
-		Usage: "Run a generator or bundle",
+		Name:    "generate",
+		Aliases: []string{"g"},
+		Usage:   "Run a generator or bundle",
 		Description: `Run a generator or bundle to create or modify files in an existing project.
 
 TAG auto-resolves generators from the library template first, then falls back

--- a/internal/commands/scaffold.go
+++ b/internal/commands/scaffold.go
@@ -21,6 +21,7 @@ import (
 func ScaffoldCommand() *cli.Command {
 	return &cli.Command{
 		Name:      "scaffold",
+		Aliases:   []string{"s"},
 		Usage:     "Create a new project from a template",
 		ArgsUsage: "[template] [project-name]",
 		Description: `Scaffold a new project from a local, remote, or library template.


### PR DESCRIPTION
## Summary
- Add short aliases for the two most-used commands: `tag s` → `tag scaffold`, `tag g` → `tag generate`
- Update `.skill/SKILL.md` quick start and CLI quick reference with alias documentation

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/commands/...` passes
- [ ] Manual: verify `tag s --help` and `tag g --help` work

🤖 Generated with [Claude Code](https://claude.com/claude-code)