### PR TITLE
feat: generation history + tag undo (#172)

### DIFF
--- a/.skill/SKILL.md
+++ b/.skill/SKILL.md
@@ -170,6 +170,9 @@ my-project/
 | `tag lib ls` | List installed templates |
 | `tag lib rm <name>` | Remove template |
 | `tag lib update [name]` | Update from source |
+| `tag undo` | Revert the last generation |
+| `tag undo --list` | Show generation history |
+| `tag undo --id <id>` | Revert a specific generation |
 | `tag update` | Self-update to latest release |
 | `tag version [--check]` | Print version, check for updates |
 

--- a/.skill/reference.md
+++ b/.skill/reference.md
@@ -320,6 +320,25 @@ tag cache clear                        # Clear expired entries
 tag cache clear --all                  # Clear entire cache
 ```
 
+### Generation History & Undo
+
+Every `tag generate` and `tag scaffold` records a manifest entry in `.tag/history.json` with SHA256 hashes of affected files. `tag undo` uses this manifest to safely revert changes.
+
+```bash
+tag undo                               # Revert the last generation (with confirmation)
+tag undo --yes                         # Skip confirmation prompt
+tag undo --list                        # Show generation history (newest first)
+tag undo --id gen_1741000000_a3f2bc    # Revert a specific generation by ID
+tag undo --force                       # Override conflict detection
+tag undo --partial                     # Revert unmodified files, skip conflicting ones
+```
+
+**Conflict detection**: If a file was modified after generation was recorded, `undo` refuses to overwrite it with a clear error. Use `--force` to override or `--partial` to skip conflicting files.
+
+**Manifest location**: `.tag/history.json` — generated automatically, do not edit manually.
+
+**Backup location**: `.tag/history/backups/<generation-id>/` — stores pre-modification copies for inject/append operations.
+
 ### Self-Update
 
 ```bash

--- a/docs/commands/undo.md
+++ b/docs/commands/undo.md
@@ -1,0 +1,76 @@
+# tag undo
+
+Revert files created or modified by a previous `tag generate` or `tag scaffold`.
+
+## Synopsis
+
+```bash
+tag undo [flags]
+```
+
+## Description
+
+`tag undo` reads the generation history manifest (`.tag/history.json`) to revert the most recent generation. Created files are deleted; injected or appended content is restored from backups stored in `.tag/history/backups/`.
+
+**Conflict detection**: Before reverting, `undo` compares the current hash of each file against the hash recorded at generation time. If a file has been modified after generation, `undo` refuses to overwrite it.
+
+## Flags
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--list` | | Show generation history (newest first) and exit |
+| `--id <id>` | `-i` | Undo a specific generation by ID instead of the last one |
+| `--yes` | `-y` | Skip the confirmation prompt |
+| `--force` | `-f` | Override conflict detection and revert even modified files |
+| `--partial` | | Revert unmodified files; silently skip conflicting ones |
+
+## Examples
+
+```bash
+# View what can be undone
+tag undo --list
+
+# Undo the last generation (shows preview + confirmation)
+tag undo
+
+# Undo without prompting
+tag undo --yes
+
+# Undo a specific generation
+tag undo --id gen_1741000000_a3f2bc
+
+# Force-revert even if files were modified
+tag undo --force
+
+# Partial revert: only unmodified files
+tag undo --partial
+```
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Generation reverted successfully |
+| `1` | Conflict detected (use `--force` or `--partial`) |
+| `1` | Generation ID not found |
+| `1` | No generations to undo |
+
+## History Manifest
+
+The manifest is stored at `.tag/history.json`. Each entry contains:
+
+- **ID**: Unique generation ID (`gen_<unix>_<6hex>`)
+- **Timestamp**: When the generation was recorded (UTC)
+- **Template**: Generator or bundle name
+- **Files**: List of affected files with `action`, `hash_before`, and `hash_after`
+
+**Actions**:
+- `create` — file was newly created (undo deletes it)
+- `inject` — content was injected at a marker (undo restores backup)
+- `append` — content was appended to a file (undo restores backup)
+
+## Notes
+
+- Only one undo is possible per generation entry. After undo, the entry is removed from the manifest.
+- Scaffold generations are recorded in the *output project's* `.tag/history.json`, not the template's.
+- The `--list` output is ordered newest first.

--- a/internal/commands/generate.go
+++ b/internal/commands/generate.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -11,6 +12,7 @@ import (
 	"github.com/kaikenlabs/tag/internal/chalk"
 	"github.com/kaikenlabs/tag/internal/config"
 	"github.com/kaikenlabs/tag/internal/engine"
+	"github.com/kaikenlabs/tag/internal/history"
 	"github.com/kaikenlabs/tag/internal/hooks"
 	"github.com/kaikenlabs/tag/internal/template"
 	"github.com/kaikenlabs/tag/internal/types"
@@ -18,13 +20,19 @@ import (
 	"github.com/kaikenlabs/tag/pkg/app"
 )
 
-// newEngine is a function variable that creates a new engine.
+// newEngine is a function variable that creates a new generator with optional history recording.
 // It can be replaced in tests to inject a mock generator.
-var newEngine = engine.NewGenerator
+var newEngine = func(dryRun bool, dirPath, sharedPath string, rec *history.Recorder) (engine.Generator, error) {
+	tmplEngine, err := template.NewEngine()
+	if err != nil {
+		return nil, fmt.Errorf("cannot create template engine: %w", err)
+	}
+	return engine.NewGeneratorWithRecorder(tmplEngine, dryRun, dirPath, sharedPath, rec)
+}
 
-// newBundleEngine is a function variable that creates an engine with a shared template engine.
+// newBundleEngine is a function variable that creates a generator with a shared template engine and history recording.
 // It can be replaced in tests to inject a mock generator.
-var newBundleEngine = engine.NewGeneratorWithEngine
+var newBundleEngine = engine.NewGeneratorWithRecorder
 
 func GenerateCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
@@ -141,6 +149,11 @@ func generateBundle(c *cli.Context, cfg *config.Config, generatorName, targetNam
 	}
 
 	dryRun := c.Bool(flags.DryRunFlag)
+	tagDir := types.TemplatesDir
+
+	// Create a single recorder shared across all generators in the bundle so
+	// that first-touch semantics for hash_before work correctly.
+	rec := history.NewRecorder(tagDir)
 
 	slog.Info(chalk.Green("running bundle"), "bundle", generatorName, "target", targetName)
 	for _, generator := range bundle.Generators {
@@ -164,7 +177,7 @@ func generateBundle(c *cli.Context, cfg *config.Config, generatorName, targetNam
 			}
 		}
 
-		gen, genErr := newBundleEngine(tmplEngine, dryRun, genDirPath, sharedPath)
+		gen, genErr := newBundleEngine(tmplEngine, dryRun, genDirPath, sharedPath, rec)
 		if genErr != nil {
 			return app.Errorf("error creating engine: %w", genErr)
 		}
@@ -180,7 +193,16 @@ func generateBundle(c *cli.Context, cfg *config.Config, generatorName, targetNam
 	}
 
 	if !c.Bool("no-hooks") {
-		return runHooks(cfg.Hooks.Post, hooks.HookPhasePostGen, cfg.Variables)
+		if err := runHooks(cfg.Hooks.Post, hooks.HookPhasePostGen, cfg.Variables); err != nil {
+			return err
+		}
+	}
+
+	if !dryRun {
+		gen := rec.Build(generatorName, "generate")
+		if appendErr := history.Append(tagDir, gen); appendErr != nil {
+			slog.Warn("could not write history manifest", "error", appendErr)
+		}
 	}
 	return nil
 }
@@ -194,7 +216,11 @@ func generateTemplate(c *cli.Context, cfg *config.Config, generatorName, targetN
 
 	slog.Info(chalk.Green("running generator"), "generator", generatorName, "target", targetName)
 
-	gen, err := newEngine(c.Bool(flags.DryRunFlag), dirPath, sharedPath)
+	dryRun := c.Bool(flags.DryRunFlag)
+	tagDir := types.TemplatesDir
+	rec := history.NewRecorder(tagDir)
+
+	gen, err := newEngine(dryRun, dirPath, sharedPath, rec)
 	if err != nil {
 		return app.Errorf("error creating engine: %w", err)
 	}
@@ -204,13 +230,21 @@ func generateTemplate(c *cli.Context, cfg *config.Config, generatorName, targetN
 		data.ScaffoldVars = cfg.Variables
 	}
 
-	err = gen.Generate(data)
-	if err != nil {
+	if err := gen.Generate(data); err != nil {
 		return app.Errorf("error when generating template: %w", err)
 	}
 
 	if !c.Bool("no-hooks") {
-		return runHooks(cfg.Hooks.Post, hooks.HookPhasePostGen, cfg.Variables)
+		if err := runHooks(cfg.Hooks.Post, hooks.HookPhasePostGen, cfg.Variables); err != nil {
+			return err
+		}
+	}
+
+	if !dryRun {
+		histGen := rec.Build(generatorName, "generate")
+		if appendErr := history.Append(tagDir, histGen); appendErr != nil {
+			slog.Warn("could not write history manifest", "error", appendErr)
+		}
 	}
 	return nil
 }

--- a/internal/commands/generate_test.go
+++ b/internal/commands/generate_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/kaikenlabs/tag/internal/config"
 	"github.com/kaikenlabs/tag/internal/engine"
+	"github.com/kaikenlabs/tag/internal/history"
 	"github.com/kaikenlabs/tag/internal/hooks"
 	"github.com/kaikenlabs/tag/internal/template"
 	"github.com/kaikenlabs/tag/internal/types/flags"
@@ -100,7 +101,7 @@ Hello {{ .Name }}`
 	// Use a mock to verify the engine is called correctly
 	var capturedData engine.Data
 	originalNewEngine := newEngine
-	newEngine = func(dryRun bool, dirPath string, sharedPath string) (engine.Generator, error) {
+	newEngine = func(dryRun bool, dirPath string, sharedPath string, rec *history.Recorder) (engine.Generator, error) {
 		mock := &mockGenerator{
 			GenerateFunc: func(data engine.Data) error {
 				capturedData = data
@@ -137,7 +138,7 @@ Hello {{ .Name }}`
 
 	var capturedData engine.Data
 	originalNewEngine := newEngine
-	newEngine = func(dryRun bool, dirPath string, sharedPath string) (engine.Generator, error) {
+	newEngine = func(dryRun bool, dirPath string, sharedPath string, rec *history.Recorder) (engine.Generator, error) {
 		mock := &mockGenerator{
 			GenerateFunc: func(data engine.Data) error {
 				capturedData = data
@@ -175,7 +176,7 @@ Hello {{ .Name }}`
 
 	var capturedData engine.Data
 	originalNewEngine := newEngine
-	newEngine = func(dryRun bool, dirPath string, sharedPath string) (engine.Generator, error) {
+	newEngine = func(dryRun bool, dirPath string, sharedPath string, rec *history.Recorder) (engine.Generator, error) {
 		mock := &mockGenerator{
 			GenerateFunc: func(data engine.Data) error {
 				capturedData = data
@@ -211,7 +212,7 @@ Hello {{ .Name }}`
 	})
 
 	originalNewEngine := newEngine
-	newEngine = func(dryRun bool, dirPath string, sharedPath string) (engine.Generator, error) {
+	newEngine = func(dryRun bool, dirPath string, sharedPath string, rec *history.Recorder) (engine.Generator, error) {
 		mock := &mockGenerator{
 			GenerateFunc: func(data engine.Data) error {
 				return errors.New("template execution failed")
@@ -246,7 +247,7 @@ Hello {{ .Name }}`
 	})
 
 	originalNewEngine := newEngine
-	newEngine = func(dryRun bool, dirPath string, sharedPath string) (engine.Generator, error) {
+	newEngine = func(dryRun bool, dirPath string, sharedPath string, rec *history.Recorder) (engine.Generator, error) {
 		return nil, errors.New("failed to create engine")
 	}
 	t.Cleanup(func() { newEngine = originalNewEngine })
@@ -315,7 +316,7 @@ Hello {{ .Name }}`
 
 	var generateCalls int
 	originalBundleEngine := newBundleEngine
-	newBundleEngine = func(tmplEngine *template.Engine, dryRun bool, dirPath string, sharedPath string) (engine.Generator, error) {
+	newBundleEngine = func(tmplEngine *template.Engine, dryRun bool, dirPath string, sharedPath string, rec *history.Recorder) (engine.Generator, error) {
 		mock := &mockGenerator{
 			GenerateFunc: func(data engine.Data) error {
 				generateCalls++
@@ -357,7 +358,7 @@ Hello {{ .Name }}`
 
 	var generateCalls int
 	originalBundleEngine := newBundleEngine
-	newBundleEngine = func(tmplEngine *template.Engine, dryRun bool, dirPath string, sharedPath string) (engine.Generator, error) {
+	newBundleEngine = func(tmplEngine *template.Engine, dryRun bool, dirPath string, sharedPath string, rec *history.Recorder) (engine.Generator, error) {
 		mock := &mockGenerator{
 			GenerateFunc: func(data engine.Data) error {
 				generateCalls++
@@ -524,7 +525,7 @@ Hello {{ .Name }}`
 
 	var capturedDirPath, capturedSharedPath string
 	originalBundleEngine := newBundleEngine
-	newBundleEngine = func(tmplEngine *template.Engine, dryRun bool, dirPath string, sharedPath string) (engine.Generator, error) {
+	newBundleEngine = func(tmplEngine *template.Engine, dryRun bool, dirPath string, sharedPath string, rec *history.Recorder) (engine.Generator, error) {
 		capturedDirPath = dirPath
 		capturedSharedPath = sharedPath
 		mock := &mockGenerator{
@@ -603,7 +604,7 @@ Hello {{ .Name }}`
 
 	var capturedSharedPath string
 	originalBundleEngine := newBundleEngine
-	newBundleEngine = func(tmplEngine *template.Engine, dryRun bool, dirPath string, sharedPath string) (engine.Generator, error) {
+	newBundleEngine = func(tmplEngine *template.Engine, dryRun bool, dirPath string, sharedPath string, rec *history.Recorder) (engine.Generator, error) {
 		capturedSharedPath = sharedPath
 		mock := &mockGenerator{
 			GenerateFunc: func(data engine.Data) error {
@@ -731,7 +732,7 @@ Hello {{ .Name }}`
 
 	var capturedData engine.Data
 	originalNewEngine := newEngine
-	newEngine = func(dryRun bool, dirPath string, sharedPath string) (engine.Generator, error) {
+	newEngine = func(dryRun bool, dirPath string, sharedPath string, rec *history.Recorder) (engine.Generator, error) {
 		mock := &mockGenerator{
 			GenerateFunc: func(data engine.Data) error {
 				capturedData = data
@@ -771,7 +772,7 @@ Hello {{ .Name }}`
 
 	var capturedData engine.Data
 	originalNewEngine := newEngine
-	newEngine = func(dryRun bool, dirPath string, sharedPath string) (engine.Generator, error) {
+	newEngine = func(dryRun bool, dirPath string, sharedPath string, rec *history.Recorder) (engine.Generator, error) {
 		mock := &mockGenerator{
 			GenerateFunc: func(data engine.Data) error {
 				capturedData = data
@@ -847,7 +848,7 @@ Hello {{ .Name }}`
 
 	var capturedData engine.Data
 	originalBundleEngine := newBundleEngine
-	newBundleEngine = func(tmplEngine *template.Engine, dryRun bool, dirPath string, sharedPath string) (engine.Generator, error) {
+	newBundleEngine = func(tmplEngine *template.Engine, dryRun bool, dirPath string, sharedPath string, rec *history.Recorder) (engine.Generator, error) {
 		mock := &mockGenerator{
 			GenerateFunc: func(data engine.Data) error {
 				capturedData = data

--- a/internal/commands/scaffold.go
+++ b/internal/commands/scaffold.go
@@ -10,6 +10,7 @@ import (
 	"github.com/urfave/cli/v2"
 
 	"github.com/kaikenlabs/tag/internal/convert"
+	"github.com/kaikenlabs/tag/internal/history"
 	"github.com/kaikenlabs/tag/internal/library"
 	"github.com/kaikenlabs/tag/internal/parse"
 	"github.com/kaikenlabs/tag/internal/remote"
@@ -128,6 +129,8 @@ func scaffoldFromLibrary(c *cli.Context, lib *library.Library, entry *library.En
 		return app.Errorf("failed to initialize scaffold: %w", err)
 	}
 
+	s.SetRecorder(history.NewRecorder(""))
+
 	if err := s.Run(opts); err != nil {
 		var ccErr *scaffold.CookiecutterDetectedError
 		if errors.As(err, &ccErr) {
@@ -194,6 +197,9 @@ func scaffoldFromRef(c *cli.Context, positional []string) error {
 	if err != nil {
 		return app.Errorf("failed to initialize scaffold: %w", err)
 	}
+
+	// Scaffold only creates new files (no inject/append), so tagDir for backups is unused.
+	s.SetRecorder(history.NewRecorder(""))
 
 	if err := s.Run(opts); err != nil {
 		var ccErr *scaffold.CookiecutterDetectedError
@@ -320,6 +326,7 @@ func handleCookiecutterDetection(c *cli.Context, _ *scaffold.CookiecutterDetecte
 	if err != nil {
 		return app.Errorf("failed to reinitialize scaffold: %w", err)
 	}
+	s.SetRecorder(history.NewRecorder(""))
 	if err := s.Run(opts); err != nil {
 		return app.Errorf("scaffolding failed: %w", err)
 	}

--- a/internal/commands/undo.go
+++ b/internal/commands/undo.go
@@ -1,0 +1,232 @@
+package commands
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/kaikenlabs/tag/internal/history"
+	"github.com/kaikenlabs/tag/internal/types"
+	"github.com/kaikenlabs/tag/pkg/app"
+)
+
+// UndoCommand returns the `tag undo` command definition.
+func UndoCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "undo",
+		Usage: "Revert a previous generation",
+		Description: `Revert files created or modified by a previous tag generate or tag scaffold.
+
+By default, reverts the most recent generation. Use --id to target a specific
+generation and --list to view the full history.
+
+Conflict detection: if a file was modified after the generation was recorded,
+undo refuses to overwrite it. Use --force to override, or --partial to revert
+only the unmodified files.
+
+EXAMPLES
+  tag undo                           Undo the last generation
+  tag undo --list                    Show generation history
+  tag undo --id gen_1741000000_a3f2bc  Undo a specific generation
+  tag undo --yes                     Skip confirmation prompt
+  tag undo --force                   Override conflict detection
+  tag undo --partial                 Revert unmodified files, skip conflicts`,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:    "id",
+				Usage:   "Generation ID to undo (default: last generation)",
+				Aliases: []string{"i"},
+			},
+			&cli.BoolFlag{
+				Name:  "list",
+				Usage: "List all recorded generations and exit",
+			},
+			&cli.BoolFlag{
+				Name:    "yes",
+				Aliases: []string{"y"},
+				Usage:   "Skip confirmation prompt",
+			},
+			&cli.BoolFlag{
+				Name:    "force",
+				Aliases: []string{"f"},
+				Usage:   "Override conflict detection and revert even if files were modified",
+			},
+			&cli.BoolFlag{
+				Name:  "partial",
+				Usage: "Revert unmodified files and skip conflicting ones instead of aborting",
+			},
+		},
+		Action: undoAction,
+	}
+}
+
+func undoAction(c *cli.Context) error {
+	tagDir, err := resolveTagDir()
+	if err != nil {
+		return err
+	}
+
+	if c.Bool("list") {
+		return listGenerations(tagDir, c)
+	}
+
+	return runUndo(tagDir, c)
+}
+
+func listGenerations(tagDir string, c *cli.Context) error {
+	gens, err := history.ListGenerations(tagDir)
+	if err != nil {
+		return app.Errorf("cannot load history: %w", err)
+	}
+
+	if len(gens) == 0 {
+		fmt.Fprintln(c.App.Writer, "No generations recorded.")
+		return nil
+	}
+
+	fmt.Fprintln(c.App.Writer, "Generation history (newest first):")
+	for _, g := range gens {
+		name := g.Template
+		if name == "" {
+			name = g.Command
+		}
+		fmt.Fprintf(c.App.Writer, "  %s  %s  %-20s  %d file(s)\n",
+			g.ID,
+			g.Timestamp.Format("2006-01-02 15:04:05"),
+			name,
+			len(g.Files),
+		)
+	}
+	return nil
+}
+
+func runUndo(tagDir string, c *cli.Context) error {
+	genID := c.String("id")
+	force := c.Bool("force")
+	partial := c.Bool("partial")
+	yes := c.Bool("yes")
+
+	// Load manifest to determine what will be reverted so we can show a preview.
+	m, err := history.Load(tagDir)
+	if err != nil {
+		return app.Errorf("cannot load history: %w", err)
+	}
+
+	// Find the target generation.
+	var targetGen *history.Generation
+	if genID == "" {
+		if len(m.Generations) == 0 {
+			return app.Errorf("no generations to undo")
+		}
+		g := m.Generations[len(m.Generations)-1]
+		targetGen = &g
+	} else {
+		for i := range m.Generations {
+			if m.Generations[i].ID == genID {
+				g := m.Generations[i]
+				targetGen = &g
+				break
+			}
+		}
+		if targetGen == nil {
+			return app.Errorf("generation %q not found", genID)
+		}
+	}
+
+	if !yes {
+		name := targetGen.Template
+		if name == "" {
+			name = targetGen.Command
+		}
+		fmt.Fprintf(c.App.Writer, "About to undo generation %s (%s) — %d file(s)\n",
+			targetGen.ID, name, len(targetGen.Files))
+		for _, f := range targetGen.Files {
+			fmt.Fprintf(c.App.Writer, "  [%s] %s\n", f.Action, f.Path)
+		}
+		fmt.Fprintln(c.App.Writer)
+
+		if !promptConfirm(c) {
+			fmt.Fprintln(c.App.Writer, "Undo cancelled.")
+			return nil
+		}
+	}
+
+	// Always pass the resolved ID so history.Undo targets exactly the
+	// generation shown in the preview, eliminating any TOCTOU window.
+	opts := history.UndoOptions{
+		GenID:   targetGen.ID,
+		Force:   force,
+		Partial: partial,
+		Out:     c.App.Writer,
+	}
+
+	if err := history.Undo(tagDir, opts); err != nil {
+		var conflictErr *history.ConflictError
+		if errors.As(err, &conflictErr) {
+			fmt.Fprintln(c.App.Writer, "Conflict: the following files were modified after generation:")
+			for _, p := range conflictErr.Paths {
+				fmt.Fprintf(c.App.Writer, "  - %s\n", p)
+			}
+			fmt.Fprintln(c.App.Writer, "\nUse --force to override, or --partial to revert unmodified files only.")
+			return app.Errorf("undo aborted due to conflicts")
+		}
+		return app.Errorf("undo failed: %w", err)
+	}
+
+	return nil
+}
+
+// resolveTagDir returns the absolute path to the .tag/ directory for the
+// current project by walking up from the current working directory.
+func resolveTagDir() (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", app.Errorf("cannot get working directory: %w", err)
+	}
+
+	dir := cwd
+	for {
+		candidate := filepath.Join(dir, types.TemplatesDir)
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate, nil
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+
+	// Fallback: use the .tag/ directory relative to cwd (will be created if needed).
+	return filepath.Join(cwd, types.TemplatesDir), nil
+}
+
+// promptConfirm asks the user for a yes/no answer on stdin. Falls back to
+// false if not a TTY (non-interactive mode).
+func promptConfirm(c *cli.Context) bool {
+	if !isTerminal() {
+		fmt.Fprintln(c.App.Writer, "Non-interactive mode: use --yes to confirm undo automatically.")
+		return false
+	}
+
+	fmt.Fprint(c.App.Writer, "Proceed? [y/N] ")
+	var response string
+	if _, err := fmt.Fscan(os.Stdin, &response); err != nil {
+		return false
+	}
+	return strings.ToLower(strings.TrimSpace(response)) == "y"
+}
+
+// isTerminal returns true if stdin is connected to a terminal (interactive mode).
+func isTerminal() bool {
+	fi, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return (fi.Mode() & os.ModeCharDevice) != 0
+}

--- a/internal/commands/undo_test.go
+++ b/internal/commands/undo_test.go
@@ -1,0 +1,126 @@
+package commands
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+
+	"github.com/kaikenlabs/tag/internal/history"
+)
+
+// runUndoApp is a test helper that runs the undo command within a temp project
+// directory (containing a .tag/ directory) and returns output + error.
+func runUndoApp(t *testing.T, projectDir string, args ...string) (string, error) {
+	t.Helper()
+	// Change into the project dir so resolveTagDir finds .tag/.
+	orig, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(projectDir))
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+
+	var out bytes.Buffer
+	app := &cli.App{
+		Writer:         &out,
+		Commands:       []*cli.Command{UndoCommand()},
+		ExitErrHandler: func(_ *cli.Context, _ error) {},
+	}
+
+	argv := append([]string{"tag", "undo"}, args...)
+	err = app.Run(argv)
+	return out.String(), err
+}
+
+func TestUT_UndoCommand_List_EmptyHistory(t *testing.T) {
+	dir := t.TempDir()
+	tagDir := filepath.Join(dir, ".tag")
+	require.NoError(t, os.MkdirAll(tagDir, 0o755))
+
+	out, err := runUndoApp(t, dir, "--list")
+	require.NoError(t, err)
+	assert.Contains(t, out, "No generations recorded")
+}
+
+func TestUT_UndoCommand_List_ShowsGenerations(t *testing.T) {
+	dir := t.TempDir()
+	tagDir := filepath.Join(dir, ".tag")
+	require.NoError(t, os.MkdirAll(tagDir, 0o755))
+
+	g := history.Generation{
+		ID:        "gen_1_aaa",
+		Timestamp: time.Date(2026, 3, 2, 10, 0, 0, 0, time.UTC),
+		Template:  "model",
+		Command:   "generate",
+		Files:     []history.FileEntry{{Path: "handler.go", Action: history.ActionCreate, HashAfter: "sha256:abc"}},
+	}
+	require.NoError(t, history.Append(tagDir, g))
+
+	out, err := runUndoApp(t, dir, "--list")
+	require.NoError(t, err)
+	assert.Contains(t, out, "gen_1_aaa")
+	assert.Contains(t, out, "model")
+}
+
+func TestUT_UndoCommand_UndoLastGeneration_WithYes(t *testing.T) {
+	dir := t.TempDir()
+	tagDir := filepath.Join(dir, ".tag")
+	require.NoError(t, os.MkdirAll(tagDir, 0o755))
+
+	// Create a file to be undone.
+	target := filepath.Join(dir, "handler.go")
+	require.NoError(t, os.WriteFile(target, []byte("package main"), 0o644))
+	hash, err := history.HashFile(target)
+	require.NoError(t, err)
+
+	g := history.Generation{
+		ID:      "gen_1_aaa",
+		Command: "generate", Template: "model",
+		Files: []history.FileEntry{{Path: target, Action: history.ActionCreate, HashAfter: hash}},
+	}
+	require.NoError(t, history.Append(tagDir, g))
+
+	_, err = runUndoApp(t, dir, "--yes")
+	require.NoError(t, err)
+
+	_, statErr := os.Stat(target)
+	assert.True(t, os.IsNotExist(statErr))
+}
+
+func TestUT_UndoCommand_ConflictError_DisplaysHelp(t *testing.T) {
+	dir := t.TempDir()
+	tagDir := filepath.Join(dir, ".tag")
+	require.NoError(t, os.MkdirAll(tagDir, 0o755))
+
+	target := filepath.Join(dir, "handler.go")
+	require.NoError(t, os.WriteFile(target, []byte("original"), 0o644))
+	hashAfter := history.HashBytes([]byte("original"))
+
+	g := history.Generation{
+		ID:      "gen_1_aaa",
+		Command: "generate",
+		Files:   []history.FileEntry{{Path: target, Action: history.ActionCreate, HashAfter: hashAfter}},
+	}
+	require.NoError(t, history.Append(tagDir, g))
+
+	// User modifies the file.
+	require.NoError(t, os.WriteFile(target, []byte("user modified"), 0o644))
+
+	out, err := runUndoApp(t, dir, "--yes")
+	assert.Error(t, err)
+	assert.Contains(t, out, "--force")
+}
+
+func TestUT_UndoCommand_UnknownTagDir_StillWorks(t *testing.T) {
+	// Even without a .tag/ dir, undo --list should show "No generations".
+	dir := t.TempDir()
+	// No .tag/ created — resolveTagDir falls back to cwd/.tag
+
+	out, err := runUndoApp(t, dir, "--list")
+	require.NoError(t, err)
+	assert.Contains(t, out, "No generations recorded")
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/kaikenlabs/tag/internal/chalk"
+	"github.com/kaikenlabs/tag/internal/history"
 	"github.com/kaikenlabs/tag/internal/parse"
 	"github.com/kaikenlabs/tag/internal/template"
 	"github.com/kaikenlabs/tag/internal/types"
@@ -59,6 +60,46 @@ func NewGeneratorWithEngine(tmplEngine *template.Engine, dryRun bool, dirPath, s
 	}
 
 	core := NewCore(parser, w, os.Stdout)
+	return &core, nil
+}
+
+// NewGeneratorWithRecorder creates a Generator that records file operations
+// into rec. It is identical to NewGeneratorWithEngine but wraps the FileWriter
+// with a history.RecordingFileWriter.
+func NewGeneratorWithRecorder(tmplEngine *template.Engine, dryRun bool, dirPath, sharedPath string, rec *history.Recorder) (Generator, error) {
+	if dryRun {
+		slog.Info(chalk.Cyan("DRYRUN MODE"))
+	}
+
+	templates, err := LoadTemplateFiles(dirPath)
+	if err != nil {
+		return nil, fmt.Errorf("cannot load templates: %w", err)
+	}
+
+	sharedTemplates, sharedErr := LoadTemplateFiles(sharedPath)
+	if sharedErr != nil {
+		slog.Debug("shared templates not loaded", "path", sharedPath, "error", sharedErr)
+	}
+
+	if len(sharedTemplates) > 0 {
+		loader := template.CreateMemoryLoaderFromMap(sharedTemplates)
+		tmplEngine.SetLoader(loader)
+		tmplEngine.SetSharedContent(sharedTemplates)
+		slog.Debug("loaded shared templates", "count", len(sharedTemplates))
+	}
+
+	parser := NewParserWithExecutor(tmplEngine, templates, sharedTemplates)
+	w, err := writer.NewFileWriter(dryRun)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create writer: %w", err)
+	}
+
+	fw := w
+	if rec != nil {
+		fw = history.NewRecordingFileWriter(w, rec)
+	}
+
+	core := NewCore(parser, fw, os.Stdout)
 	return &core, nil
 }
 

--- a/internal/history/errors.go
+++ b/internal/history/errors.go
@@ -1,0 +1,24 @@
+package history
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrNotFound is returned when a generation ID does not exist in the manifest.
+var ErrNotFound = errors.New("generation not found")
+
+// ErrConflict is returned when one or more files have been modified after the
+// generation was recorded, and --force has not been passed.
+var ErrConflict = errors.New("files modified after generation")
+
+// ConflictError carries the list of paths that have conflicting modifications.
+type ConflictError struct {
+	Paths []string
+}
+
+func (e *ConflictError) Error() string {
+	return fmt.Sprintf("%s: %v", ErrConflict.Error(), e.Paths)
+}
+
+func (e *ConflictError) Unwrap() error { return ErrConflict }

--- a/internal/history/hash.go
+++ b/internal/history/hash.go
@@ -1,0 +1,29 @@
+package history
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"os"
+)
+
+// HashFile computes a hex-encoded SHA256 hash of the file at path.
+func HashFile(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("open %s: %w", path, err)
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", fmt.Errorf("hash %s: %w", path, err)
+	}
+	return fmt.Sprintf("sha256:%x", h.Sum(nil)), nil
+}
+
+// HashBytes computes a hex-encoded SHA256 hash of b.
+func HashBytes(b []byte) string {
+	sum := sha256.Sum256(b)
+	return fmt.Sprintf("sha256:%x", sum)
+}

--- a/internal/history/hash_test.go
+++ b/internal/history/hash_test.go
@@ -1,0 +1,46 @@
+package history
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUT_HashBytes_KnownContent(t *testing.T) {
+	// echo -n "hello" | sha256sum → 2cf24dba...
+	h := HashBytes([]byte("hello"))
+	assert.Equal(t, "sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824", h)
+}
+
+func TestUT_HashBytes_EmptyInput(t *testing.T) {
+	h := HashBytes([]byte{})
+	assert.Equal(t, "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", h)
+}
+
+func TestUT_HashFile_KnownContent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "file.txt")
+	require.NoError(t, os.WriteFile(path, []byte("hello"), 0o644))
+
+	h, err := HashFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824", h)
+}
+
+func TestUT_HashFile_EmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty.txt")
+	require.NoError(t, os.WriteFile(path, []byte{}, 0o644))
+
+	h, err := HashFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", h)
+}
+
+func TestUT_HashFile_NonExistentFile(t *testing.T) {
+	_, err := HashFile("/nonexistent/path/file.txt")
+	assert.Error(t, err)
+}

--- a/internal/history/manifest.go
+++ b/internal/history/manifest.go
@@ -1,0 +1,94 @@
+package history
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/kaikenlabs/tag/internal/types"
+)
+
+// Load reads the manifest from tagDir/.tag/history.json.
+// If the file does not exist, it returns an empty manifest (not an error).
+func Load(tagDir string) (Manifest, error) {
+	path := manifestPath(tagDir)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return Manifest{}, nil
+		}
+		return Manifest{}, fmt.Errorf("read history manifest: %w", err)
+	}
+
+	var m Manifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return Manifest{}, fmt.Errorf("parse history manifest: %w", err)
+	}
+	return m, nil
+}
+
+// Save writes the manifest to tagDir/.tag/history.json atomically
+// (write to a temp file in the same directory, then rename).
+func Save(tagDir string, m Manifest) error {
+	if err := os.MkdirAll(tagDir, types.DirMode); err != nil {
+		return fmt.Errorf("create tag dir: %w", err)
+	}
+
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal history manifest: %w", err)
+	}
+
+	target := manifestPath(tagDir)
+	tmp := target + ".tmp"
+	if err := os.WriteFile(tmp, data, types.FileMode); err != nil {
+		return fmt.Errorf("write temp manifest: %w", err)
+	}
+
+	if err := os.Rename(tmp, target); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("rename manifest: %w", err)
+	}
+	return nil
+}
+
+// Append loads the manifest, appends g, and saves it atomically.
+func Append(tagDir string, g Generation) error {
+	m, err := Load(tagDir)
+	if err != nil {
+		return err
+	}
+	m.Generations = append(m.Generations, g)
+	return Save(tagDir, m)
+}
+
+// Remove loads the manifest, removes the generation with id, and saves it.
+// Returns ErrNotFound if no such generation exists.
+func Remove(tagDir, id string) error {
+	m, err := Load(tagDir)
+	if err != nil {
+		return err
+	}
+	idx := indexByID(m, id)
+	if idx < 0 {
+		return ErrNotFound
+	}
+	m.Generations = append(m.Generations[:idx], m.Generations[idx+1:]...)
+	return Save(tagDir, m)
+}
+
+func manifestPath(tagDir string) string {
+	return filepath.Join(tagDir, types.HistoryFile)
+}
+
+func indexByID(m Manifest, id string) int {
+	for i, g := range m.Generations {
+		if g.ID == id {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/history/manifest_test.go
+++ b/internal/history/manifest_test.go
@@ -1,0 +1,110 @@
+package history
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUT_Manifest_LoadNonExistent_ReturnsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	m, err := Load(dir)
+	require.NoError(t, err)
+	assert.Empty(t, m.Generations)
+}
+
+func TestUT_Manifest_SaveLoad_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	hb := "sha256:aabbcc"
+	original := Manifest{
+		Generations: []Generation{
+			{
+				ID:        "gen_1_abc",
+				Timestamp: time.Date(2026, 3, 2, 10, 0, 0, 0, time.UTC),
+				Template:  "model",
+				Command:   "generate",
+				Files: []FileEntry{
+					{Path: "handler.go", Action: ActionCreate, HashBefore: nil, HashAfter: "sha256:deadbeef"},
+					{Path: "router.go", Action: ActionInject, HashBefore: &hb, HashAfter: "sha256:cafebabe"},
+				},
+			},
+		},
+	}
+
+	require.NoError(t, Save(dir, original))
+	loaded, err := Load(dir)
+	require.NoError(t, err)
+
+	require.Len(t, loaded.Generations, 1)
+	g := loaded.Generations[0]
+	assert.Equal(t, "gen_1_abc", g.ID)
+	assert.Equal(t, "model", g.Template)
+	assert.Len(t, g.Files, 2)
+	assert.Nil(t, g.Files[0].HashBefore)
+	assert.NotNil(t, g.Files[1].HashBefore)
+	assert.Equal(t, "sha256:aabbcc", *g.Files[1].HashBefore)
+}
+
+func TestUT_Manifest_AtomicWrite_OverwritesExisting(t *testing.T) {
+	dir := t.TempDir()
+
+	first := Manifest{Generations: []Generation{{ID: "gen_1_aaa", Command: "generate"}}}
+	require.NoError(t, Save(dir, first))
+
+	second := Manifest{Generations: []Generation{{ID: "gen_2_bbb", Command: "generate"}}}
+	require.NoError(t, Save(dir, second))
+
+	loaded, err := Load(dir)
+	require.NoError(t, err)
+	require.Len(t, loaded.Generations, 1)
+	assert.Equal(t, "gen_2_bbb", loaded.Generations[0].ID)
+}
+
+func TestUT_Manifest_CorruptJSON_ReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "history.json")
+	require.NoError(t, os.WriteFile(path, []byte("{not valid json"), 0o644))
+
+	_, err := Load(dir)
+	assert.Error(t, err)
+}
+
+func TestUT_Manifest_Append_AddsGeneration(t *testing.T) {
+	dir := t.TempDir()
+	g1 := Generation{ID: "gen_1_aaa", Command: "generate"}
+	g2 := Generation{ID: "gen_2_bbb", Command: "generate"}
+
+	require.NoError(t, Append(dir, g1))
+	require.NoError(t, Append(dir, g2))
+
+	m, err := Load(dir)
+	require.NoError(t, err)
+	require.Len(t, m.Generations, 2)
+	assert.Equal(t, "gen_1_aaa", m.Generations[0].ID)
+	assert.Equal(t, "gen_2_bbb", m.Generations[1].ID)
+}
+
+func TestUT_Manifest_Remove_RemovesGeneration(t *testing.T) {
+	dir := t.TempDir()
+	g1 := Generation{ID: "gen_1_aaa", Command: "generate"}
+	g2 := Generation{ID: "gen_2_bbb", Command: "generate"}
+	require.NoError(t, Append(dir, g1))
+	require.NoError(t, Append(dir, g2))
+
+	require.NoError(t, Remove(dir, "gen_1_aaa"))
+
+	m, err := Load(dir)
+	require.NoError(t, err)
+	require.Len(t, m.Generations, 1)
+	assert.Equal(t, "gen_2_bbb", m.Generations[0].ID)
+}
+
+func TestUT_Manifest_Remove_UnknownID_ReturnsErrNotFound(t *testing.T) {
+	dir := t.TempDir()
+	err := Remove(dir, "gen_unknown")
+	assert.ErrorIs(t, err, ErrNotFound)
+}

--- a/internal/history/recorder.go
+++ b/internal/history/recorder.go
@@ -1,0 +1,246 @@
+package history
+
+import (
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"time"
+
+	"github.com/kaikenlabs/tag/internal/types"
+	"github.com/kaikenlabs/tag/internal/writer"
+)
+
+// Recorder accumulates FileEntry records for a single generation.
+// It tracks which files have already been snapshotted so that hash_before
+// is only captured once per file per generation (first-touch semantics),
+// which is correct when a bundle runs multiple generators against the same file.
+type Recorder struct {
+	tagDir      string
+	genID       string
+	snapshotted map[string]bool // files for which hash_before has been captured
+	entries     map[string]*FileEntry
+}
+
+// NewRecorder creates a Recorder that will store backups under tagDir.
+func NewRecorder(tagDir string) *Recorder {
+	return &Recorder{
+		tagDir:      tagDir,
+		genID:       newGenID(),
+		snapshotted: make(map[string]bool),
+		entries:     make(map[string]*FileEntry),
+	}
+}
+
+// RecordCreate records a file that was newly created (no prior content).
+// Should be called after the file has been written.
+func (r *Recorder) RecordCreate(path, hashAfter string) {
+	if e, exists := r.entries[path]; exists {
+		// File was already recorded in this generation; update hash_after only.
+		e.HashAfter = hashAfter
+		return
+	}
+	r.entries[path] = &FileEntry{
+		Path:       path,
+		Action:     ActionCreate,
+		HashBefore: nil,
+		HashAfter:  hashAfter,
+	}
+}
+
+// RecordModify records a file that was modified (inject or append).
+// Should be called after the file has been written.
+// hashBefore is the hash before this generation touched the file (first-touch only).
+func (r *Recorder) RecordModify(path, action, hashBefore, hashAfter string) {
+	if e, exists := r.entries[path]; exists {
+		// Already recorded in this generation; only update hash_after.
+		e.Action = action
+		e.HashAfter = hashAfter
+		return
+	}
+	hb := hashBefore
+	r.entries[path] = &FileEntry{
+		Path:       path,
+		Action:     action,
+		HashBefore: &hb,
+		HashAfter:  hashAfter,
+	}
+}
+
+// BackupDir returns the path where backups for this generation are stored.
+func (r *Recorder) BackupDir() string {
+	return filepath.Join(r.tagDir, types.HistoryBackupsDir, r.genID)
+}
+
+// Build returns a completed Generation with all recorded entries.
+func (r *Recorder) Build(template, command string) Generation {
+	files := make([]FileEntry, 0, len(r.entries))
+	for _, e := range r.entries {
+		files = append(files, *e)
+	}
+	// Sort by path for deterministic manifest output.
+	slices.SortFunc(files, func(a, b FileEntry) int {
+		if a.Path < b.Path {
+			return -1
+		}
+		if a.Path > b.Path {
+			return 1
+		}
+		return 0
+	})
+	return Generation{
+		ID:        r.genID,
+		Timestamp: time.Now().UTC(),
+		Template:  template,
+		Command:   command,
+		Files:     files,
+	}
+}
+
+// GenID returns the generation ID assigned to this recorder.
+func (r *Recorder) GenID() string { return r.genID }
+
+// newGenID generates a generation ID in the form gen_<unix>_<6hex>.
+func newGenID() string {
+	b := make([]byte, 3)
+	if _, err := rand.Read(b); err != nil {
+		// Fallback to a deterministic suffix on error (extremely unlikely).
+		return fmt.Sprintf("gen_%d_000000", time.Now().Unix())
+	}
+	return fmt.Sprintf("gen_%d_%x", time.Now().Unix(), b)
+}
+
+// RecordingFileWriter wraps a writer.FileWriter to record file operations
+// via a Recorder. It implements writer.FileWriter.
+type RecordingFileWriter struct {
+	inner  writer.FileWriter
+	rec    *Recorder
+	tagDir string
+}
+
+// NewRecordingFileWriter creates a RecordingFileWriter decorator.
+func NewRecordingFileWriter(inner writer.FileWriter, rec *Recorder) *RecordingFileWriter {
+	return &RecordingFileWriter{inner: inner, rec: rec, tagDir: rec.tagDir}
+}
+
+// Ensure RecordingFileWriter satisfies writer.FileWriter at compile time.
+var _ writer.FileWriter = (*RecordingFileWriter)(nil)
+
+// WriteFile records a "create" operation and delegates to the inner writer.
+func (w *RecordingFileWriter) WriteFile(name string, data []byte, perm fs.FileMode) error {
+	if err := w.inner.WriteFile(name, data, perm); err != nil {
+		return err
+	}
+	hashAfter, err := HashFile(name)
+	if err != nil {
+		return fmt.Errorf("hash after write %s: %w", name, err)
+	}
+	w.rec.RecordCreate(name, hashAfter)
+	return nil
+}
+
+// AppendFile records an "append" operation. If the file does not exist before
+// the append, it records a "create" action (hash_before=nil).
+func (w *RecordingFileWriter) AppendFile(name string, data []byte) error {
+	hashBefore, existed, err := w.snapshotBefore(name)
+	if err != nil {
+		return err
+	}
+
+	if appendErr := w.inner.AppendFile(name, data); appendErr != nil {
+		return appendErr
+	}
+
+	hashAfter, err := HashFile(name)
+	if err != nil {
+		return fmt.Errorf("hash after append %s: %w", name, err)
+	}
+
+	if !existed {
+		w.rec.RecordCreate(name, hashAfter)
+	} else {
+		w.rec.RecordModify(name, ActionAppend, hashBefore, hashAfter)
+	}
+	return nil
+}
+
+// InjectIntoFile records an "inject" operation.
+func (w *RecordingFileWriter) InjectIntoFile(name string, data []byte, inject writer.Inject) error {
+	hashBefore, existed, err := w.snapshotBefore(name)
+	if err != nil {
+		return err
+	}
+
+	if injectErr := w.inner.InjectIntoFile(name, data, inject); injectErr != nil {
+		return injectErr
+	}
+
+	hashAfter, err := HashFile(name)
+	if err != nil {
+		return fmt.Errorf("hash after inject %s: %w", name, err)
+	}
+
+	if !existed {
+		w.rec.RecordCreate(name, hashAfter)
+	} else {
+		w.rec.RecordModify(name, ActionInject, hashBefore, hashAfter)
+	}
+	return nil
+}
+
+// snapshotBefore captures the hash of name (if it exists) and creates a backup.
+// Returns (hash, existed, error). Uses first-touch semantics: if the file has
+// already been snapshotted in this generation, the backup is not recreated.
+func (w *RecordingFileWriter) snapshotBefore(name string) (hashBefore string, existed bool, err error) {
+	_, statErr := os.Stat(name)
+	if errors.Is(statErr, fs.ErrNotExist) {
+		return "", false, nil
+	}
+	if statErr != nil {
+		return "", false, fmt.Errorf("stat %s: %w", name, statErr)
+	}
+
+	if !w.rec.snapshotted[name] {
+		// First touch: capture hash and create backup.
+		h, err := HashFile(name)
+		if err != nil {
+			return "", true, err
+		}
+		if err := w.backupFile(name); err != nil {
+			return "", true, err
+		}
+		w.rec.snapshotted[name] = true
+		return h, true, nil
+	}
+
+	// Subsequent touch: hash_before was already captured; return empty string
+	// so the caller calls RecordModify with an empty hashBefore, which
+	// RecordModify ignores (it only updates hash_after for subsequent touches).
+	return "", true, nil
+}
+
+// backupFile copies name to the generation backup directory.
+func (w *RecordingFileWriter) backupFile(name string) error {
+	backupPath := filepath.Join(w.rec.BackupDir(), name)
+	if err := os.MkdirAll(filepath.Dir(backupPath), types.DirMode); err != nil {
+		return fmt.Errorf("create backup dir for %s: %w", name, err)
+	}
+
+	data, err := os.ReadFile(name)
+	if err != nil {
+		return fmt.Errorf("read for backup %s: %w", name, err)
+	}
+
+	info, err := os.Stat(name)
+	if err != nil {
+		return fmt.Errorf("stat for backup %s: %w", name, err)
+	}
+
+	if err := os.WriteFile(backupPath, data, info.Mode()); err != nil {
+		return fmt.Errorf("write backup %s: %w", backupPath, err)
+	}
+	return nil
+}

--- a/internal/history/recorder_test.go
+++ b/internal/history/recorder_test.go
@@ -1,0 +1,182 @@
+package history
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kaikenlabs/tag/internal/writer"
+)
+
+// stubFileWriter is a minimal FileWriter backed by the real filesystem.
+type stubFileWriter struct{}
+
+func (s *stubFileWriter) WriteFile(name string, data []byte, perm fs.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(name), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(name, data, perm)
+}
+
+func (s *stubFileWriter) AppendFile(name string, data []byte) error {
+	f, err := os.OpenFile(name, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = f.Write(data)
+	return err
+}
+
+func (s *stubFileWriter) InjectIntoFile(name string, data []byte, _ writer.Inject) error {
+	existing, err := os.ReadFile(name)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(name, append(existing, data...), 0o644)
+}
+
+func TestUT_Recorder_RecordCreate_NilHashBefore(t *testing.T) {
+	rec := NewRecorder(t.TempDir())
+	rec.RecordCreate("handler.go", "sha256:abc")
+
+	gen := rec.Build("model", "generate")
+	require.Len(t, gen.Files, 1)
+	assert.Equal(t, ActionCreate, gen.Files[0].Action)
+	assert.Nil(t, gen.Files[0].HashBefore)
+	assert.Equal(t, "sha256:abc", gen.Files[0].HashAfter)
+}
+
+func TestUT_Recorder_RecordModify_HasHashBefore(t *testing.T) {
+	rec := NewRecorder(t.TempDir())
+	rec.RecordModify("router.go", ActionInject, "sha256:before", "sha256:after")
+
+	gen := rec.Build("model", "generate")
+	require.Len(t, gen.Files, 1)
+	assert.Equal(t, ActionInject, gen.Files[0].Action)
+	require.NotNil(t, gen.Files[0].HashBefore)
+	assert.Equal(t, "sha256:before", *gen.Files[0].HashBefore)
+	assert.Equal(t, "sha256:after", gen.Files[0].HashAfter)
+}
+
+func TestUT_Recorder_Build_ReturnsGeneration(t *testing.T) {
+	rec := NewRecorder(t.TempDir())
+	rec.RecordCreate("a.go", "sha256:aaa")
+	rec.RecordCreate("b.go", "sha256:bbb")
+
+	gen := rec.Build("crud", "generate")
+	assert.Equal(t, "crud", gen.Template)
+	assert.Equal(t, "generate", gen.Command)
+	assert.NotEmpty(t, gen.ID)
+	assert.False(t, gen.Timestamp.IsZero())
+	assert.Len(t, gen.Files, 2)
+}
+
+func TestUT_RecordingWriter_WriteFile_RecordsCreate(t *testing.T) {
+	dir := t.TempDir()
+	tagDir := filepath.Join(dir, ".tag")
+
+	rec := NewRecorder(tagDir)
+	rw := NewRecordingFileWriter(&stubFileWriter{}, rec)
+
+	target := filepath.Join(dir, "handler.go")
+	require.NoError(t, rw.WriteFile(target, []byte("package main"), 0o644))
+
+	gen := rec.Build("model", "generate")
+	require.Len(t, gen.Files, 1)
+	assert.Equal(t, ActionCreate, gen.Files[0].Action)
+	assert.Equal(t, target, gen.Files[0].Path)
+	assert.Nil(t, gen.Files[0].HashBefore)
+	assert.NotEmpty(t, gen.Files[0].HashAfter)
+}
+
+func TestUT_RecordingWriter_AppendFile_RecordsModify_CreatesBackup(t *testing.T) {
+	dir := t.TempDir()
+	tagDir := filepath.Join(dir, ".tag")
+
+	// Pre-create the target file.
+	target := filepath.Join(dir, "router.go")
+	require.NoError(t, os.WriteFile(target, []byte("original"), 0o644))
+	originalHash, err := HashFile(target)
+	require.NoError(t, err)
+
+	rec := NewRecorder(tagDir)
+	rw := NewRecordingFileWriter(&stubFileWriter{}, rec)
+	require.NoError(t, rw.AppendFile(target, []byte("\nappended")))
+
+	gen := rec.Build("routes", "generate")
+	require.Len(t, gen.Files, 1)
+	assert.Equal(t, ActionAppend, gen.Files[0].Action)
+	require.NotNil(t, gen.Files[0].HashBefore)
+	assert.Equal(t, originalHash, *gen.Files[0].HashBefore)
+
+	// Backup should exist.
+	backupPath := filepath.Join(rec.BackupDir(), target)
+	_, statErr := os.Stat(backupPath)
+	assert.NoError(t, statErr, "backup file should exist")
+}
+
+func TestUT_RecordingWriter_InjectIntoFile_RecordsModify_CreatesBackup(t *testing.T) {
+	dir := t.TempDir()
+	tagDir := filepath.Join(dir, ".tag")
+
+	target := filepath.Join(dir, "app.go")
+	require.NoError(t, os.WriteFile(target, []byte("original"), 0o644))
+
+	rec := NewRecorder(tagDir)
+	rw := NewRecordingFileWriter(&stubFileWriter{}, rec)
+	require.NoError(t, rw.InjectIntoFile(target, []byte("\ninjected"), writer.Inject{}))
+
+	gen := rec.Build("routes", "generate")
+	require.Len(t, gen.Files, 1)
+	assert.Equal(t, ActionInject, gen.Files[0].Action)
+	assert.NotNil(t, gen.Files[0].HashBefore)
+}
+
+func TestUT_RecordingWriter_AppendFile_TargetNotExist_RecordsCreate(t *testing.T) {
+	dir := t.TempDir()
+	tagDir := filepath.Join(dir, ".tag")
+	target := filepath.Join(dir, "new.go")
+
+	rec := NewRecorder(tagDir)
+	rw := NewRecordingFileWriter(&stubFileWriter{}, rec)
+	require.NoError(t, rw.AppendFile(target, []byte("content")))
+
+	gen := rec.Build("model", "generate")
+	require.Len(t, gen.Files, 1)
+	assert.Equal(t, ActionCreate, gen.Files[0].Action)
+	assert.Nil(t, gen.Files[0].HashBefore)
+}
+
+func TestUT_RecordingWriter_FirstTouchSemantics_SameFileTwice(t *testing.T) {
+	dir := t.TempDir()
+	tagDir := filepath.Join(dir, ".tag")
+
+	target := filepath.Join(dir, "router.go")
+	require.NoError(t, os.WriteFile(target, []byte("v0"), 0o644))
+	v0Hash, err := HashFile(target)
+	require.NoError(t, err)
+
+	rec := NewRecorder(tagDir)
+	rw := NewRecordingFileWriter(&stubFileWriter{}, rec)
+
+	// Two appends to the same file in one generation (simulates a bundle).
+	require.NoError(t, rw.AppendFile(target, []byte("v1")))
+	require.NoError(t, rw.AppendFile(target, []byte("v2")))
+
+	gen := rec.Build("bundle", "generate")
+	// Should have exactly one entry for the file.
+	require.Len(t, gen.Files, 1)
+	entry := gen.Files[0]
+	// hash_before must be v0 (pre-generation state).
+	require.NotNil(t, entry.HashBefore)
+	assert.Equal(t, v0Hash, *entry.HashBefore)
+	// hash_after must reflect the state after both appends.
+	currentHash, err := HashFile(target)
+	require.NoError(t, err)
+	assert.Equal(t, currentHash, entry.HashAfter)
+}

--- a/internal/history/types.go
+++ b/internal/history/types.go
@@ -1,0 +1,33 @@
+package history
+
+import "time"
+
+// Manifest is the root of .tag/history.json.
+type Manifest struct {
+	Generations []Generation `json:"generations"`
+}
+
+// Generation is a single generation record representing one `tag generate`
+// or `tag scaffold` invocation.
+type Generation struct {
+	ID        string      `json:"id"`
+	Timestamp time.Time   `json:"timestamp"`
+	Template  string      `json:"template,omitempty"`
+	Command   string      `json:"command"` // "generate" or "scaffold"
+	Files     []FileEntry `json:"files"`
+}
+
+// FileEntry records a single file operation within a generation.
+type FileEntry struct {
+	Path       string  `json:"path"`
+	Action     string  `json:"action"` // "create", "inject", "append"
+	HashBefore *string `json:"hash_before"`
+	HashAfter  string  `json:"hash_after"`
+}
+
+// Action constants for FileEntry.
+const (
+	ActionCreate = "create"
+	ActionInject = "inject"
+	ActionAppend = "append"
+)

--- a/internal/history/undo.go
+++ b/internal/history/undo.go
@@ -1,0 +1,212 @@
+package history
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+
+	"github.com/kaikenlabs/tag/internal/types"
+)
+
+// UndoOptions controls the behaviour of the undo engine.
+type UndoOptions struct {
+	// GenID identifies the generation to undo. When empty, the last generation
+	// in the manifest is used.
+	GenID string
+	// Force skips conflict detection and proceeds even when files have been
+	// modified after the generation was recorded.
+	Force bool
+	// Partial reverts files that have not been modified and silently skips
+	// those that conflict, instead of aborting.
+	Partial bool
+	// Out receives the human-readable summary written after a successful undo.
+	Out io.Writer
+}
+
+// Undo reverts a generation recorded in tagDir's manifest.
+// On success, the generation entry is removed from the manifest.
+func Undo(tagDir string, opts UndoOptions) error {
+	m, err := Load(tagDir)
+	if err != nil {
+		return err
+	}
+
+	// Resolve target generation.
+	var gen Generation
+	if opts.GenID == "" {
+		if len(m.Generations) == 0 {
+			return errors.New("no generations to undo")
+		}
+		gen = m.Generations[len(m.Generations)-1]
+	} else {
+		idx := indexByID(m, opts.GenID)
+		if idx < 0 {
+			return ErrNotFound
+		}
+		gen = m.Generations[idx]
+	}
+
+	// Conflict detection: compare current file hash vs recorded hash_after.
+	conflicted := checkConflicts(gen)
+
+	if len(conflicted) > 0 {
+		if !opts.Force && !opts.Partial {
+			return &ConflictError{Paths: conflicted}
+		}
+		if opts.Partial {
+			printConflictWarning(opts.Out, gen.ID, conflicted)
+		}
+	}
+
+	// Revert files in reverse order.
+	backupDir := filepath.Join(tagDir, types.HistoryBackupsDir, gen.ID)
+	var reverted, skipped int
+	for i := len(gen.Files) - 1; i >= 0; i-- {
+		entry := gen.Files[i]
+
+		// In partial mode, skip conflicted files.
+		if opts.Partial && !opts.Force && isConflicted(entry, conflicted) {
+			skipped++
+			continue
+		}
+
+		if err := revertFile(entry, backupDir); err != nil {
+			return fmt.Errorf("undo file %s: %w", entry.Path, err)
+		}
+		reverted++
+	}
+
+	// Clean up empty directories left by deleted files.
+	cleanEmptyDirs(gen.Files)
+
+	// Remove backup directory for this generation.
+	_ = os.RemoveAll(backupDir)
+
+	// Remove generation from manifest.
+	if err := Remove(tagDir, gen.ID); err != nil {
+		return fmt.Errorf("update manifest: %w", err)
+	}
+
+	printSummary(opts.Out, gen, reverted, skipped)
+	return nil
+}
+
+// ListGenerations returns all generations in the manifest, newest first.
+func ListGenerations(tagDir string) ([]Generation, error) {
+	m, err := Load(tagDir)
+	if err != nil {
+		return nil, err
+	}
+	// Return a copy reversed so newest is first.
+	gs := make([]Generation, len(m.Generations))
+	for i, g := range m.Generations {
+		gs[len(m.Generations)-1-i] = g
+	}
+	return gs, nil
+}
+
+// checkConflicts returns the paths of files whose current hash differs from
+// the recorded hash_after (i.e., they have been modified after generation).
+func checkConflicts(gen Generation) []string {
+	var conflicts []string
+	for _, entry := range gen.Files {
+		current, err := HashFile(entry.Path)
+		if err != nil {
+			// File no longer exists or can't be read; for "create" actions this
+			// means the file was already deleted — not a conflict.
+			if entry.Action == ActionCreate {
+				continue
+			}
+			// For inject/append, missing backup target is a conflict.
+			conflicts = append(conflicts, entry.Path)
+			continue
+		}
+		if current != entry.HashAfter {
+			conflicts = append(conflicts, entry.Path)
+		}
+	}
+	return conflicts
+}
+
+func isConflicted(entry FileEntry, conflicted []string) bool {
+	return slices.Contains(conflicted, entry.Path)
+}
+
+// revertFile undoes a single FileEntry.
+func revertFile(entry FileEntry, backupDir string) error {
+	switch entry.Action {
+	case ActionCreate:
+		// Delete the file. If it no longer exists, treat as already reverted.
+		if _, statErr := os.Stat(entry.Path); statErr != nil {
+			if errors.Is(statErr, os.ErrNotExist) {
+				return nil // already gone — desired state
+			}
+			return fmt.Errorf("check file %s: %w", entry.Path, statErr)
+		}
+		return os.Remove(entry.Path)
+
+	case ActionInject, ActionAppend:
+		// Restore from backup.
+		backupPath := filepath.Join(backupDir, entry.Path)
+		data, err := os.ReadFile(backupPath)
+		if err != nil {
+			return fmt.Errorf("read backup for %s: %w", entry.Path, err)
+		}
+		info, err := os.Stat(backupPath)
+		if err != nil {
+			return fmt.Errorf("stat backup for %s: %w", entry.Path, err)
+		}
+		if err := os.MkdirAll(filepath.Dir(entry.Path), types.DirMode); err != nil {
+			return fmt.Errorf("create parent dir for %s: %w", entry.Path, err)
+		}
+		return os.WriteFile(entry.Path, data, info.Mode())
+	}
+	return nil
+}
+
+// cleanEmptyDirs removes empty directories left behind after deleting created files.
+func cleanEmptyDirs(files []FileEntry) {
+	seen := make(map[string]bool)
+	for _, entry := range files {
+		if entry.Action != ActionCreate {
+			continue
+		}
+		dir := filepath.Dir(entry.Path)
+		for dir != "." && dir != "/" && !seen[dir] {
+			seen[dir] = true
+			entries, err := os.ReadDir(dir)
+			if err != nil || len(entries) > 0 {
+				break
+			}
+			if err := os.Remove(dir); err != nil {
+				break
+			}
+			dir = filepath.Dir(dir)
+		}
+	}
+}
+
+func printConflictWarning(out io.Writer, genID string, paths []string) {
+	if out == nil {
+		return
+	}
+	fmt.Fprintf(out, "Warning: the following files were modified after generation %s and will be skipped:\n", genID)
+	for _, p := range paths {
+		fmt.Fprintf(out, "  - %s\n", p)
+	}
+}
+
+func printSummary(out io.Writer, gen Generation, reverted, skipped int) {
+	if out == nil {
+		return
+	}
+	fmt.Fprintf(out, "Undid generation %s (%s)\n", gen.ID, gen.Template)
+	fmt.Fprintf(out, "  %d file(s) reverted", reverted)
+	if skipped > 0 {
+		fmt.Fprintf(out, ", %d file(s) skipped (conflict)", skipped)
+	}
+	fmt.Fprintln(out)
+}

--- a/internal/history/undo_test.go
+++ b/internal/history/undo_test.go
@@ -1,0 +1,249 @@
+package history
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupGenerationWithFile creates a file, adds a backup (for inject/append entries),
+// writes a manifest entry, and returns the tag dir and file path.
+func setupUndoEnv(t *testing.T) (tagDir, projectDir string) {
+	t.Helper()
+	dir := t.TempDir()
+	tagDir = filepath.Join(dir, ".tag")
+	require.NoError(t, os.MkdirAll(tagDir, 0o755))
+	return tagDir, dir
+}
+
+func TestUT_UndoEngine_LastGeneration_DeletesCreatedFiles(t *testing.T) {
+	tagDir, projectDir := setupUndoEnv(t)
+	target := filepath.Join(projectDir, "handler.go")
+	require.NoError(t, os.WriteFile(target, []byte("package main"), 0o644))
+	hash, err := HashFile(target)
+	require.NoError(t, err)
+
+	gen := Generation{
+		ID: "gen_1_aaa", Timestamp: time.Now(), Template: "model", Command: "generate",
+		Files: []FileEntry{{Path: target, Action: ActionCreate, HashAfter: hash}},
+	}
+	require.NoError(t, Append(tagDir, gen))
+
+	var out bytes.Buffer
+	require.NoError(t, Undo(tagDir, UndoOptions{Out: &out}))
+
+	_, statErr := os.Stat(target)
+	assert.True(t, os.IsNotExist(statErr), "created file should be deleted")
+	assert.Contains(t, out.String(), "gen_1_aaa")
+
+	m, err := Load(tagDir)
+	require.NoError(t, err)
+	assert.Empty(t, m.Generations)
+}
+
+func TestUT_UndoEngine_LastGeneration_RestoresModifiedFiles(t *testing.T) {
+	tagDir, projectDir := setupUndoEnv(t)
+	target := filepath.Join(projectDir, "router.go")
+	original := []byte("original content")
+	modified := []byte("original content\nappended")
+
+	// Write the "after" state to the target.
+	require.NoError(t, os.WriteFile(target, modified, 0o644))
+	hashAfter, err := HashFile(target)
+	require.NoError(t, err)
+
+	// Set up backup (pre-generation content).
+	backupDir := filepath.Join(tagDir, "history", "backups", "gen_1_bbb")
+	backupPath := filepath.Join(backupDir, target)
+	require.NoError(t, os.MkdirAll(filepath.Dir(backupPath), 0o755))
+	require.NoError(t, os.WriteFile(backupPath, original, 0o644))
+
+	hashBefore := HashBytes(original)
+	gen := Generation{
+		ID: "gen_1_bbb", Timestamp: time.Now(), Template: "routes", Command: "generate",
+		Files: []FileEntry{{Path: target, Action: ActionAppend, HashBefore: &hashBefore, HashAfter: hashAfter}},
+	}
+	require.NoError(t, Append(tagDir, gen))
+
+	require.NoError(t, Undo(tagDir, UndoOptions{Out: &bytes.Buffer{}}))
+
+	restored, err := os.ReadFile(target)
+	require.NoError(t, err)
+	assert.Equal(t, original, restored)
+}
+
+func TestUT_UndoEngine_SpecificID_ByID(t *testing.T) {
+	tagDir, projectDir := setupUndoEnv(t)
+	target := filepath.Join(projectDir, "service.go")
+	require.NoError(t, os.WriteFile(target, []byte("pkg"), 0o644))
+	hash, err := HashFile(target)
+	require.NoError(t, err)
+
+	gen1 := Generation{
+		ID: "gen_1_aaa", Command: "generate",
+		Files: []FileEntry{{Path: "other.go", Action: ActionCreate, HashAfter: "sha256:xxx"}},
+	}
+	gen2 := Generation{
+		ID: "gen_2_bbb", Command: "generate",
+		Files: []FileEntry{{Path: target, Action: ActionCreate, HashAfter: hash}},
+	}
+	require.NoError(t, Append(tagDir, gen1))
+	require.NoError(t, Append(tagDir, gen2))
+
+	require.NoError(t, Undo(tagDir, UndoOptions{GenID: "gen_2_bbb", Out: &bytes.Buffer{}}))
+
+	_, statErr := os.Stat(target)
+	assert.True(t, os.IsNotExist(statErr))
+
+	m, err := Load(tagDir)
+	require.NoError(t, err)
+	require.Len(t, m.Generations, 1)
+	assert.Equal(t, "gen_1_aaa", m.Generations[0].ID)
+}
+
+func TestUT_UndoEngine_UnknownID_ReturnsErrNotFound(t *testing.T) {
+	tagDir, _ := setupUndoEnv(t)
+	err := Undo(tagDir, UndoOptions{GenID: "gen_unknown", Out: &bytes.Buffer{}})
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestUT_UndoEngine_NoGenerations_ReturnsError(t *testing.T) {
+	tagDir, _ := setupUndoEnv(t)
+	err := Undo(tagDir, UndoOptions{Out: &bytes.Buffer{}})
+	assert.Error(t, err)
+}
+
+func TestUT_UndoEngine_ConflictDetection_Blocks_ByDefault(t *testing.T) {
+	tagDir, projectDir := setupUndoEnv(t)
+	target := filepath.Join(projectDir, "handler.go")
+	require.NoError(t, os.WriteFile(target, []byte("original"), 0o644))
+
+	// Record hash of original.
+	hashAfter := HashBytes([]byte("original"))
+	gen := Generation{
+		ID: "gen_1_aaa", Command: "generate",
+		Files: []FileEntry{{Path: target, Action: ActionCreate, HashAfter: hashAfter}},
+	}
+	require.NoError(t, Append(tagDir, gen))
+
+	// Simulate user modification after generation.
+	require.NoError(t, os.WriteFile(target, []byte("user modified"), 0o644))
+
+	err := Undo(tagDir, UndoOptions{Out: &bytes.Buffer{}})
+	assert.ErrorIs(t, err, ErrConflict)
+}
+
+func TestUT_UndoEngine_ConflictDetection_Force_Proceeds(t *testing.T) {
+	tagDir, projectDir := setupUndoEnv(t)
+	target := filepath.Join(projectDir, "handler.go")
+	require.NoError(t, os.WriteFile(target, []byte("original"), 0o644))
+
+	hashAfter := HashBytes([]byte("original"))
+	gen := Generation{
+		ID: "gen_1_aaa", Command: "generate",
+		Files: []FileEntry{{Path: target, Action: ActionCreate, HashAfter: hashAfter}},
+	}
+	require.NoError(t, Append(tagDir, gen))
+
+	require.NoError(t, os.WriteFile(target, []byte("user modified"), 0o644))
+
+	err := Undo(tagDir, UndoOptions{Force: true, Out: &bytes.Buffer{}})
+	assert.NoError(t, err)
+	_, statErr := os.Stat(target)
+	assert.True(t, os.IsNotExist(statErr))
+}
+
+func TestUT_UndoEngine_ConflictDetection_Partial_SkipsConflicted(t *testing.T) {
+	tagDir, projectDir := setupUndoEnv(t)
+
+	cleanFile := filepath.Join(projectDir, "clean.go")
+	dirtyFile := filepath.Join(projectDir, "dirty.go")
+	require.NoError(t, os.WriteFile(cleanFile, []byte("clean"), 0o644))
+	require.NoError(t, os.WriteFile(dirtyFile, []byte("dirty_original"), 0o644))
+
+	cleanHash := HashBytes([]byte("clean"))
+	dirtyHash := HashBytes([]byte("dirty_original"))
+
+	gen := Generation{
+		ID: "gen_1_aaa", Command: "generate",
+		Files: []FileEntry{
+			{Path: cleanFile, Action: ActionCreate, HashAfter: cleanHash},
+			{Path: dirtyFile, Action: ActionCreate, HashAfter: dirtyHash},
+		},
+	}
+	require.NoError(t, Append(tagDir, gen))
+
+	// Modify only dirty file.
+	require.NoError(t, os.WriteFile(dirtyFile, []byte("user modified"), 0o644))
+
+	var out bytes.Buffer
+	err := Undo(tagDir, UndoOptions{Partial: true, Out: &out})
+	assert.NoError(t, err)
+
+	_, cleanStatErr := os.Stat(cleanFile)
+	assert.True(t, os.IsNotExist(cleanStatErr), "clean file should be deleted")
+
+	_, dirtyStatErr := os.Stat(dirtyFile)
+	assert.False(t, os.IsNotExist(dirtyStatErr), "dirty file should still exist (skipped)")
+
+	assert.Contains(t, out.String(), "skipped (conflict)")
+}
+
+func TestUT_UndoEngine_DeletesEmptyDirectories(t *testing.T) {
+	tagDir, projectDir := setupUndoEnv(t)
+
+	subDir := filepath.Join(projectDir, "internal", "auth")
+	require.NoError(t, os.MkdirAll(subDir, 0o755))
+	target := filepath.Join(subDir, "handler.go")
+	require.NoError(t, os.WriteFile(target, []byte("pkg"), 0o644))
+	hash, err := HashFile(target)
+	require.NoError(t, err)
+
+	gen := Generation{
+		ID: "gen_1_aaa", Command: "generate",
+		Files: []FileEntry{{Path: target, Action: ActionCreate, HashAfter: hash}},
+	}
+	require.NoError(t, Append(tagDir, gen))
+
+	require.NoError(t, Undo(tagDir, UndoOptions{Out: &bytes.Buffer{}}))
+
+	_, dirStatErr := os.Stat(subDir)
+	assert.True(t, os.IsNotExist(dirStatErr), "empty directory should be removed")
+}
+
+func TestUT_UndoEngine_ListGenerations_NewestFirst(t *testing.T) {
+	tagDir, _ := setupUndoEnv(t)
+	g1 := Generation{ID: "gen_1_aaa", Command: "generate"}
+	g2 := Generation{ID: "gen_2_bbb", Command: "generate"}
+	require.NoError(t, Append(tagDir, g1))
+	require.NoError(t, Append(tagDir, g2))
+
+	gens, err := ListGenerations(tagDir)
+	require.NoError(t, err)
+	require.Len(t, gens, 2)
+	assert.Equal(t, "gen_2_bbb", gens[0].ID)
+	assert.Equal(t, "gen_1_aaa", gens[1].ID)
+}
+
+func TestUT_UndoEngine_UndoTwice_SecondReturnsNotFound(t *testing.T) {
+	tagDir, projectDir := setupUndoEnv(t)
+	target := filepath.Join(projectDir, "handler.go")
+	require.NoError(t, os.WriteFile(target, []byte("pkg"), 0o644))
+	hash, err := HashFile(target)
+	require.NoError(t, err)
+
+	gen := Generation{
+		ID: "gen_1_aaa", Command: "generate",
+		Files: []FileEntry{{Path: target, Action: ActionCreate, HashAfter: hash}},
+	}
+	require.NoError(t, Append(tagDir, gen))
+
+	require.NoError(t, Undo(tagDir, UndoOptions{Out: &bytes.Buffer{}}))
+	err = Undo(tagDir, UndoOptions{Out: &bytes.Buffer{}})
+	assert.Error(t, err, "second undo should fail because no generations remain")
+}

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"io"
@@ -15,6 +16,7 @@ import (
 
 	"github.com/kaikenlabs/tag/internal/convert"
 	"github.com/kaikenlabs/tag/internal/engine"
+	"github.com/kaikenlabs/tag/internal/history"
 	"github.com/kaikenlabs/tag/internal/scaffold"
 	"github.com/kaikenlabs/tag/internal/template"
 )
@@ -425,4 +427,149 @@ func TestIT_GenerateWithScaffoldVars(t *testing.T) {
 	require.NoError(t, err)
 
 	compareDirectories(t, expectedDir, workDir)
+}
+
+// --- History / Undo integration tests ---
+
+// setupTagDir creates the .tag/ directory inside workDir and returns its path.
+func setupTagDir(t *testing.T, workDir string) string {
+	t.Helper()
+	tagDir := filepath.Join(workDir, ".tag")
+	require.NoError(t, os.MkdirAll(tagDir, 0o755))
+	return tagDir
+}
+
+// runGenWithRecorder creates a generator with history recording, runs it, and
+// writes the manifest entry. Returns the tagDir path.
+func runGenWithRecorder(t *testing.T, tagDir, generatorDir, name string) {
+	t.Helper()
+	tmplEngine, err := template.NewEngine()
+	require.NoError(t, err)
+
+	rec := history.NewRecorder(tagDir)
+	gen, err := engine.NewGeneratorWithRecorder(tmplEngine, false, generatorDir, "", rec)
+	require.NoError(t, err)
+
+	require.NoError(t, gen.Generate(engine.Data{Name: name}))
+
+	histGen := rec.Build(filepath.Base(generatorDir), "generate")
+	require.NoError(t, history.Append(tagDir, histGen))
+}
+
+// TestIT_GenerateRecordsManifest verifies that a generation with a Recorder
+// writes a history manifest with the correct entry.
+func TestIT_GenerateRecordsManifest(t *testing.T) {
+	testdataDir := getTestdataDir()
+	generatorDir := filepath.Join(testdataDir, "generators", "service")
+
+	workDir := setupWorkDir(t, "")
+	tagDir := setupTagDir(t, workDir)
+	runGenWithRecorder(t, tagDir, generatorDir, "payment")
+
+	m, err := history.Load(tagDir)
+	require.NoError(t, err)
+	require.Len(t, m.Generations, 1)
+
+	g := m.Generations[0]
+	assert.Equal(t, "service", g.Template)
+	assert.NotEmpty(t, g.ID)
+	require.Len(t, g.Files, 1)
+	assert.Equal(t, history.ActionCreate, g.Files[0].Action)
+	assert.NotEmpty(t, g.Files[0].HashAfter)
+}
+
+// TestIT_UndoCreate_DeletesFile verifies that undoing a "create" generation
+// removes the created file from disk.
+func TestIT_UndoCreate_DeletesFile(t *testing.T) {
+	testdataDir := getTestdataDir()
+	generatorDir := filepath.Join(testdataDir, "generators", "service")
+
+	workDir := setupWorkDir(t, "")
+	tagDir := setupTagDir(t, workDir)
+	runGenWithRecorder(t, tagDir, generatorDir, "payment")
+
+	createdPath := filepath.Join(workDir, "app", "service", "payment.go")
+	require.FileExists(t, createdPath, "file should exist after generation")
+
+	var out bytes.Buffer
+	require.NoError(t, history.Undo(tagDir, history.UndoOptions{Out: &out}))
+
+	assert.NoFileExists(t, createdPath, "file should be deleted after undo")
+	assert.Contains(t, out.String(), "1 file(s) reverted")
+}
+
+// TestIT_UndoInject_RestoresFile verifies that undoing an inject generation
+// restores the target file to its pre-injection content.
+func TestIT_UndoInject_RestoresFile(t *testing.T) {
+	testdataDir := getTestdataDir()
+	generatorDir := filepath.Join(testdataDir, "generators", "inject-after")
+	preExistingDir := filepath.Join(testdataDir, "pre-existing", "inject-after")
+
+	workDir := setupWorkDir(t, preExistingDir)
+	tagDir := setupTagDir(t, workDir)
+
+	targetPath := filepath.Join(workDir, "app", "router.go")
+	originalContent, err := os.ReadFile(targetPath)
+	require.NoError(t, err)
+
+	runGenWithRecorder(t, tagDir, generatorDir, "users")
+
+	afterContent, err := os.ReadFile(targetPath)
+	require.NoError(t, err)
+	assert.NotEqual(t, string(originalContent), string(afterContent), "file should differ after inject")
+
+	require.NoError(t, history.Undo(tagDir, history.UndoOptions{}))
+
+	restoredContent, err := os.ReadFile(targetPath)
+	require.NoError(t, err)
+	assert.Equal(t, string(originalContent), string(restoredContent), "file should be restored after undo")
+}
+
+// TestIT_UndoConflict_ErrorWithoutForce verifies that undo refuses to overwrite
+// a file modified after generation.
+func TestIT_UndoConflict_ErrorWithoutForce(t *testing.T) {
+	testdataDir := getTestdataDir()
+	generatorDir := filepath.Join(testdataDir, "generators", "inject-after")
+	preExistingDir := filepath.Join(testdataDir, "pre-existing", "inject-after")
+
+	workDir := setupWorkDir(t, preExistingDir)
+	tagDir := setupTagDir(t, workDir)
+	runGenWithRecorder(t, tagDir, generatorDir, "users")
+
+	// Simulate post-generation edit.
+	targetPath := filepath.Join(workDir, "app", "router.go")
+	require.NoError(t, os.WriteFile(targetPath, []byte("// manually edited\n"), 0o644))
+
+	err := history.Undo(tagDir, history.UndoOptions{})
+	var conflictErr *history.ConflictError
+	require.ErrorAs(t, err, &conflictErr)
+	assert.NotEmpty(t, conflictErr.Paths)
+}
+
+// TestIT_UndoConflict_ForceOverrides verifies that --force allows undo to proceed
+// even when a file was modified after generation.
+func TestIT_UndoConflict_ForceOverrides(t *testing.T) {
+	testdataDir := getTestdataDir()
+	generatorDir := filepath.Join(testdataDir, "generators", "inject-after")
+	preExistingDir := filepath.Join(testdataDir, "pre-existing", "inject-after")
+
+	workDir := setupWorkDir(t, preExistingDir)
+	tagDir := setupTagDir(t, workDir)
+
+	targetPath := filepath.Join(workDir, "app", "router.go")
+	originalContent, err := os.ReadFile(targetPath)
+	require.NoError(t, err)
+
+	runGenWithRecorder(t, tagDir, generatorDir, "users")
+
+	// Simulate post-generation edit.
+	require.NoError(t, os.WriteFile(targetPath, []byte("// manually edited\n"), 0o644))
+
+	var out bytes.Buffer
+	require.NoError(t, history.Undo(tagDir, history.UndoOptions{Force: true, Out: &out}))
+	assert.Contains(t, out.String(), "1 file(s) reverted")
+
+	restoredContent, err := os.ReadFile(targetPath)
+	require.NoError(t, err)
+	assert.Equal(t, string(originalContent), string(restoredContent), "force undo should restore to pre-generation state")
 }

--- a/internal/scaffold/output.go
+++ b/internal/scaffold/output.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/format/gitignore"
 
 	"github.com/kaikenlabs/tag/internal/fileutil"
+	"github.com/kaikenlabs/tag/internal/history"
 	"github.com/kaikenlabs/tag/internal/template"
 	"github.com/kaikenlabs/tag/internal/types"
 )
@@ -31,6 +32,13 @@ type DefaultOutputWriter struct {
 	allowRecursiveRender bool
 	derivedVarNames      map[string]bool
 	out                  io.Writer
+	recorder             *history.Recorder // optional; nil = no recording
+}
+
+// SetRecorder attaches a history recorder to this writer. When set, every
+// file written during scaffold is recorded as a "create" entry.
+func (w *DefaultOutputWriter) SetRecorder(r *history.Recorder) {
+	w.recorder = r
 }
 
 // NewOutputWriter creates a new output writer.
@@ -228,11 +236,19 @@ func (w *DefaultOutputWriter) processFile(srcPath, destPath string, ctx template
 			copy(fullContent, sample)
 			copy(fullContent[len(sample):], remainder)
 		}
-		return w.processTemplate(srcPath, destPath, fullContent, ctx, mode)
+		if err := w.processTemplate(srcPath, destPath, fullContent, ctx, mode); err != nil {
+			return err
+		}
+		w.recordCreate(destPath)
+		return nil
 	}
 
 	// Binary file: stream to destination using io.Copy
-	return streamBinaryFile(f, destPath, sample, mode)
+	if err := streamBinaryFile(f, destPath, sample, mode); err != nil {
+		return err
+	}
+	w.recordCreate(destPath)
+	return nil
 }
 
 // streamBinaryFile writes a binary file to destPath by first writing the already-read
@@ -327,6 +343,19 @@ func (w *DefaultOutputWriter) processTemplate(srcPath, destPath string, content 
 	}
 
 	return nil
+}
+
+// recordCreate records a newly written file with the history recorder, if set.
+func (w *DefaultOutputWriter) recordCreate(destPath string) {
+	if w.recorder == nil {
+		return
+	}
+	hashAfter, err := history.HashFile(destPath)
+	if err != nil {
+		fmt.Fprintf(w.out, "Warning: could not hash %s for history: %v\n", destPath, err)
+		return
+	}
+	w.recorder.RecordCreate(destPath, hashAfter)
 }
 
 // buildTemplateContext builds the template context from variables.

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/charmbracelet/glamour"
 
+	"github.com/kaikenlabs/tag/internal/history"
 	"github.com/kaikenlabs/tag/internal/hooks"
 	"github.com/kaikenlabs/tag/internal/replay"
 	"github.com/kaikenlabs/tag/internal/schema"
@@ -34,8 +35,18 @@ type Scaffold struct {
 	writer     OutputWriter
 	engine     template.TemplateRenderer
 	prompter   Prompter
-	hookRunner hooks.HookRunner // Executes pre/post scaffold hooks
-	output     io.Writer        // Destination for user-facing messages (default: os.Stdout)
+	hookRunner hooks.HookRunner  // Executes pre/post scaffold hooks
+	output     io.Writer         // Destination for user-facing messages (default: os.Stdout)
+	recorder   *history.Recorder // Optional history recorder; nil = no recording
+}
+
+// SetRecorder attaches a history recorder. When set, file operations during
+// scaffolding are recorded and a manifest entry is written on success.
+func (s *Scaffold) SetRecorder(r *history.Recorder) {
+	s.recorder = r
+	if w, ok := s.writer.(*DefaultOutputWriter); ok {
+		w.SetRecorder(r)
+	}
 }
 
 // NewScaffold creates a new scaffold instance with default dependencies.
@@ -295,6 +306,15 @@ func (s *Scaffold) executeScaffold(ctx *runContext) error {
 	// Save replay data and display summary
 	saveReplayData(s.output, ctx.opts, ctx.config, ctx.vars)
 	s.displaySummary(ctx.outputDir, ctx.templateDirAbs, ctx.vars, ctx.opts)
+
+	// Write history manifest entry to the output project's .tag/ directory.
+	if s.recorder != nil {
+		gen := s.recorder.Build(ctx.opts.TemplateName, "scaffold")
+		tagDir := filepath.Join(ctx.projectRoot, types.TemplatesDir)
+		if appendErr := history.Append(tagDir, gen); appendErr != nil {
+			fmt.Fprintf(s.output, "Warning: could not write history manifest: %v\n", appendErr)
+		}
+	}
 
 	success = true
 	return nil

--- a/internal/types/constants.go
+++ b/internal/types/constants.go
@@ -34,6 +34,12 @@ const (
 
 	// TagIgnoreFile is the name of the gitignore-style exclusion file for templates.
 	TagIgnoreFile = ".tagignore"
+
+	// HistoryFile is the filename for the generation history manifest.
+	HistoryFile = "history.json"
+
+	// HistoryBackupsDir is the subdirectory inside TemplatesDir where backups are stored.
+	HistoryBackupsDir = "history/backups"
 )
 
 // InjectClause represents where to inject content relative to a marker.

--- a/main.go
+++ b/main.go
@@ -50,6 +50,7 @@ func main() {
 			commands.LibCommand(),
 			commands.CacheCommand(),
 			commands.ConvertCommand(),
+			commands.UndoCommand(),
 			commands.VersionCommand(Version),
 			commands.UpdateCommand(Version),
 		},


### PR DESCRIPTION
## Summary

- Adds `internal/history/` package: manifest management, SHA256 file hashing, generation recorder, and undo engine
- Wires history recording into `tag generate` (single generator + bundles) and `tag scaffold` pipelines via `RecordingFileWriter` decorator pattern
- Adds `tag undo` command with `--list`, `--id`, `--yes`, `--force`, and `--partial` flags for safe generation reverting with conflict detection

## Changes

### New: `internal/history/`
- `types.go` — `Manifest`, `Generation`, `FileEntry` types with JSON serialization
- `hash.go` — SHA256 file hashing (`HashFile`, `HashBytes`)
- `manifest.go` — atomic manifest read/write/append/remove with `.tmp` rename pattern
- `recorder.go` — `Recorder` accumulates file operations; `RecordingFileWriter` wraps `writer.FileWriter` to intercept create/inject/append with first-touch hash semantics
- `undo.go` — `Undo` engine with conflict detection, force/partial modes, backup restore, and empty-directory cleanup

### Modified: Pipelines
- `engine/engine.go` — `NewGeneratorWithRecorder` creates a generator with history tracking
- `scaffold/output.go` + `scaffold/scaffold.go` — recorder attached via `SetRecorder`; manifest written to output project's `.tag/`
- `commands/generate.go` — recorder created per invocation; bundle uses shared recorder for first-touch semantics

### New: `commands/undo.go` + `commands/undo_test.go`
- Full `tag undo` command implementation with confirmation prompt, preview, and conflict display

### Tests
- 5 new integration tests: `TestIT_GenerateRecordsManifest`, `TestIT_UndoCreate_DeletesFile`, `TestIT_UndoInject_RestoresFile`, `TestIT_UndoConflict_ErrorWithoutForce`, `TestIT_UndoConflict_ForceOverrides`
- Unit tests for all history package functions and undo command

### Docs
- `.skill/SKILL.md` — added `tag undo` to CLI Quick Reference
- `.skill/reference.md` — added Generation History & Undo section
- `docs/commands/undo.md` — full command reference

### Code Review Fixes (from `/p:go-code-review`)
- **C1**: `revertFile` now uses `os.Stat` to distinguish `ErrNotExist` from real I/O errors instead of blindly treating any `HashFile` error as "file already gone"
- **C2**: `runUndo` always passes the resolved generation ID to `history.Undo`, eliminating a TOCTOU window in the default (no `--id`) case
- **S1**: `manifestPath` and `BackupDir()` now use `types.HistoryFile` / `types.HistoryBackupsDir` constants instead of hardcoded strings
- **S2**: Hardcoded `0o755` in `revertFile` replaced with `types.DirMode`
- **N1**: `Build()` sorts `FileEntry` slice by path for deterministic manifest output
- **N3**: `isTerminal()` now checks `os.Stdin` instead of `os.Stdout`

## Test plan

- [x] All unit tests pass (`go test $(go list ./... | grep -v integration)`)
- [x] New integration tests pass: `TestIT_GenerateRecordsManifest`, `TestIT_UndoCreate_DeletesFile`, `TestIT_UndoInject_RestoresFile`, `TestIT_UndoConflict_ErrorWithoutForce`, `TestIT_UndoConflict_ForceOverrides`
- [x] `make lint` clean (10 pre-existing gosec false positives, none in new code)

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)