### PR TITLE
feat: bundle and generator prerequisites (requires field)

### DIFF
--- a/.skill/SKILL.md
+++ b/.skill/SKILL.md
@@ -117,6 +117,32 @@ Bundles run multiple generators sequentially. Stored as JSON in `.tag/_bundles/`
 }
 ```
 
+### Bundle Prerequisites
+
+Bundles and generators can declare `requires` — a list of `.tagconfig.json` variable names that must be present and truthy. If unmet, `tag generate` aborts with an error listing the missing variables.
+
+```json
+{
+  "name": "crud",
+  "requires": ["use_db"],
+  "generators": [
+    { "name": "model" },
+    { "name": "repository" }
+  ]
+}
+```
+
+For generators, add `requires` in the generator's `tag.template.json`:
+
+```json
+{
+  "requires": ["use_docker"],
+  "vars": { "port": 8080 }
+}
+```
+
+`tag generate list` hides generators/bundles with unmet requirements by default. Use `--all` to show everything.
+
 Generators and bundles are **auto-resolved** — no `--bundle` flag needed.
 
 ### Self-Contained Bundles
@@ -159,7 +185,7 @@ my-project/
 |---------|-------------|
 | `tag scaffold [template] [name]` | Create project (no args = picker). Alias: `tag s` |
 | `tag generate <gen-or-bundle> <name>` | Run generator or bundle. Alias: `tag g` |
-| `tag generate list` | List generators and bundles. Alias: `tag g list` |
+| `tag generate list [--all]` | List generators and bundles. Alias: `tag g list` |
 | `tag template init` | Initialize `.tag/` structure |
 | `tag template new generator <name>` | Create generator (`--in-bundle`, `--lib`) |
 | `tag template new bundle <name>` | Create bundle (`--self-contained`, `--lib`) |
@@ -189,6 +215,7 @@ my-project/
 | `-B` / `--in-bundle` | template new generator | Create inside bundle |
 | `-s` / `--self-contained` | template new bundle | Self-contained bundle |
 | `--dry-run` / `-d` | scaffold, generate, convert | Preview without writing |
+| `--all` | generate list, template list | Show all generators/bundles, including those with unmet requirements |
 | `--on-existing` | generate | Existing file policy: `fail` (default), `skip`, `overwrite` |
 | `-v` / `--verbose` | generate | Print per-file operation details in summary |
 | `--force` | scaffold | Overwrite existing output |

--- a/.skill/recipes.md
+++ b/.skill/recipes.md
@@ -98,10 +98,11 @@ desc: Inject route registration
 	r.Get("/{{ name | kebab | plural }}", {{ name | camel }}Handler.Get)
 ```
 
-**Bundle** — `.tag/_bundles/resource.json`:
+**Bundle** — `.tag/_bundles/resource/resource.json`:
 ```json
 {
   "name": "resource",
+  "requires": ["use_db"],
   "generators": [
     { "name": "model" },
     { "name": "repository" },
@@ -110,6 +111,8 @@ desc: Inject route registration
   ]
 }
 ```
+
+The `requires` field ensures this bundle only runs when the project's `.tagconfig.json` has `"use_db": true`. Without it, `tag generate list` hides the bundle and `tag generate resource product` aborts with a clear error.
 
 **Usage**: `tag generate resource product` creates all 4 files.
 

--- a/.skill/reference.md
+++ b/.skill/reference.md
@@ -339,6 +339,42 @@ tag cache clear                        # Clear expired entries
 tag cache clear --all                  # Clear entire cache
 ```
 
+### Bundle Prerequisites
+
+Bundles and generators can declare a `requires` field — an array of `.tagconfig.json` variable names that must be present and truthy for the generator/bundle to run.
+
+**In a bundle manifest** (`.tag/_bundles/<name>/<name>.json`):
+
+```json
+{
+  "name": "crud",
+  "requires": ["use_db"],
+  "generators": [
+    { "name": "model" },
+    { "name": "repository" }
+  ]
+}
+```
+
+**In a generator config** (`tag.template.json` inside the generator directory):
+
+```json
+{
+  "requires": ["use_docker"],
+  "vars": { "port": 8080 }
+}
+```
+
+When `tag generate` is invoked and requirements are unmet, it aborts with a message listing each unmet variable and whether it is "not set" or "currently disabled":
+
+```
+generator "service" requires the following variables to be enabled:
+  - use_db (not set in .tagconfig.json)
+  hint: re-scaffold with the required variables enabled to use this generator
+```
+
+`tag generate list` and `tag template list` hide items with unmet requirements by default. Use `--all` to show everything. Items with requirements display them as `[requires: x, y]` in the list output.
+
 ### Code Generation Flags
 
 | Flag | Description |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,7 @@ main.go                         CLI entry point (urfave/cli/v2)
     │       ├── generate.go         - Code generation command + execution
     │       ├── generate_list.go    - Generator/bundle discovery and display
     │       ├── generate_resolve.go - Generator/bundle path resolution + auto-resolve
+    │       ├── prereq.go           - Prerequisite checking (requires field)
     │       ├── lint.go              - Template linting command
     │       ├── scaffold.go         - Project scaffolding + library picker
     │       ├── convert.go          - Cookiecutter conversion command

--- a/docs/commands/generate.md
+++ b/docs/commands/generate.md
@@ -58,6 +58,7 @@ When a project was scaffolded from a template, the scaffold-time variables (e.g.
 | `--on-existing <policy>` | | How to handle create-action files that already exist: `fail` (default), `skip`, `overwrite` |
 | `--no-hooks` | | Skip execution of pre and post hooks |
 | `--dry-run` | `-d` | Preview output without writing files |
+| `--all` | | (`list` subcommand only) Show all generators/bundles, including those with unmet requirements |
 
 ## Global Flags
 
@@ -75,11 +76,14 @@ List all available generators and bundles for the current project.
 ```bash
 tag generate list
 tag generate ls    # alias
