### PR TITLE
feat: add `tag template graph` command

### DIFF
--- a/internal/commands/graph.go
+++ b/internal/commands/graph.go
@@ -1,0 +1,73 @@
+package commands
+
+import (
+	"os"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/kaikenlabs/tag/internal/graph"
+	"github.com/kaikenlabs/tag/pkg/app"
+)
+
+func templateGraphCommand() *cli.Command {
+	return &cli.Command{
+		Name:      "graph",
+		Usage:     "Visualize generator dependency graph",
+		ArgsUsage: "[path]",
+		Description: `Analyzes a TAG template directory and builds a dependency graph
+showing how generators relate to each other through file creation,
+injection, and append operations.
+
+Reports:
+  - Generators and their file actions (create, inject, append)
+  - Bundles with execution order validation
+  - Injection markers found in scaffold source files
+  - Warnings for missing targets, file conflicts, and order violations
+
+Examples:
+  tag template graph
+  tag template graph ./my-template
+  tag template graph --format json
+  tag template graph --format dot | dot -Tpng -o graph.png`,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:  "format",
+				Usage: "output format: text, json, or dot",
+				Value: "text",
+			},
+		},
+		//nolint:goconst // "json" used as format string across commands package
+		Action: func(c *cli.Context) error {
+			if c.NArg() > 1 {
+				return app.UsageErrorf("expected at most one path argument, got %d", c.NArg())
+			}
+
+			root := "."
+			if c.NArg() == 1 {
+				root = c.Args().First()
+			}
+
+			report, err := graph.Analyze(root)
+			if err != nil {
+				return app.Errorf("graph analysis failed: %w", err)
+			}
+
+			out := os.Stdout
+
+			switch format := c.String("format"); format {
+			case "text":
+				graph.WriteText(out, report)
+			case "json":
+				if jsonErr := graph.WriteJSON(out, report); jsonErr != nil {
+					return app.Errorf("write json: %w", jsonErr)
+				}
+			case "dot":
+				graph.WriteDOT(out, report)
+			default:
+				return app.UsageErrorf("unsupported format %q (use text, json, or dot)", format)
+			}
+
+			return nil
+		},
+	}
+}

--- a/internal/commands/template.go
+++ b/internal/commands/template.go
@@ -13,7 +13,7 @@ import (
 func TemplateCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
 		Name:  "template",
-		Usage: "Template authoring commands (init, new, info, list, lint, test, variables)",
+		Usage: "Template authoring commands (init, new, info, list, lint, test, variables, graph)",
 		Subcommands: []*cli.Command{
 			templateInitCommand(),
 			templateNewCommand(cfg),
@@ -22,6 +22,7 @@ func TemplateCommand(cfg *config.Config) *cli.Command {
 			templateLintCommand(),
 			templateTestCommand(),
 			templateVariablesCommand(),
+			templateGraphCommand(),
 		},
 	}
 }

