### PR TITLE
fix: set app usage description in CLI help output

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ func main() {
 	tag := &cli.App{
 		Version:              Version,
 		Name:                 AppName,
+		Usage:                "Template-driven code generation and project scaffolding",
 		EnableBashCompletion: true,
 		Commands: []*cli.Command{
 			commands.GenerateCommand(cfg),


### PR DESCRIPTION
## Summary
- Replace default urfave/cli description ("A new cli application") with "Template-driven code generation and project scaffolding" in `tag --help` output

## Test plan
- [x] Verified `go run . --help` shows updated description

🤖 Generated with [Claude Code](https://claude.com/claude-code)