+tag generate list --all   # include generators/bundles with unmet requirements
 ```
 
 This is equivalent to `tag template list` — both show the same output.
 
-Output shows generators grouped by source (template library vs local project) and bundles. Each generator's description is read from its `tag.template.json` file (if present).
+By default, generators and bundles whose `requires` prerequisites are not met by the current `.tagconfig.json` variables are hidden. Pass `--all` to show everything.
+
+Output shows generators grouped by source (template library vs local project) and bundles. Each generator's description is read from its `tag.template.json` file (if present). Generators or bundles with prerequisites display them as `[requires: x, y]` after the description.
 
 Example output:
 ```
@@ -233,6 +237,20 @@ func New{{ n.pascal_case }}Handler() *{{ n.pascal_case }}Handler {
 }
 ```
 
+Bundles support an optional `requires` field listing `.tagconfig.json` variable names that must be truthy for the bundle to run:
+
+```json
+{
+  "requires": ["use_db"],
+  "generators": [
+    { "name": "model" },
+    { "name": "repository" }
+  ]
+}
+```
+
+Individual generators can also declare `requires` in their `tag.template.json`. See [Prerequisites](#prerequisites) below.
+
 ## Configuration
 
 Generator behavior is configured via `.tagconfig.json` in your project root. This file is created automatically by `tag template init` or `tag scaffold`.
@@ -380,6 +398,40 @@ notes: "Remember to register the handler in routes.go"
 ---
 ```
 
+## Prerequisites
+
+Generators and bundles can declare prerequisites via the `requires` field — an array of variable names that must exist and be truthy in the project's `.tagconfig.json`.
+
+**Generator prerequisites** are declared in the generator's `tag.template.json`:
+
+```json
+{
+  "requires": ["use_docker"],
+  "vars": { "port": 8080 }
+}
+```
+
+**Bundle prerequisites** are declared in the bundle manifest (`<name>.json`):
+
+```json
+{
+  "requires": ["use_db"],
+  "generators": [{ "name": "model" }, { "name": "repository" }]
+}
+```
+
+When `tag generate` encounters unmet requirements, it aborts with a message listing each missing or disabled variable:
+
+```
+bundle "crud" requires the following variables to be enabled:
+  - use_db (not set in .tagconfig.json)
+  hint: re-scaffold with the required variables enabled to use this bundle
+```
+
+A variable is considered "truthy" if it is a non-empty string, `true`, or a non-zero number. `false`, `0`, `""`, and absent variables are all considered unmet.
+
+**Listing behavior**: `tag generate list` hides generators and bundles with unmet requirements by default. Use `--all` to include them. Items with prerequisites show `[requires: x, y]` after their description.
+
 ## Error Handling
 
 | Error | Cause | Solution |
@@ -388,6 +440,7 @@ notes: "Remember to register the handler in routes.go"
 | "generator not found in .tag" | Generator not found locally (no library template configured) | Create the generator in `.tag/` |
 | "template not found in library" | `.tagconfig.json` references a template that isn't installed | Run `tag lib add <ref>` to install the template |
 | "template version mismatch" | Library template version differs from scaffold-time version | Consider re-scaffolding or running `tag lib update <name>` |
+| "<kind> \"name\" requires the following variables to be enabled" | Prerequisites in `requires` not met by `.tagconfig.json` | Re-scaffold with the required variables enabled, or set them manually in `.tagconfig.json` |
 | "cannot open bundle file" | Bundle file not found | Verify bundle exists in `_bundles/` |
 | "hook failed" | Pre/post hook returned error | Check hook command and permissions |
 | user quit (exit code 1) | User pressed `q` during `--dry-run` interactive review | Normal exit — no files were written |

--- a/internal/commands/generate.go
+++ b/internal/commands/generate.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kaikenlabs/tag/internal/history"
 	"github.com/kaikenlabs/tag/internal/hooks"
 	"github.com/kaikenlabs/tag/internal/template"
+	"github.com/kaikenlabs/tag/internal/tmplconfig"
 	"github.com/kaikenlabs/tag/internal/types"
 	"github.com/kaikenlabs/tag/internal/types/flags"
 	"github.com/kaikenlabs/tag/internal/writer"
@@ -224,6 +225,15 @@ func generateBundle(c *cli.Context, cfg *config.Config, fac generatorFactories, 
 		return app.Errorf("cannot decode bundle file: %w", err)
 	}
 