--- a/internal/graph/analyzer.go
+++ b/internal/graph/analyzer.go
@@ -1,0 +1,463 @@
+package graph
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/kaikenlabs/tag/internal/engine"
+	"github.com/kaikenlabs/tag/internal/fileutil"
+	"github.com/kaikenlabs/tag/internal/template"
+	"github.com/kaikenlabs/tag/internal/types"
+)
+
+// Action type constants.
+const (
+	actionCreate = "create"
+	actionInject = "inject"
+	actionAppend = "append"
+)
+
+// Analyze scans a template directory and returns a GraphReport describing
+// the dependency graph between generators, files, and injection markers.
+func Analyze(root string) (*GraphReport, error) {
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return nil, fmt.Errorf("resolve path: %w", err)
+	}
+
+	info, err := os.Stat(absRoot)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, fmt.Errorf("path does not exist: %s", root)
+		}
+		return nil, fmt.Errorf("stat path: %w", err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("path is not a directory: %s", root)
+	}
+
+	report := &GraphReport{}
+
+	// Scan generators from .tag/ directory.
+	tagDir := filepath.Join(absRoot, types.TemplatesDir)
+	generators, warnings := scanGenerators(tagDir)
+	report.Generators = generators
+	report.Warnings = append(report.Warnings, warnings...)
+
+	// Scan bundles from .tag/_bundles/ directory.
+	bundlesDir := filepath.Join(tagDir, types.BundlesDir)
+	report.Bundles = scanBundles(bundlesDir, report.Generators)
+
+	// Scan scaffold source files for injection markers.
+	allMarkers := collectAllMarkers(report.Generators)
+	report.Markers = scanMarkers(absRoot, allMarkers)
+
+	// Generate cross-reference warnings.
+	report.Warnings = append(report.Warnings, generateWarnings(report)...)
+
+	return report, nil
+}
+
+// scanGenerators reads .tag/ for generator subdirectories and extracts
+// metadata from each generator's template files.
+func scanGenerators(tagDir string) ([]GeneratorNode, []Warning) {
+	entries, err := os.ReadDir(tagDir)
+	if err != nil {
+		return nil, nil
+	}
+
+	var generators []GeneratorNode
+	var warnings []Warning
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		// Skip reserved directories.
+		if strings.HasPrefix(name, "_") || strings.HasPrefix(name, ".") {
+			continue
+		}
+
+		genDir := filepath.Join(tagDir, name)
+		actions, genWarnings := extractGeneratorActions(name, genDir)
+		generators = append(generators, GeneratorNode{
+			Name:    name,
+			Actions: actions,
+		})
+		warnings = append(warnings, genWarnings...)
+	}
+
+	// Sort generators by name for deterministic output.
+	slices.SortFunc(generators, func(a, b GeneratorNode) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+
+	return generators, warnings
+}
+
+// extractGeneratorActions loads template files from a generator directory
+// and extracts metadata to determine what actions each template performs.
+func extractGeneratorActions(genName, genDir string) ([]ActionInfo, []Warning) {
+	templates, err := engine.LoadTemplateFiles(genDir)
+	if err != nil {
+		return nil, nil
+	}
+
+	var actions []ActionInfo
+	var warnings []Warning
+
+	for filePath, content := range templates {
+		// Skip tag.template.json — not a template file.
+		if filepath.Base(filePath) == types.TemplateConfigFile {
+			continue
+		}
+
+		action, warn := parseTemplateAction(genName, filePath, content)
+		if warn != nil {
+			warnings = append(warnings, *warn)
+			continue
+		}
+		if action != nil {
+			actions = append(actions, *action)
+		}
+	}
+
+	// Sort actions by target for deterministic output.
+	slices.SortFunc(actions, func(a, b ActionInfo) int {
+		return strings.Compare(a.Target, b.Target)
+	})
+
+	return actions, warnings
+}
+
+// parseTemplateAction extracts a single action from a template file's metadata.
+// Returns nil action if the file has no metadata block.
+func parseTemplateAction(genName, filePath, content string) (*ActionInfo, *Warning) {
+	metaRaw, _, extractErr := template.ExtractMetadata(content)
+	if extractErr != nil {
+		if errors.Is(extractErr, template.ErrNoMetadataBlock) {
+			return nil, nil
+		}
+		w := Warning{
+			Code:      "malformed_metadata",
+			Generator: genName,
+			Message:   fmt.Sprintf("cannot extract metadata from %s: %v", filepath.Base(filePath), extractErr),
+		}
+		return nil, &w
+	}
+
+	meta, parseErr := template.ParseMetadata(metaRaw)
+	if parseErr != nil {
+		w := Warning{
+			Code:      "malformed_metadata",
+			Generator: genName,
+			Message:   fmt.Sprintf("cannot parse metadata in %s: %v", filepath.Base(filePath), parseErr),
+		}
+		return nil, &w
+	}
+
+	action := ActionInfo{
+		Target: meta.To,
+	}
+
+	switch meta.Action {
+	case template.ActionInject:
+		action.Type = actionInject
+		action.Marker = meta.InjectMatcher
+		action.Position = strings.ToLower(string(meta.InjectClause))
+	case template.ActionAppend:
+		action.Type = actionAppend
+	default:
+		action.Type = actionCreate
+	}
+
+	return &action, nil
+}
+
+// scanBundles reads .tag/_bundles/ for bundle definitions and validates
+// their generator execution order.
+func scanBundles(bundlesDir string, generators []GeneratorNode) []BundleInfo {
+	entries, err := os.ReadDir(bundlesDir)
+	if err != nil {
+		return nil
+	}
+
+	// Build a lookup of generator actions by name.
+	genActions := make(map[string][]ActionInfo)
+	for _, gen := range generators {
+		genActions[gen.Name] = gen.Actions
+	}
+
+	var bundles []BundleInfo
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		bundleFile := filepath.Join(bundlesDir, name, name+types.BundleExtension)
+		data, readErr := os.ReadFile(bundleFile)
+		if readErr != nil {
+			continue
+		}
+
+		var bundle engine.Bundle
+		if jsonErr := json.Unmarshal(data, &bundle); jsonErr != nil {
+			continue
+		}
+
+		order := make([]string, 0, len(bundle.Generators))
+		for _, gen := range bundle.Generators {
+			order = append(order, gen.Name)
+		}
+
+		bundles = append(bundles, BundleInfo{
+			Name:       name,
+			Order:      order,
+			ValidOrder: validateBundleOrder(order, genActions),
+		})
+	}
+
+	// Sort bundles by name for deterministic output.
+	slices.SortFunc(bundles, func(a, b BundleInfo) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+
+	return bundles
+}
+
+// validateBundleOrder checks if generators that create files appear before
+// generators that inject into those files.
+func validateBundleOrder(order []string, genActions map[string][]ActionInfo) bool {
+	// Build index of which generator creates each target.
+	createdBy := make(map[string]int) // target -> index of creating generator
+	for i, genName := range order {
+		for _, action := range genActions[genName] {
+			if action.Type == actionCreate {
+				createdBy[action.Target] = i
+			}
+		}
+	}
+
+	// Check if any inject targets are created by a later generator.
+	for i, genName := range order {
+		for _, action := range genActions[genName] {
+			if action.Type == actionInject {
+				if createIdx, ok := createdBy[action.Target]; ok && createIdx > i {
+					return false
+				}
+			}
+		}
+	}
+
+	return true
+}
+
+// collectAllMarkers returns a set of all injection markers used by generators.
+func collectAllMarkers(generators []GeneratorNode) map[string][]string {
+	// marker text -> list of generator names
+	markers := make(map[string][]string)
+	for _, gen := range generators {
+		for _, action := range gen.Actions {
+			if action.Type == actionInject && action.Marker != "" {
+				markers[action.Marker] = append(markers[action.Marker], gen.Name)
+			}
+		}
+	}
+	return markers
+}
+
+// scanMarkers walks the scaffold source files looking for injection marker
+// strings. It skips .tag/, _generators/, and config files.
+func scanMarkers(root string, markers map[string][]string) []MarkerInfo {
+	if len(markers) == 0 {
+		return nil
+	}
+
+	var found []MarkerInfo
+
+	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return nil //nolint:nilerr // best-effort scan
+		}
+
+		if skip, skipDir := shouldSkipMarkerEntry(root, path, d); skip {
+			if skipDir {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		fileMarkers := scanFileForMarkers(root, path, markers)
+		found = append(found, fileMarkers...)
+
+		return nil
+	})
+
+	// Sort by file then line for deterministic output.
+	slices.SortFunc(found, func(a, b MarkerInfo) int {
+		if cmp := strings.Compare(a.File, b.File); cmp != 0 {
+			return cmp
+		}
+		return a.Line - b.Line
+	})
+
+	return found
+}
+
+// shouldSkipMarkerEntry returns whether to skip a path during marker scanning.
+func shouldSkipMarkerEntry(root, path string, d fs.DirEntry) (skip, skipDir bool) {
+	relPath, relErr := filepath.Rel(root, path)
+	if relErr != nil {
+		return true, false
+	}
+
+	if d.IsDir() {
+		name := d.Name()
+		if (name == types.TemplatesDir || name == types.GeneratorsDir || strings.HasPrefix(name, ".")) && relPath != "." {
+			return true, true
+		}
+		return true, false
+	}
+
+	if filepath.Base(path) == types.TemplateConfigFile {
+		return true, false
+	}
+
+	return false, false
+}
+
+// scanFileForMarkers reads a file and searches for marker strings.
+func scanFileForMarkers(root, path string, markers map[string][]string) []MarkerInfo {
+	content, readErr := os.ReadFile(path)
+	if readErr != nil {
+		return nil
+	}
+
+	if !fileutil.IsTextContent(content) {
+		return nil
+	}
+
+	relPath, relErr := filepath.Rel(root, path)
+	if relErr != nil {
+		return nil
+	}
+
+	var found []MarkerInfo
+	scanner := bufio.NewScanner(strings.NewReader(string(content)))
+	lineNum := 0
+	for scanner.Scan() {
+		lineNum++
+		line := scanner.Text()
+		for markerText, usedBy := range markers {
+			if strings.Contains(line, markerText) {
+				found = append(found, MarkerInfo{
+					File:   relPath,
+					Line:   lineNum,
+					Text:   markerText,
+					UsedBy: usedBy,
+				})
+			}
+		}
+	}
+
+	return found
+}
+
+// generateWarnings produces cross-reference warnings from the analysis.
+func generateWarnings(report *GraphReport) []Warning {
+	var warnings []Warning
+	warnings = append(warnings, checkFileConflicts(report.Generators)...)
+	warnings = append(warnings, checkMissingTargets(report.Generators)...)
+	warnings = append(warnings, checkBundleOrderViolations(report.Bundles)...)
+
+	// Sort warnings for deterministic output.
+	slices.SortFunc(warnings, func(a, b Warning) int {
+		if cmp := strings.Compare(a.Code, b.Code); cmp != 0 {
+			return cmp
+		}
+		return strings.Compare(a.Message, b.Message)
+	})
+
+	return warnings
+}
+
+// checkFileConflicts warns when multiple generators create the same file.
+func checkFileConflicts(generators []GeneratorNode) []Warning {
+	// target -> list of generator names that create it
+	creators := make(map[string][]string)
+	for _, gen := range generators {
+		for _, action := range gen.Actions {
+			if action.Type == actionCreate {
+				creators[action.Target] = append(creators[action.Target], gen.Name)
+			}
+		}
+	}
+
+	var warnings []Warning
+	for target, gens := range creators {
+		if len(gens) > 1 {
+			warnings = append(warnings, Warning{
+				Code:    "file_conflict",
+				Message: fmt.Sprintf("file %q is created by multiple generators: %s", target, strings.Join(gens, ", ")),
+			})
+		}
+	}
+	return warnings
+}
+
+// checkMissingTargets warns when an inject target is not created by any generator.
+func checkMissingTargets(generators []GeneratorNode) []Warning {
+	createdTargets := make(map[string]struct{})
+	for _, gen := range generators {
+		for _, action := range gen.Actions {
+			if action.Type == actionCreate {
+				createdTargets[action.Target] = struct{}{}
+			}
+		}
+	}
+
+	var warnings []Warning
+	for _, gen := range generators {
+		for _, action := range gen.Actions {
+			if action.Type != actionInject {
+				continue
+			}
+			if _, ok := createdTargets[action.Target]; ok {
+				continue
+			}
+			// Skip targets with template variables — can't evaluate statically.
+			if strings.Contains(action.Target, "{{") {
+				continue
+			}
+			warnings = append(warnings, Warning{
+				Code:      "missing_target",
+				Generator: gen.Name,
+				Message:   fmt.Sprintf("generator %q injects into %q, but no generator creates it (may exist in scaffold)", gen.Name, action.Target),
+			})
+		}
+	}
+	return warnings
+}
+
+// checkBundleOrderViolations warns about bundles with bad execution order.
+func checkBundleOrderViolations(bundles []BundleInfo) []Warning {
+	var warnings []Warning
+	for _, bundle := range bundles {
+		if !bundle.ValidOrder {
+			warnings = append(warnings, Warning{
+				Code:    "order_violation",
+				Message: fmt.Sprintf("bundle %q has generators that inject before their target is created", bundle.Name),
+			})
+		}
+	}
+	return warnings
+}