+	// Check bundle prerequisites before running any generators.
+	vars := make(map[string]any)
+	if cfg.Variables != nil {
+		vars = cfg.Variables
+	}
+	if reqErr := checkRequirements(generatorName, "bundle", bundle.Requires, vars); reqErr != nil {
+		return reqErr
+	}
+
 	tmplEngine, err := template.NewEngine()
 	if err != nil {
 		return app.Errorf("cannot create template engine: %w", err)
@@ -283,6 +293,20 @@ func generateBundle(c *cli.Context, cfg *config.Config, fac generatorFactories, 
 }
 
 func generateTemplate(c *cli.Context, cfg *config.Config, fac generatorFactories, generatorName, targetName, dirPath, sharedPath string, onExisting engine.OnExistingPolicy) error {
+	// Check generator prerequisites from tag.template.json if present.
+	vars := make(map[string]any)
+	if cfg.Variables != nil {
+		vars = cfg.Variables
+	}
+	configPath := filepath.Join(dirPath, types.TemplateConfigFile)
+	if data, readErr := os.ReadFile(configPath); readErr == nil {
+		if tc, parseErr := tmplconfig.ParseTemplateConfig(data); parseErr == nil {
+			if reqErr := checkRequirements(generatorName, "generator", tc.Requires, vars); reqErr != nil {
+				return reqErr
+			}
+		}
+	}
+
 	slog.Info(chalk.Green("running generator"), "generator", generatorName, "target", targetName)
 	return generateWithHooks(c, cfg, generatorName, func(rec *history.Recorder) (engine.GenerateResult, error) {
 		gen, err := fac.newEngine(c.Bool(flags.DryRunFlag), dirPath, sharedPath, rec, c.App.Writer)

--- a/internal/commands/generate_list.go
+++ b/internal/commands/generate_list.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kaikenlabs/tag/internal/scaffold"
 	"github.com/kaikenlabs/tag/internal/template"
 	"github.com/kaikenlabs/tag/internal/types"
+	"github.com/kaikenlabs/tag/internal/types/flags"
 
 	"github.com/urfave/cli/v2"
 )
@@ -24,8 +25,14 @@ func generateListCommand(cfg *config.Config) *cli.Command {
 		Name:    "list",
 		Aliases: []string{"ls"},
 		Usage:   "List available generators and bundles",
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:  flags.AllFlag,
+				Usage: "Show all generators and bundles, including those with unmet requirements",
+			},
+		},
 		Action: func(c *cli.Context) error {
-			return generateList(cfg, os.Stdout)
+			return generateList(cfg, c.Bool(flags.AllFlag), os.Stdout)
 		},
 	}
 }
@@ -35,6 +42,7 @@ type generatorInfo struct {
 	Name        string
 	Description string
 	Source      string // "template" or "local"
+	Requires    []string
 }
 
 // generatorLists holds all collected generator/bundle data for a project.
@@ -70,12 +78,24 @@ func collectGeneratorLists(cfg *config.Config) generatorLists {
 	return lists
 }
 