--- a/internal/graph/analyzer_test.go
+++ b/internal/graph/analyzer_test.go
@@ -1,0 +1,610 @@
+package graph
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupGraphTemplate creates a temporary template directory with .tag/
+// generators and optional scaffold files. Returns the root path.
+func setupGraphTemplate(t *testing.T, generators map[string]map[string]string, scaffoldFiles map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+
+	for genName, files := range generators {
+		genDir := filepath.Join(root, ".tag", genName)
+		require.NoError(t, os.MkdirAll(genDir, 0o755))
+		for fileName, content := range files {
+			require.NoError(t, os.WriteFile(filepath.Join(genDir, fileName), []byte(content), 0o644))
+		}
+	}
+
+	for path, content := range scaffoldFiles {
+		absPath := filepath.Join(root, path)
+		require.NoError(t, os.MkdirAll(filepath.Dir(absPath), 0o755))
+		require.NoError(t, os.WriteFile(absPath, []byte(content), 0o644))
+	}
+
+	return root
+}
+
+func setupBundle(t *testing.T, root, name, content string) {
+	t.Helper()
+	bundleDir := filepath.Join(root, ".tag", "_bundles", name)
+	require.NoError(t, os.MkdirAll(bundleDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(bundleDir, name+".json"),
+		[]byte(content),
+		0o644,
+	))
+}
+
+func TestUT_AnalyzeCreateActions(t *testing.T) {
+	t.Parallel()
+
+	root := setupGraphTemplate(t,
+		map[string]map[string]string{
+			"model": {
+				"model.go": "---\nto: internal/models/{{ name }}.go\n---\npackage models\n",
+			},
+		},
+		nil,
+	)
+
+	report, err := Analyze(root)
+	require.NoError(t, err)
+	require.Len(t, report.Generators, 1)
+	assert.Equal(t, "model", report.Generators[0].Name)
+	require.Len(t, report.Generators[0].Actions, 1)
+	assert.Equal(t, "create", report.Generators[0].Actions[0].Type)
+	assert.Equal(t, "internal/models/{{ name }}.go", report.Generators[0].Actions[0].Target)
+}
+
+func TestUT_AnalyzeInjectActions(t *testing.T) {
+	t.Parallel()
+
+	root := setupGraphTemplate(t,
+		map[string]map[string]string{
+			"route": {
+				"route.go": "---\nto: internal/router.go\ninject: true\nafter: // TAG:routes\n---\nrouter.Handle()\n",
+			},
+		},
+		nil,
+	)
+
+	report, err := Analyze(root)
+	require.NoError(t, err)
+	require.Len(t, report.Generators, 1)
+	require.Len(t, report.Generators[0].Actions, 1)
+
+	action := report.Generators[0].Actions[0]
+	assert.Equal(t, "inject", action.Type)
+	assert.Equal(t, "internal/router.go", action.Target)
+	assert.Equal(t, "// TAG:routes", action.Marker)
+	assert.Equal(t, "after", action.Position)
+}
+
+func TestUT_AnalyzeInjectBefore(t *testing.T) {
+	t.Parallel()
+
+	root := setupGraphTemplate(t,
+		map[string]map[string]string{
+			"import": {
+				"import.go": "---\nto: internal/main.go\ninject: true\nbefore: // TAG:end-imports\n---\nimport \"pkg\"\n",
+			},
+		},
+		nil,
+	)
+
+	report, err := Analyze(root)
+	require.NoError(t, err)
+	require.Len(t, report.Generators[0].Actions, 1)
+
+	action := report.Generators[0].Actions[0]
+	assert.Equal(t, "inject", action.Type)
+	assert.Equal(t, "before", action.Position)
+	assert.Equal(t, "// TAG:end-imports", action.Marker)
+}
+
+func TestUT_AnalyzeAppendActions(t *testing.T) {
+	t.Parallel()
+
+	root := setupGraphTemplate(t,
+		map[string]map[string]string{
+			"migration": {
+				"migration.sql": "---\nto: migrations/latest.sql\nappend: true\n---\nALTER TABLE;\n",
+			},
+		},
+		nil,
+	)
+
+	report, err := Analyze(root)
+	require.NoError(t, err)
+	require.Len(t, report.Generators, 1)
+	require.Len(t, report.Generators[0].Actions, 1)
+	assert.Equal(t, "append", report.Generators[0].Actions[0].Type)
+	assert.Equal(t, "migrations/latest.sql", report.Generators[0].Actions[0].Target)
+}
+
+func TestUT_AnalyzeBundleOrder(t *testing.T) {
+	t.Parallel()
+
+	root := setupGraphTemplate(t,
+		map[string]map[string]string{
+			"model": {
+				"model.go": "---\nto: internal/models/user.go\n---\npackage models\n",
+			},
+			"route": {
+				"route.go": "---\nto: internal/models/user.go\ninject: true\nafter: // TAG:fields\n---\nName string\n",
+			},
+		},
+		nil,
+	)
+
+	bundleJSON := `{"name":"crud","generators":[{"name":"model"},{"name":"route"}]}`
+	setupBundle(t, root, "crud", bundleJSON)
+
+	report, err := Analyze(root)
+	require.NoError(t, err)
+	require.Len(t, report.Bundles, 1)
+	assert.Equal(t, "crud", report.Bundles[0].Name)
+	assert.Equal(t, []string{"model", "route"}, report.Bundles[0].Order)
+	assert.True(t, report.Bundles[0].ValidOrder, "create before inject should be valid")
+}
+
+func TestUT_AnalyzeBundleOrderViolation(t *testing.T) {
+	t.Parallel()
+
+	root := setupGraphTemplate(t,
+		map[string]map[string]string{
+			"model": {
+				"model.go": "---\nto: internal/models/user.go\n---\npackage models\n",
+			},
+			"route": {
+				"route.go": "---\nto: internal/models/user.go\ninject: true\nafter: // TAG:fields\n---\nName string\n",
+			},
+		},
+		nil,
+	)
+
+	// Bad order: inject before create.
+	bundleJSON := `{"name":"crud","generators":[{"name":"route"},{"name":"model"}]}`
+	setupBundle(t, root, "crud", bundleJSON)
+
+	report, err := Analyze(root)
+	require.NoError(t, err)
+	require.Len(t, report.Bundles, 1)
+	assert.False(t, report.Bundles[0].ValidOrder, "inject before create should be invalid")
+
+	// Should have an order_violation warning.
+	var found bool
+	for _, w := range report.Warnings {
+		if w.Code == "order_violation" {
+			found = true
+		}
+	}
+	assert.True(t, found, "expected order_violation warning")
+}
+
+func TestUT_AnalyzeMarkerFound(t *testing.T) {
+	t.Parallel()
+
+	root := setupGraphTemplate(t,
+		map[string]map[string]string{
+			"route": {
+				"route.go": "---\nto: internal/router.go\ninject: true\nafter: // TAG:routes\n---\nrouter.Handle()\n",
+			},
+		},
+		map[string]string{
+			"internal/router.go": "package internal\n\n// TAG:routes\n",
+		},
+	)
+
+	report, err := Analyze(root)
+	require.NoError(t, err)
+	require.Len(t, report.Markers, 1)
+	assert.Equal(t, "internal/router.go", report.Markers[0].File)
+	assert.Equal(t, 3, report.Markers[0].Line)
+	assert.Equal(t, "// TAG:routes", report.Markers[0].Text)
+	assert.Contains(t, report.Markers[0].UsedBy, "route")
+}
+
+func TestUT_AnalyzeMissingInjectTarget(t *testing.T) {
+	t.Parallel()
+
+	root := setupGraphTemplate(t,
+		map[string]map[string]string{
+			"route": {
+				"route.go": "---\nto: internal/router.go\ninject: true\nafter: // TAG:routes\n---\nrouter.Handle()\n",
+			},
+		},
+		nil,
+	)
+
+	report, err := Analyze(root)
+	require.NoError(t, err)
+
+	var found bool
+	for _, w := range report.Warnings {
+		if w.Code == "missing_target" && strings.Contains(w.Message, "internal/router.go") {
+			found = true
+		}
+	}
+	assert.True(t, found, "expected missing_target warning for internal/router.go")
+}
+
+func TestUT_AnalyzeFileConflict(t *testing.T) {
+	t.Parallel()
+
+	root := setupGraphTemplate(t,
+		map[string]map[string]string{
+			"gen1": {
+				"file.go": "---\nto: output.go\n---\npackage main\n",
+			},
+			"gen2": {
+				"file.go": "---\nto: output.go\n---\npackage main\n",
+			},
+		},
+		nil,
+	)
+
+	report, err := Analyze(root)
+	require.NoError(t, err)
+
+	var found bool
+	for _, w := range report.Warnings {
+		if w.Code == "file_conflict" && strings.Contains(w.Message, "output.go") {
+			found = true
+		}
+	}
+	assert.True(t, found, "expected file_conflict warning for output.go")
+}
+
+func TestUT_AnalyzeEmptyTemplate(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+
+	report, err := Analyze(root)
+	require.NoError(t, err)
+	assert.Empty(t, report.Generators)
+	assert.Empty(t, report.Bundles)
+	assert.Empty(t, report.Markers)
+	assert.Empty(t, report.Warnings)
+}
+
+func TestUT_AnalyzeMalformedMetadata(t *testing.T) {
+	t.Parallel()
+
+	root := setupGraphTemplate(t,
+		map[string]map[string]string{
+			"broken": {
+				"bad.go": "---\nnot a valid line\n---\npackage broken\n",
+			},
+		},
+		nil,
+	)
+
+	report, err := Analyze(root)
+	require.NoError(t, err)
+
+	// Generator should still appear.
+	require.Len(t, report.Generators, 1)
+	assert.Equal(t, "broken", report.Generators[0].Name)
+
+	// Should have a malformed_metadata warning.
+	var found bool
+	for _, w := range report.Warnings {
+		if w.Code == "malformed_metadata" {
+			found = true
+		}
+	}
+	assert.True(t, found, "expected malformed_metadata warning")
+}
+
+func TestUT_AnalyzeMultipleGenerators(t *testing.T) {
+	t.Parallel()
+
+	root := setupGraphTemplate(t,
+		map[string]map[string]string{
+			"handler": {
+				"handler.go": "---\nto: internal/handler.go\n---\npackage internal\n",
+			},
+			"model": {
+				"model.go": "---\nto: internal/model.go\n---\npackage internal\n",
+			},
+			"route": {
+				"route.go": "---\nto: internal/handler.go\ninject: true\nafter: // TAG:routes\n---\nroute\n",
+			},
+		},
+		nil,
+	)
+
+	report, err := Analyze(root)
+	require.NoError(t, err)
+	assert.Len(t, report.Generators, 3)
+
+	// Verify sorted order.
+	assert.Equal(t, "handler", report.Generators[0].Name)
+	assert.Equal(t, "model", report.Generators[1].Name)
+	assert.Equal(t, "route", report.Generators[2].Name)
+}
+
+func TestUT_AnalyzeSkipsReservedDirs(t *testing.T) {
+	t.Parallel()
+
+	root := setupGraphTemplate(t,
+		map[string]map[string]string{
+			"model": {
+				"model.go": "---\nto: internal/model.go\n---\npackage internal\n",
+			},
+			"_shared": {
+				"shared.go": "---\nto: should/not/appear.go\n---\nshared\n",
+			},
+		},
+		nil,
+	)
+
+	report, err := Analyze(root)
+	require.NoError(t, err)
+
+	// _shared should be skipped.
+	assert.Len(t, report.Generators, 1)
+	assert.Equal(t, "model", report.Generators[0].Name)
+}
+
+func TestUT_AnalyzeNoMetadataBlock(t *testing.T) {
+	t.Parallel()
+
+	root := setupGraphTemplate(t,
+		map[string]map[string]string{
+			"simple": {
+				"readme.md": "Just a readme with no frontmatter",
+			},
+		},
+		nil,
+	)
+
+	report, err := Analyze(root)
+	require.NoError(t, err)
+	require.Len(t, report.Generators, 1)
+	assert.Empty(t, report.Generators[0].Actions) // No actions from a file without metadata.
+}
+
+func TestUT_AnalyzeMultipleTemplatesInGenerator(t *testing.T) {
+	t.Parallel()
+
+	root := setupGraphTemplate(t,
+		map[string]map[string]string{
+			"fullstack": {
+				"handler.go":      "---\nto: internal/handler.go\n---\npackage internal\n",
+				"handler_test.go": "---\nto: internal/handler_test.go\n---\npackage internal\n",
+			},
+		},
+		nil,
+	)
+
+	report, err := Analyze(root)
+	require.NoError(t, err)
+	require.Len(t, report.Generators, 1)
+	assert.Len(t, report.Generators[0].Actions, 2)
+}
+
+func TestUT_AnalyzeSkipsTagTemplateJSON(t *testing.T) {
+	t.Parallel()
+
+	root := setupGraphTemplate(t,
+		map[string]map[string]string{
+			"model": {
+				"tag.template.json": `{"vars": {"name": {"type": "string"}}}`,
+				"model.go":          "---\nto: internal/model.go\n---\npackage internal\n",
+			},
+		},
+		nil,
+	)
+
+	report, err := Analyze(root)
+	require.NoError(t, err)
+	require.Len(t, report.Generators, 1)
+	// Only model.go action, not tag.template.json.
+	assert.Len(t, report.Generators[0].Actions, 1)
+}
+
+func TestUT_FormatJSON(t *testing.T) {
+	t.Parallel()
+
+	report := &GraphReport{
+		Generators: []GeneratorNode{
+			{
+				Name: "model",
+				Actions: []ActionInfo{
+					{Type: "create", Target: "internal/model.go"},
+				},
+			},
+		},
+	}
+
+	var buf strings.Builder
+	err := WriteJSON(&buf, report)
+	require.NoError(t, err)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(buf.String()), &parsed))
+
+	// Verify generators exist.
+	gens, ok := parsed["generators"].([]any)
+	require.True(t, ok)
+	require.Len(t, gens, 1)
+
+	// Verify empty arrays not null.
+	bundles, ok := parsed["bundles"].([]any)
+	require.True(t, ok)
+	assert.Empty(t, bundles)
+
+	markers, ok := parsed["markers"].([]any)
+	require.True(t, ok)
+	assert.Empty(t, markers)
+
+	warnings, ok := parsed["warnings"].([]any)
+	require.True(t, ok)
+	assert.Empty(t, warnings)
+}
+
+func TestUT_FormatDOT(t *testing.T) {
+	t.Parallel()
+
+	report := &GraphReport{
+		Generators: []GeneratorNode{
+			{
+				Name: "model",
+				Actions: []ActionInfo{
+					{Type: "create", Target: "internal/model.go"},
+				},
+			},
+			{
+				Name: "route",
+				Actions: []ActionInfo{
+					{Type: "inject", Target: "internal/router.go", Marker: "// TAG:routes", Position: "after"},
+				},
+			},
+		},
+		Bundles: []BundleInfo{
+			{
+				Name:       "crud",
+				Order:      []string{"model", "route"},
+				ValidOrder: true,
+			},
+		},
+	}
+
+	var buf strings.Builder
+	WriteDOT(&buf, report)
+	output := buf.String()
+
+	assert.Contains(t, output, "digraph generators {")
+	assert.Contains(t, output, `"model" [shape=box]`)
+	assert.Contains(t, output, `"route" [shape=box]`)
+	assert.Contains(t, output, `"internal/model.go" [shape=ellipse]`)
+	assert.Contains(t, output, `"model" -> "internal/model.go"`)
+	assert.Contains(t, output, `"route" -> "internal/router.go"`)
+	assert.Contains(t, output, "subgraph cluster_crud")
+	assert.Contains(t, output, `"model" -> "route"`)
+	assert.Contains(t, output, "}")
+}
+
+func TestUT_FormatText(t *testing.T) {
+	t.Parallel()
+
+	report := &GraphReport{
+		Generators: []GeneratorNode{
+			{
+				Name: "model",
+				Actions: []ActionInfo{
+					{Type: "create", Target: "internal/model.go"},
+				},
+			},
+			{
+				Name: "route",
+				Actions: []ActionInfo{
+					{Type: "inject", Target: "internal/router.go", Marker: "// TAG:routes", Position: "after"},
+				},
+			},
+		},
+		Bundles: []BundleInfo{
+			{
+				Name:       "crud",
+				Order:      []string{"model", "route"},
+				ValidOrder: true,
+			},
+		},
+		Markers: []MarkerInfo{
+			{File: "internal/router.go", Line: 10, Text: "// TAG:routes", UsedBy: []string{"route"}},
+		},
+		Warnings: []Warning{
+			{Code: "missing_target", Generator: "route", Message: "generator injects into non-existent file"},
+		},
+	}
+
+	var buf strings.Builder
+	WriteText(&buf, report)
+	output := buf.String()
+
+	assert.Contains(t, output, "Generators:")
+	assert.Contains(t, output, "model")
+	assert.Contains(t, output, "internal/model.go")
+	assert.Contains(t, output, "[create]")
+	assert.Contains(t, output, "route")
+	assert.Contains(t, output, "[inject after")
+	assert.Contains(t, output, "// TAG:routes")
+	assert.Contains(t, output, "Bundles:")
+	assert.Contains(t, output, "crud")
+	assert.Contains(t, output, "Injection markers found:")
+	assert.Contains(t, output, "internal/router.go:10")
+	assert.Contains(t, output, "Warnings:")
+	assert.Contains(t, output, "[missing_target]")
+	assert.Contains(t, output, "2 generator(s)")
+}
+
+func TestUT_AnalyzeNonexistentPath(t *testing.T) {
+	t.Parallel()
+
+	_, err := Analyze("/nonexistent/path/that/does/not/exist")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not exist")
+}
+
+func TestUT_AnalyzeNotADirectory(t *testing.T) {
+	t.Parallel()
+
+	tmpFile := filepath.Join(t.TempDir(), "file.txt")
+	require.NoError(t, os.WriteFile(tmpFile, []byte("hello"), 0o644))
+
+	_, err := Analyze(tmpFile)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a directory")
+}
+
+func TestUT_ValidateBundleOrderEmpty(t *testing.T) {
+	t.Parallel()
+
+	result := validateBundleOrder(nil, nil)
+	assert.True(t, result)
+}
+
+func TestUT_FormatTextEmptyReport(t *testing.T) {
+	t.Parallel()
+
+	report := &GraphReport{}
+	var buf strings.Builder
+	WriteText(&buf, report)
+	output := buf.String()
+
+	assert.Contains(t, output, "Generators:")
+	assert.Contains(t, output, "(none)")
+	assert.Contains(t, output, "0 generator(s)")
+}
+
+func TestUT_FormatJSONEmptyReport(t *testing.T) {
+	t.Parallel()
+
+	report := &GraphReport{}
+	var buf strings.Builder
+	err := WriteJSON(&buf, report)
+	require.NoError(t, err)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(buf.String()), &parsed))
+
+	// All arrays should be [] not null.
+	for _, key := range []string{"generators", "bundles", "markers", "warnings"} {
+		arr, ok := parsed[key].([]any)
+		require.True(t, ok, "expected %s to be array", key)
+		assert.Empty(t, arr)
+	}
+}