-func generateList(cfg *config.Config, w io.Writer) error {
+func generateList(cfg *config.Config, showAll bool, w io.Writer) error {
 	if err := config.CheckConfig(cfg); err != nil {
 		return err
 	}
 
 	lists := collectGeneratorLists(cfg)
+
+	// Filter out generators/bundles with unmet requirements unless --all is set.
+	vars := make(map[string]any)
+	if cfg.Variables != nil {
+		vars = cfg.Variables
+	}
+	if !showAll {
+		lists.templateGens = filterByRequirements(lists.templateGens, vars)
+		lists.localGens = filterByRequirements(lists.localGens, vars)
+		lists.templateBundles = filterByRequirements(lists.templateBundles, vars)
+		lists.localBundles = filterByRequirements(lists.localBundles, vars)
+	}
 
 	// Check if there's anything to show
 	if len(lists.templateGens) == 0 && len(lists.localGens) == 0 && len(lists.templateBundles) == 0 && len(lists.localBundles) == 0 {
@@ -135,10 +155,14 @@ func generateList(cfg *config.Config, w io.Writer) error {
 }
 
 func printGeneratorLine(w io.Writer, g generatorInfo) {
+	reqSuffix := ""
+	if len(g.Requires) > 0 {
+		reqSuffix = " [requires: " + strings.Join(g.Requires, ", ") + "]"
+	}
 	if g.Description != "" {
-		fmt.Fprintf(w, "  %-20s %s\n", g.Name, g.Description)
+		fmt.Fprintf(w, "  %-20s %s%s\n", g.Name, g.Description, reqSuffix)
 	} else {
-		fmt.Fprintf(w, "  %s\n", g.Name)
+		fmt.Fprintf(w, "  %s%s\n", g.Name, reqSuffix)
 	}
 }
 
@@ -169,6 +193,7 @@ func scanDirEntries(dir string) []generatorInfo {
 		if readErr == nil {
 			if tc, parseErr := scaffold.ParseTemplateConfig(data); parseErr == nil {
 				info.Description = tc.Description
+				info.Requires = tc.Requires
 			}
 		}
 
@@ -206,13 +231,14 @@ func scanBundles(dir string) []generatorInfo {
 
 		info := generatorInfo{Name: name}
 
-		// Read description from bundle manifest (<name>/<name>.json).
+		// Read description and requires from bundle manifest (<name>/<name>.json).
 		manifestPath := filepath.Join(dir, name, name+types.BundleExtension)
 		data, readErr := os.ReadFile(manifestPath)
 		if readErr == nil {
 			var bundle engine.Bundle
 			if jsonErr := json.Unmarshal(data, &bundle); jsonErr == nil {
 				info.Description = bundle.Description
+				info.Requires = bundle.Requires
 			}
 		}
 
@@ -255,4 +281,16 @@ func readFrontmatterDesc(genDir string) string {
 	}
 
 	return ""
+}
+
+// filterByRequirements returns only generators/bundles whose requirements
+// are all met by the given variables. Items with no requirements pass through.
+func filterByRequirements(items []generatorInfo, vars map[string]any) []generatorInfo {
+	var filtered []generatorInfo
+	for _, item := range items {
+		if requirementsMet(item.Requires, vars) {
+			filtered = append(filtered, item)
+		}
+	}
+	return filtered
 }

--- a/internal/commands/generate_test.go
+++ b/internal/commands/generate_test.go
@@ -983,7 +983,7 @@ func TestUT_GenerateList_NoGenerators(t *testing.T) {
 	cfg := createTestConfig(t, tmpDir)
 
 	var buf bytes.Buffer
-	err := generateList(cfg, &buf)
+	err := generateList(cfg, true, &buf)
 
 	require.NoError(t, err)
 	assert.Contains(t, buf.String(), "No generators found.")
@@ -1001,7 +1001,7 @@ func TestUT_GenerateList_LocalGenerators(t *testing.T) {
 	cfg := createTestConfig(t, tmpDir)
 
 	var buf bytes.Buffer
-	err := generateList(cfg, &buf)
+	err := generateList(cfg, true, &buf)
 
 	require.NoError(t, err)
 	output := buf.String()
@@ -1022,7 +1022,7 @@ func TestUT_GenerateList_GeneratorWithDescription(t *testing.T) {
 
 	cfg := createTestConfig(t, tmpDir)
 
-	err := generateList(cfg, io.Discard)
+	err := generateList(cfg, true, io.Discard)
 
 	require.NoError(t, err)
 }
@@ -1038,7 +1038,7 @@ func TestUT_GenerateList_WithBundles(t *testing.T) {
 
 	cfg := createTestConfig(t, tmpDir)
 
-	err := generateList(cfg, io.Discard)
+	err := generateList(cfg, true, io.Discard)
 
 	require.NoError(t, err)
 }
@@ -1055,14 +1055,14 @@ func TestUT_GenerateList_BundleDescriptionShown(t *testing.T) {
 	cfg := createTestConfig(t, tmpDir)
 
 	var buf bytes.Buffer
-	err := generateList(cfg, &buf)
+	err := generateList(cfg, true, &buf)
 
 	require.NoError(t, err)
 	assert.Contains(t, buf.String(), "Scaffolds a full feature")
 }
 
 func TestUT_GenerateList_NoConfig(t *testing.T) {
-	err := generateList(nil, io.Discard)
+	err := generateList(nil, true, io.Discard)
 
 	require.Error(t, err)
 }
@@ -1167,7 +1167,7 @@ func TestUT_GenerateList_FrontmatterDescShown(t *testing.T) {
 	cfg := createTestConfig(t, tmpDir)
 
 	var buf bytes.Buffer
-	err := generateList(cfg, &buf)
+	err := generateList(cfg, true, &buf)
 
 	require.NoError(t, err)
 	output := buf.String()
@@ -1383,4 +1383,384 @@ func TestUT_PrintGenerateSummary_SummaryLineFormat(t *testing.T) {
 	var buf bytes.Buffer
 	printGenerateSummary(&buf, result, false)
 	assert.Equal(t, "Generated: 3 created, 1 skipped, 2 overwritten, 4 modified\n", buf.String())
+}
+
+// --- Prerequisites tests ---
+
+func TestUT_GenerateBundle_RequirementsMet(t *testing.T) {
+	tmpDir := setupTempDir(t)
+
+	templateContent := `---
+to: output/{{ .Name }}.txt
+---
+Hello {{ .Name }}`
+
+	createGenerator(t, tmpDir, "hello", templateContent)
+	createSharedDir(t, tmpDir)
+
+	bundleJSON := `{"name":"mybundle","requires":["use_postgres"],"generators":[{"name":"hello"}]}`
+	createBundle(t, tmpDir, "mybundle", bundleJSON)
+
+	cfg := createTestConfig(t, tmpDir)
+	cfg.Variables = map[string]any{
+		"use_postgres": true,
+	}
+
+	ctx := createTestCLIContext(t, []string{"mybundle", "world"}, map[string]any{
+		flags.PathFlag:       tmpDir,
+		flags.SharedPathFlag: "_shared",
+		flags.BundlePathFlag: "_bundles",
+	})
+
+	var generateCalls int
+	fac := defaultGeneratorFactories()
+	fac.newBundleEngine = func(tmplEngine *template.Engine, dryRun bool, dirPath string, sharedPath string, rec *history.Recorder, _ io.Writer) (engine.Generator, error) {
+		mock := &mockGenerator{
+			GenerateFunc: func(data engine.Data) (engine.GenerateResult, error) {
+				generateCalls++
+				return engine.GenerateResult{}, nil
+			},
+		}
+		return mock, nil
+	}
+
+	err := generateAction(ctx, cfg, fac)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, generateCalls, "generator should run when requirements are met")
+}
+
+func TestUT_GenerateBundle_RequirementsUnmet(t *testing.T) {
+	tmpDir := setupTempDir(t)
+
+	templateContent := `---
+to: output/{{ .Name }}.txt
+---
+Hello {{ .Name }}`
+
+	createGenerator(t, tmpDir, "hello", templateContent)
+	createSharedDir(t, tmpDir)
+
+	bundleJSON := `{"name":"mybundle","requires":["use_postgres"],"generators":[{"name":"hello"}]}`
+	createBundle(t, tmpDir, "mybundle", bundleJSON)
+
+	cfg := createTestConfig(t, tmpDir)
+	cfg.Variables = map[string]any{
+		"use_postgres": false,
+	}
+
+	ctx := createTestCLIContext(t, []string{"mybundle", "world"}, map[string]any{
+		flags.PathFlag:       tmpDir,
+		flags.SharedPathFlag: "_shared",
+		flags.BundlePathFlag: "_bundles",
+	})
+
+	err := generateAction(ctx, cfg, defaultGeneratorFactories())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "use_postgres")
+}
+
+func TestUT_GenerateBundle_RequirementsPartiallyMet(t *testing.T) {
+	tmpDir := setupTempDir(t)
+
+	templateContent := `---
+to: output/{{ .Name }}.txt
+---
+Hello {{ .Name }}`
+
+	createGenerator(t, tmpDir, "hello", templateContent)
+	createSharedDir(t, tmpDir)
+
+	bundleJSON := `{"name":"mybundle","requires":["use_postgres","use_amqp"],"generators":[{"name":"hello"}]}`
+	createBundle(t, tmpDir, "mybundle", bundleJSON)
+
+	cfg := createTestConfig(t, tmpDir)
+	cfg.Variables = map[string]any{
+		"use_postgres": true,
+		"use_amqp":     false,
+	}
+
+	ctx := createTestCLIContext(t, []string{"mybundle", "world"}, map[string]any{
+		flags.PathFlag:       tmpDir,
+		flags.SharedPathFlag: "_shared",
+		flags.BundlePathFlag: "_bundles",
+	})
+
+	err := generateAction(ctx, cfg, defaultGeneratorFactories())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "use_amqp")
+	assert.NotContains(t, err.Error(), "use_postgres")
+}
+
+func TestUT_GenerateBundle_NoRequirements_BackwardCompat(t *testing.T) {
+	tmpDir := setupTempDir(t)
+
+	templateContent := `---
+to: output/{{ .Name }}.txt
+---
+Hello {{ .Name }}`
+
+	createGenerator(t, tmpDir, "hello", templateContent)
+	createSharedDir(t, tmpDir)
+
+	// Bundle without "requires" field — should work unchanged.
+	bundleJSON := `{"name":"mybundle","generators":[{"name":"hello"}]}`
+	createBundle(t, tmpDir, "mybundle", bundleJSON)
+
+	cfg := createTestConfig(t, tmpDir)
+	cfg.Variables = map[string]any{
+		"use_postgres": false,
+	}
+
+	ctx := createTestCLIContext(t, []string{"mybundle", "world"}, map[string]any{
+		flags.PathFlag:       tmpDir,
+		flags.SharedPathFlag: "_shared",
+		flags.BundlePathFlag: "_bundles",
+	})
+
+	var generateCalls int
+	fac := defaultGeneratorFactories()
+	fac.newBundleEngine = func(tmplEngine *template.Engine, dryRun bool, dirPath string, sharedPath string, rec *history.Recorder, _ io.Writer) (engine.Generator, error) {
+		mock := &mockGenerator{
+			GenerateFunc: func(data engine.Data) (engine.GenerateResult, error) {
+				generateCalls++
+				return engine.GenerateResult{}, nil
+			},
+		}
+		return mock, nil
+	}
+
+	err := generateAction(ctx, cfg, fac)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, generateCalls, "generator should run when no requirements are specified")
+}
+
+func TestUT_GenerateBundle_RequirementsMissing_NoConfig(t *testing.T) {
+	tmpDir := setupTempDir(t)
+
+	templateContent := `---
+to: output/{{ .Name }}.txt
+---
+Hello {{ .Name }}`
+
+	createGenerator(t, tmpDir, "hello", templateContent)
+	createSharedDir(t, tmpDir)
+
+	bundleJSON := `{"name":"mybundle","requires":["use_postgres"],"generators":[{"name":"hello"}]}`
+	createBundle(t, tmpDir, "mybundle", bundleJSON)
+
+	cfg := createTestConfig(t, tmpDir)
+	// No variables set at all.
+
+	ctx := createTestCLIContext(t, []string{"mybundle", "world"}, map[string]any{
+		flags.PathFlag:       tmpDir,
+		flags.SharedPathFlag: "_shared",
+		flags.BundlePathFlag: "_bundles",
+	})
+
+	err := generateAction(ctx, cfg, defaultGeneratorFactories())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "use_postgres")
+	assert.Contains(t, err.Error(), "not set")
+}
+
+func TestUT_GenerateList_FiltersUnmetRequirements(t *testing.T) {
+	tmpDir := setupTempDir(t)
+
+	createGenerator(t, tmpDir, "domain", `---
+to: output/{{ .Name }}.txt
+desc: Domain generator
+---
+Hello`)
+
+	// Create a bundle with requirements
+	bundleJSON := `{"name":"crud","description":"CRUD bundle","requires":["use_postgres"],"generators":[{"name":"domain"}]}`
+	createBundle(t, tmpDir, "crud", bundleJSON)
+
+	// Create a bundle without requirements
+	bundleJSON2 := `{"name":"bdd","description":"BDD bundle","generators":[{"name":"domain"}]}`
+	createBundle(t, tmpDir, "bdd", bundleJSON2)
+
+	cfg := createTestConfig(t, tmpDir)
+	cfg.Variables = map[string]any{
+		"use_postgres": false,
+	}
+
+	var buf bytes.Buffer
+	err := generateList(cfg, false, &buf)
+
+	require.NoError(t, err)
+	output := buf.String()
+	assert.NotContains(t, output, "crud", "bundle with unmet requirements should be filtered out")
+	assert.Contains(t, output, "bdd", "bundle without requirements should be shown")
+}
+
+func TestUT_GenerateList_AllFlagShowsEverything(t *testing.T) {
+	tmpDir := setupTempDir(t)
+
+	createGenerator(t, tmpDir, "domain", `---
+to: output/{{ .Name }}.txt
+desc: Domain generator
+---
+Hello`)
+
+	bundleJSON := `{"name":"crud","description":"CRUD bundle","requires":["use_postgres"],"generators":[{"name":"domain"}]}`
+	createBundle(t, tmpDir, "crud", bundleJSON)
+
+	cfg := createTestConfig(t, tmpDir)
+	cfg.Variables = map[string]any{
+		"use_postgres": false,
+	}
+
+	var buf bytes.Buffer
+	err := generateList(cfg, true, &buf)
+
+	require.NoError(t, err)
+	output := buf.String()
+	assert.Contains(t, output, "crud", "bundle should be shown with --all flag even if requirements unmet")
+	assert.Contains(t, output, "[requires: use_postgres]", "requirements should be displayed")
+}
+
+func TestUT_GenerateList_RequirementsShownInOutput(t *testing.T) {
+	tmpDir := setupTempDir(t)
+
+	createGenerator(t, tmpDir, "domain", `---
+to: output/{{ .Name }}.txt
+---
+Hello`)
+
+	bundleJSON := `{"name":"crud","description":"CRUD bundle","requires":["use_postgres","use_amqp"],"generators":[{"name":"domain"}]}`
+	createBundle(t, tmpDir, "crud", bundleJSON)
+
+	cfg := createTestConfig(t, tmpDir)
+	cfg.Variables = map[string]any{
+		"use_postgres": true,
+		"use_amqp":     true,
+	}
+
+	var buf bytes.Buffer
+	err := generateList(cfg, false, &buf)
+
+	require.NoError(t, err)
+	output := buf.String()
+	assert.Contains(t, output, "[requires: use_postgres, use_amqp]")
+}
+
+func TestUT_GenerateTemplate_RequirementsMet(t *testing.T) {
+	tmpDir := setupTempDir(t)
+
+	templateContent := `---
+to: output/{{ .Name }}.txt
+---
+Hello {{ .Name }}`
+
+	createGenerator(t, tmpDir, "postgres-adapter", templateContent)
+	createSharedDir(t, tmpDir)
+
+	// Write a tag.template.json with requires into the generator directory.
+	genConfigPath := filepath.Join(tmpDir, "postgres-adapter", "tag.template.json")
+	require.NoError(t, os.WriteFile(genConfigPath, []byte(`{"requires":["use_postgres"]}`), 0o644))
+
+	cfg := createTestConfig(t, tmpDir)
+	cfg.Variables = map[string]any{
+		"use_postgres": true,
+	}
+
+	ctx := createTestCLIContext(t, []string{"postgres-adapter", "orders"}, map[string]any{
+		flags.PathFlag:       tmpDir,
+		flags.SharedPathFlag: "_shared",
+	})
+
+	var generateCalls int
+	fac := defaultGeneratorFactories()
+	fac.newEngine = func(dryRun bool, dirPath string, sharedPath string, rec *history.Recorder, _ io.Writer) (engine.Generator, error) {
+		mock := &mockGenerator{
+			GenerateFunc: func(data engine.Data) (engine.GenerateResult, error) {
+				generateCalls++
+				return engine.GenerateResult{}, nil
+			},
+		}
+		return mock, nil
+	}
+
+	err := generateAction(ctx, cfg, fac)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, generateCalls, "generator should run when requirements are met")
+}
+
+func TestUT_GenerateTemplate_RequirementsUnmet(t *testing.T) {
+	tmpDir := setupTempDir(t)
+
+	templateContent := `---
+to: output/{{ .Name }}.txt
+---
+Hello {{ .Name }}`
+
+	createGenerator(t, tmpDir, "postgres-adapter", templateContent)
+	createSharedDir(t, tmpDir)
+
+	// Write a tag.template.json with requires into the generator directory.
+	genConfigPath := filepath.Join(tmpDir, "postgres-adapter", "tag.template.json")
+	require.NoError(t, os.WriteFile(genConfigPath, []byte(`{"requires":["use_postgres"]}`), 0o644))
+
+	cfg := createTestConfig(t, tmpDir)
+	cfg.Variables = map[string]any{
+		"use_postgres": false,
+	}
+
+	ctx := createTestCLIContext(t, []string{"postgres-adapter", "orders"}, map[string]any{
+		flags.PathFlag:       tmpDir,
+		flags.SharedPathFlag: "_shared",
+	})
+
+	err := generateAction(ctx, cfg, defaultGeneratorFactories())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "use_postgres")
+	assert.Contains(t, err.Error(), "generator")
+}
+
+func TestUT_GenerateTemplate_NoRequirements_BackwardCompat(t *testing.T) {
+	tmpDir := setupTempDir(t)
+
+	templateContent := `---
+to: output/{{ .Name }}.txt
+---
+Hello {{ .Name }}`
+
+	createGenerator(t, tmpDir, "hello", templateContent)
+	createSharedDir(t, tmpDir)
+
+	// Generator without tag.template.json — should work unchanged.
+	cfg := createTestConfig(t, tmpDir)
+	cfg.Variables = map[string]any{
+		"use_postgres": false,
+	}
+
+	ctx := createTestCLIContext(t, []string{"hello", "world"}, map[string]any{
+		flags.PathFlag:       tmpDir,
+		flags.SharedPathFlag: "_shared",
+	})
+
+	var generateCalls int
+	fac := defaultGeneratorFactories()
+	fac.newEngine = func(dryRun bool, dirPath string, sharedPath string, rec *history.Recorder, _ io.Writer) (engine.Generator, error) {
+		mock := &mockGenerator{
+			GenerateFunc: func(data engine.Data) (engine.GenerateResult, error) {
+				generateCalls++
+				return engine.GenerateResult{}, nil
+			},
+		}
+		return mock, nil
+	}
+
+	err := generateAction(ctx, cfg, fac)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, generateCalls, "generator should run when no tag.template.json exists")
 }