--- a/internal/graph/format.go
+++ b/internal/graph/format.go
@@ -1,0 +1,181 @@
+package graph
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// WriteText writes the graph report in human-readable text format.
+func WriteText(w io.Writer, report *GraphReport) {
+	// Generators section.
+	fmt.Fprintln(w, "Generators:")
+	if len(report.Generators) == 0 {
+		fmt.Fprintln(w, "  (none)")
+	} else {
+		for _, gen := range report.Generators {
+			fmt.Fprintf(w, "  %s\n", gen.Name)
+			if len(gen.Actions) == 0 {
+				fmt.Fprintln(w, "    (no actions)")
+			}
+			for _, action := range gen.Actions {
+				writeActionText(w, action)
+			}
+		}
+	}
+
+	// Bundles section.
+	if len(report.Bundles) > 0 {
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Bundles:")
+		for _, bundle := range report.Bundles {
+			orderStatus := "valid"
+			if !bundle.ValidOrder {
+				orderStatus = "INVALID ORDER"
+			}
+			fmt.Fprintf(w, "  %s (%s)\n", bundle.Name, orderStatus)
+			for i, gen := range bundle.Order {
+				fmt.Fprintf(w, "    %d. %s\n", i+1, gen)
+			}
+		}
+	}
+
+	// Markers section.
+	if len(report.Markers) > 0 {
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Injection markers found:")
+		for _, marker := range report.Markers {
+			fmt.Fprintf(w, "  %s:%d  %q  used by: %s\n",
+				marker.File, marker.Line, marker.Text,
+				strings.Join(marker.UsedBy, ", "))
+		}
+	}
+
+	// Warnings section.
+	if len(report.Warnings) > 0 {
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Warnings:")
+		for _, warn := range report.Warnings {
+			fmt.Fprintf(w, "  [%s] %s\n", warn.Code, warn.Message)
+		}
+	}
+
+	// Summary.
+	fmt.Fprintf(w, "\nSummary: %d generator(s), %d bundle(s), %d marker(s), %d warning(s)\n",
+		len(report.Generators), len(report.Bundles), len(report.Markers), len(report.Warnings))
+}
+
+func writeActionText(w io.Writer, action ActionInfo) {
+	switch action.Type {
+	case "inject":
+		fmt.Fprintf(w, "    -> %s  [inject %s %q]\n", action.Target, action.Position, action.Marker)
+	case "append":
+		fmt.Fprintf(w, "    -> %s  [append]\n", action.Target)
+	default:
+		fmt.Fprintf(w, "    -> %s  [create]\n", action.Target)
+	}
+}
+
+// WriteJSON writes the graph report as machine-readable JSON.
+func WriteJSON(w io.Writer, report *GraphReport) error {
+	ensureNonNilSlices(report)
+
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(report)
+}
+
+func ensureNonNilSlices(report *GraphReport) {
+	if report.Generators == nil {
+		report.Generators = []GeneratorNode{}
+	}
+	for i := range report.Generators {
+		if report.Generators[i].Actions == nil {
+			report.Generators[i].Actions = []ActionInfo{}
+		}
+	}
+	if report.Bundles == nil {
+		report.Bundles = []BundleInfo{}
+	}
+	for i := range report.Bundles {
+		if report.Bundles[i].Order == nil {
+			report.Bundles[i].Order = []string{}
+		}
+	}
+	if report.Markers == nil {
+		report.Markers = []MarkerInfo{}
+	}
+	for i := range report.Markers {
+		if report.Markers[i].UsedBy == nil {
+			report.Markers[i].UsedBy = []string{}
+		}
+	}
+	if report.Warnings == nil {
+		report.Warnings = []Warning{}
+	}
+}
+
+// WriteDOT writes the graph report in Graphviz DOT format.
+func WriteDOT(w io.Writer, report *GraphReport) {
+	fmt.Fprintln(w, "digraph generators {")
+	fmt.Fprintln(w, "  rankdir=LR;")
+	fmt.Fprintln(w, "  node [fontname=\"Helvetica\"];")
+	fmt.Fprintln(w, "  edge [fontname=\"Helvetica\" fontsize=10];")
+	fmt.Fprintln(w)
+
+	// Declare generator nodes.
+	for _, gen := range report.Generators {
+		fmt.Fprintf(w, "  %q [shape=box];\n", gen.Name)
+	}
+
+	// Collect unique file targets.
+	files := make(map[string]struct{})
+	for _, gen := range report.Generators {
+		for _, action := range gen.Actions {
+			files[action.Target] = struct{}{}
+		}
+	}
+	if len(files) > 0 {
+		fmt.Fprintln(w)
+	}
+	for file := range files {
+		fmt.Fprintf(w, "  %q [shape=ellipse];\n", file)
+	}
+
+	// Draw edges from generators to files.
+	fmt.Fprintln(w)
+	for _, gen := range report.Generators {
+		for _, action := range gen.Actions {
+			label := edgeLabel(action)
+			fmt.Fprintf(w, "  %q -> %q [label=%q];\n", gen.Name, action.Target, label)
+		}
+	}
+
+	// Draw bundle subgraphs.
+	for _, bundle := range report.Bundles {
+		fmt.Fprintln(w)
+		fmt.Fprintf(w, "  subgraph cluster_%s {\n", bundle.Name)
+		fmt.Fprintf(w, "    label=%q;\n", "bundle: "+bundle.Name)
+		fmt.Fprintln(w, "    style=dashed;")
+		// Draw execution order edges within the bundle.
+		for i := range len(bundle.Order) - 1 {
+			fmt.Fprintf(w, "    %q -> %q [style=dotted label=\"then\"];\n",
+				bundle.Order[i], bundle.Order[i+1])
+		}
+		fmt.Fprintln(w, "  }")
+	}
+
+	fmt.Fprintln(w, "}")
+}
+
+func edgeLabel(action ActionInfo) string {
+	switch action.Type {
+	case "inject":
+		return fmt.Sprintf("injects (%s %q)", action.Position, action.Marker)
+	case "append":
+		return "appends"
+	default:
+		return "creates"
+	}
+}

--- a/internal/graph/types.go
+++ b/internal/graph/types.go
@@ -1,0 +1,45 @@
+package graph
+
+// GraphReport holds the full generator dependency analysis result.
+type GraphReport struct {
+	Generators []GeneratorNode `json:"generators"`
+	Bundles    []BundleInfo    `json:"bundles"`
+	Markers    []MarkerInfo    `json:"markers"`
+	Warnings   []Warning       `json:"warnings"`
+}
+
+// GeneratorNode represents a single generator and its file actions.
+type GeneratorNode struct {
+	Name    string       `json:"name"`
+	Actions []ActionInfo `json:"actions"`
+}
+
+// ActionInfo describes a file operation performed by a generator template.
+type ActionInfo struct {
+	Type     string `json:"type"`               // "create", "inject", "append"
+	Target   string `json:"target"`             // output file path (raw frontmatter value)
+	Marker   string `json:"marker,omitempty"`   // for inject actions
+	Position string `json:"position,omitempty"` // "after" or "before"
+}
+
+// BundleInfo describes a bundle and its generator execution order.
+type BundleInfo struct {
+	Name       string   `json:"name"`
+	Order      []string `json:"order"`       // generator names in execution order
+	ValidOrder bool     `json:"valid_order"` // true if create-before-inject respected
+}
+
+// MarkerInfo describes an injection marker found in scaffold source files.
+type MarkerInfo struct {
+	File   string   `json:"file"`
+	Line   int      `json:"line"`
+	Text   string   `json:"text"`
+	UsedBy []string `json:"used_by"` // generator names that inject at this marker
+}
+
+// Warning represents a potential issue found during analysis.
+type Warning struct {
+	Code      string `json:"code"`      // e.g. "missing_target", "file_conflict", "order_violation"
+	Generator string `json:"generator"` // generator name
+	Message   string `json:"message"`
+}


### PR DESCRIPTION
## Summary

- Adds `tag template graph` command that visualizes generator dependency graphs
- Scans `.tag/` generators to extract create/inject/append actions from frontmatter metadata
- Scans `.tag/_bundles/` to validate execution order (create-before-inject)
- Scans scaffold source files for injection markers and cross-references them
- Supports three output formats: `--format text` (default), `json`, and `dot` (Graphviz)
- Detects and warns about file conflicts, missing inject targets, and bundle order violations

## Test plan

- [x] 22 unit tests covering analyzer, all three formatters, and edge cases
- [x] `golangci-lint` passes with 0 issues
- [x] Full test suite (`go test ./...`) passes
- [ ] Manual test: run `tag template graph` in a template directory with generators

🤖 Generated with [Claude Code](https://claude.com/claude-code)