--- a/internal/commands/prereq.go
+++ b/internal/commands/prereq.go
@@ -1,0 +1,79 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/kaikenlabs/tag/pkg/app"
+)
+
+// isTruthy returns true if the value is considered "truthy" for prerequisite
+// checking. A value is truthy if it is non-nil, non-empty string, non-zero
+// number, or boolean true. JSON unmarshaling produces float64 for numbers.
+func isTruthy(v any) bool {
+	switch val := v.(type) {
+	case nil:
+		return false
+	case bool:
+		return val
+	case string:
+		return val != ""
+	case float64:
+		return val != 0
+	case int:
+		return val != 0
+	default:
+		// Unknown types (slices, maps, etc.) are truthy if non-nil.
+		return true
+	}
+}
+
+// requirementsMet returns true if all entries in requires are present and truthy
+// in vars. Returns true when requires is empty (no prerequisites).
+func requirementsMet(requires []string, vars map[string]any) bool {
+	for _, req := range requires {
+		val, ok := vars[req]
+		if !ok || !isTruthy(val) {
+			return false
+		}
+	}
+	return true
+}
+
+// checkRequirements verifies that all entries in requires are present and truthy
+// in vars. Returns an error listing all unmet requirements, or nil if all are met.
+func checkRequirements(name, kind string, requires []string, vars map[string]any) error {
+	if len(requires) == 0 {
+		return nil
+	}
+
+	var unmet []string
+	seen := make(map[string]struct{}, len(requires))
+	for _, req := range requires {
+		if _, dup := seen[req]; dup {
+			continue
+		}
+		seen[req] = struct{}{}
+
+		val, ok := vars[req]
+		if !ok || !isTruthy(val) {
+			unmet = append(unmet, req)
+		}
+	}
+
+	if len(unmet) == 0 {
+		return nil
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s %q requires the following variables to be enabled:\n", kind, name)
+	for _, u := range unmet {
+		if _, ok := vars[u]; !ok {
+			fmt.Fprintf(&b, "  - %s (not set in .tagconfig.json)\n", u)
+		} else {
+			fmt.Fprintf(&b, "  - %s (currently disabled)\n", u)
+		}
+	}
+	b.WriteString("  hint: re-scaffold with the required variables enabled to use this " + kind)
+	return app.Errorf("%s", b.String())
+}

--- a/internal/commands/prereq_test.go
+++ b/internal/commands/prereq_test.go
@@ -1,0 +1,141 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUT_IsTruthy(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    any
+		expected bool
+	}{
+		{"nil is falsy", nil, false},
+		{"true is truthy", true, true},
+		{"false is falsy", false, false},
+		{"non-empty string is truthy", "hello", true},
+		{"empty string is falsy", "", false},
+		{"whitespace string is truthy", "   ", true},
+		{"string zero is truthy", "0", true},
+		{"positive float64 is truthy", 1.5, true},
+		{"zero float64 is falsy", 0.0, false},
+		{"negative float64 is truthy", -1.0, true},
+		{"positive int is truthy", 1, true},
+		{"zero int is falsy", 0, false},
+		{"slice is truthy", []string{"a"}, true},
+		{"map is truthy", map[string]any{"a": 1}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isTruthy(tt.value))
+		})
+	}
+}
+
+func TestUT_CheckRequirements_AllMet(t *testing.T) {
+	vars := map[string]any{
+		"use_postgres": true,
+		"use_amqp":     true,
+	}
+	err := checkRequirements("mybundle", "bundle", []string{"use_postgres", "use_amqp"}, vars)
+	require.NoError(t, err)
+}
+
+func TestUT_CheckRequirements_OneUnmet(t *testing.T) {
+	vars := map[string]any{
+		"use_postgres": true,
+		"use_amqp":     false,
+	}
+	err := checkRequirements("mybundle", "bundle", []string{"use_postgres", "use_amqp"}, vars)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "use_amqp")
+	assert.NotContains(t, err.Error(), "use_postgres")
+}
+
+func TestUT_CheckRequirements_MultipleUnmet(t *testing.T) {
+	vars := map[string]any{
+		"use_postgres": false,
+		"use_amqp":     false,
+	}
+	err := checkRequirements("mybundle", "bundle", []string{"use_postgres", "use_amqp"}, vars)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "use_postgres")
+	assert.Contains(t, err.Error(), "use_amqp")
+}
+
+func TestUT_CheckRequirements_EmptyRequires(t *testing.T) {
+	err := checkRequirements("mybundle", "bundle", nil, nil)
+	require.NoError(t, err)
+
+	err = checkRequirements("mybundle", "bundle", []string{}, nil)
+	require.NoError(t, err)
+}
+
+func TestUT_CheckRequirements_NilVars(t *testing.T) {
+	err := checkRequirements("mybundle", "bundle", []string{"use_postgres"}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "use_postgres")
+	assert.Contains(t, err.Error(), "not set")
+}
+
+func TestUT_CheckRequirements_MissingVar(t *testing.T) {
+	vars := map[string]any{
+		"use_amqp": true,
+	}
+	err := checkRequirements("mybundle", "bundle", []string{"use_postgres"}, vars)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "use_postgres")
+	assert.Contains(t, err.Error(), "not set")
+}
+
+func TestUT_CheckRequirements_FalsyVarShowsDisabled(t *testing.T) {
+	vars := map[string]any{
+		"use_postgres": false,
+	}
+	err := checkRequirements("mybundle", "bundle", []string{"use_postgres"}, vars)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "currently disabled")
+}
+
+func TestUT_CheckRequirements_DuplicateRequires(t *testing.T) {
+	vars := map[string]any{
+		"use_postgres": false,
+	}
+	err := checkRequirements("mybundle", "bundle", []string{"use_postgres", "use_postgres"}, vars)
+	require.Error(t, err)
+	// Should only mention use_postgres once
+	errStr := err.Error()
+	first := indexOf(errStr, "use_postgres")
+	second := indexOf(errStr[first+len("use_postgres"):], "use_postgres")
+	assert.Equal(t, -1, second, "use_postgres should appear only once in error")
+}
+
+func TestUT_CheckRequirements_NonBooleanTruthyValues(t *testing.T) {
+	vars := map[string]any{
+		"module_path": "github.com/example/project",
+		"port":        float64(8080),
+	}
+	err := checkRequirements("mybundle", "bundle", []string{"module_path", "port"}, vars)
+	require.NoError(t, err)
+}
+
+func TestUT_CheckRequirements_ErrorContainsBundleName(t *testing.T) {
+	vars := map[string]any{}
+	err := checkRequirements("crud-context", "bundle", []string{"use_postgres"}, vars)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "crud-context")
+	assert.Contains(t, err.Error(), "bundle")
+}
+
+func indexOf(s, substr string) int {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/commands/template.go
+++ b/internal/commands/template.go
@@ -6,6 +6,7 @@ import (
 	"github.com/urfave/cli/v2"
 
 	"github.com/kaikenlabs/tag/internal/config"
+	"github.com/kaikenlabs/tag/internal/types/flags"
 )
 
 // TemplateCommand returns the parent command for template authoring operations.
@@ -40,8 +41,14 @@ func templateListCommand(cfg *config.Config) *cli.Command {
 		Name:    "list",
 		Aliases: []string{"ls"},
 		Usage:   "List available generators and bundles",
-		Action: func(_ *cli.Context) error {
-			return generateList(cfg, os.Stdout)
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:  flags.AllFlag,
+				Usage: "Show all generators and bundles, including those with unmet requirements",
+			},
+		},
+		Action: func(c *cli.Context) error {
+			return generateList(cfg, c.Bool(flags.AllFlag), os.Stdout)
 		},
 	}
 }

--- a/internal/engine/types.go
+++ b/internal/engine/types.go
@@ -92,5 +92,6 @@ type Bundle struct {
 	Name          string         `json:"name" yaml:"name"`
 	Description   string         `json:"description,omitempty" yaml:"description,omitempty"`
 	SelfContained bool           `json:"self_contained,omitempty" yaml:"self_contained,omitempty"`
+	Requires      []string       `json:"requires,omitempty" yaml:"requires,omitempty"`
 	Generators    []GeneratorRef `json:"generators" yaml:"generators"`
 }

--- a/internal/tmplconfig/types.go
+++ b/internal/tmplconfig/types.go
@@ -17,6 +17,9 @@ type TemplateConfig struct {
 	Vars       map[string]VariableDef `json:"-"` // Custom unmarshaling needed
 	RawVars    map[string]any         `json:"vars"`
 	Hooks      *types.HooksConfig     `json:"hooks,omitempty"`
+	// Requires lists template variable names that must be truthy in the project's
+	// .tagconfig.json for this generator to run. Used for prerequisite checking.
+	Requires []string `json:"requires,omitempty"`
 }
 
 // VariableType represents the type of a template variable.

--- a/internal/types/flags/flags.go
+++ b/internal/types/flags/flags.go
@@ -15,4 +15,5 @@ const (
 	NoHooksFlag       = "no-hooks"
 	UpdateLockFlag    = "update-lock"
 	IgnoreLockFlag    = "ignore-lock"
+	AllFlag           = "all"
 )


### PR DESCRIPTION
## Summary

- Add `requires []string` field to bundle manifests and generator `tag.template.json` configs
- When `tag generate` is invoked, check required variables against `.tagconfig.json` — abort with clear error if unmet
- `tag generate list` / `tag template list` now filter out items with unmet requirements by default
- Add `--all` flag to show all generators/bundles regardless of requirements
- Show `[requires: x, y]` in listing output

Closes #207

## Changes

### Core logic (`internal/commands/prereq.go`)
- `isTruthy(v any) bool` — truthiness check for JSON-deserialized values
- `requirementsMet(requires, vars) bool` — fast check for list filtering
- `checkRequirements(name, kind, requires, vars) error` — detailed error with per-variable diagnostics

### Type changes
- `engine.Bundle` — added `Requires []string` field
- `tmplconfig.TemplateConfig` — added `Requires []string` field
- `flags.AllFlag` — new `--all` flag constant

### Command integration
- `generateBundle()` — checks bundle prerequisites before running generators
- `generateTemplate()` — reads `tag.template.json` requires if present
- `generateList()` — filters by requirements, accepts `showAll` parameter
- `generateListCommand()` / `templateListCommand()` — `--all` flag wired up

### Tests (25 new tests)
- `TestUT_IsTruthy` — 14 cases (nil, bool, string, float64, int, slice, map)
- `TestUT_CheckRequirements_*` — 8 cases (all met, unmet, partial, nil vars, duplicates, error format)
- `TestUT_GenerateBundle_Requirements*` — 5 cases (met, unmet, partial, backward compat, missing config)
- `TestUT_GenerateTemplate_Requirements*` — 3 cases (met, unmet, backward compat)
- `TestUT_GenerateList_*` — 3 cases (filters unmet, --all flag, requirements shown)

### Documentation
- `.skill/SKILL.md`, `.skill/reference.md`, `.skill/recipes.md` — prerequisites docs
- `docs/commands/generate.md` — `--all` flag, prerequisites section
- `CLAUDE.md` — architecture tree updated

## Test plan

- [x] All 25 new tests pass
- [x] All existing tests pass (no regressions)
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [ ] Manual test with a real template that has `requires` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)