### PR TITLE
feat: enhance .tagconfig.json with schema v1 (#246)

### DIFF
--- a/internal/scaffold/output.go
+++ b/internal/scaffold/output.go
@@ -465,44 +465,70 @@ func sanitizeFileMode(mode fs.FileMode) fs.FileMode {
 
 // TagConfigOptions provides template metadata for enriched .tagconfig.json generation.
 type TagConfigOptions struct {
-	TemplateSource  string         // Original ref (e.g., "gh:user/repo")
-	TemplateName    string         // Library name
-	TemplateVersion string         // From tag.template.json
-	Variables       map[string]any // Scaffold-time variable values
+	TemplateType    types.TemplateType // "local" or "remote"
+	TemplateSource  string             // Original ref (e.g., "gh:user/repo" or local path)
+	TemplateName    string             // Library name (if any)
+	TemplateVersion string             // From tag.template.json
+	TemplateRef     string             // Branch/tag used (e.g., "main", "v1.2.0")
+	CommitSHA       string             // Resolved git commit SHA (empty for local/zip)
+	SkipPatterns    []string           // User-configurable update exclusions
+	Variables       map[string]any     // Scaffold-time variable values
+}
+
+// tagConfigJSON is the serialization format for .tagconfig.json (v1 schema).
+type tagConfigJSON struct {
+	SchemaVersion int                 `json:"schema_version"`
+	Template      tagTemplateJSON     `json:"template"`
+	Variables     map[string]any      `json:"variables,omitempty"`
+	SkipPatterns  []string            `json:"skip_patterns"`
+	Env           map[string]string   `json:"env"`
+	Hooks         map[string][]string `json:"hooks"`
+}
+
+// tagTemplateJSON is the template origin section of .tagconfig.json.
+type tagTemplateJSON struct {
+	Type      types.TemplateType `json:"type"`
+	Source    string             `json:"source,omitempty"`
+	Name      string             `json:"name,omitempty"`
+	Version   string             `json:"version,omitempty"`
+	Ref       string             `json:"ref,omitempty"`
+	CommitSHA string             `json:"commit,omitempty"`
 }
 
 // GenerateTagConfig generates a .tagconfig.json file in the output directory.
-// When opts contains template metadata, it records the template origin and scaffold variables.
+// The template section is always written with an explicit type discriminator.
 func GenerateTagConfig(outputDir string, opts TagConfigOptions) error {
-	cfg := map[string]any{
-		"env": map[string]string{
+	templateType := opts.TemplateType
+	if templateType == "" {
+		templateType = types.TemplateTypeLocal
+	}
+
+	skipPatterns := opts.SkipPatterns
+	if skipPatterns == nil {
+		skipPatterns = []string{}
+	}
+
+	cfg := tagConfigJSON{
+		SchemaVersion: types.TagConfigSchemaVersion,
+		Template: tagTemplateJSON{
+			Type:      templateType,
+			Source:    opts.TemplateSource,
+			Name:      opts.TemplateName,
+			Version:   opts.TemplateVersion,
+			Ref:       opts.TemplateRef,
+			CommitSHA: opts.CommitSHA,
+		},
+		Variables:    opts.Variables,
+		SkipPatterns: skipPatterns,
+		Env: map[string]string{
 			"TAG_PATH":        types.TemplatesDir,
 			"TAG_SHARED_PATH": types.SharedDir,
 			"TAG_BUNDLE_PATH": types.BundlesDir,
 		},
-		"hooks": map[string][]string{
+		Hooks: map[string][]string{
 			"pre":  {},
 			"post": {},
 		},
-	}
-
-	// Add template origin if a library name is known.
-	// TemplateName is required — writing a partial origin with just source
-	// but no name would create invalid config (HasTemplateOrigin requires Name).
-	if opts.TemplateName != "" {
-		origin := map[string]string{
-			"source": opts.TemplateSource,
-			"name":   opts.TemplateName,
-		}
-		if opts.TemplateVersion != "" {
-			origin["version"] = opts.TemplateVersion
-		}
-		cfg["template"] = origin
-	}
-
-	// Add scaffold variables if provided
-	if len(opts.Variables) > 0 {
-		cfg["variables"] = opts.Variables
 	}
 
 	data, err := json.MarshalIndent(cfg, "", "  ")
@@ -510,10 +536,81 @@ func GenerateTagConfig(outputDir string, opts TagConfigOptions) error {
 		return fmt.Errorf("failed to marshal tagconfig: %w", err)
 	}
 
-	configPath := filepath.Join(outputDir, ".tagconfig.json")
+	configPath := filepath.Join(outputDir, types.TagConfigFile)
 	if err := os.WriteFile(configPath, data, types.FileMode); err != nil {
 		return fmt.Errorf("failed to write tagconfig: %w", err)
 	}
 
 	return nil
+}
+
+// TagConfig represents a parsed .tagconfig.json file.
+// Used by the update system to read existing project configurations.
+type TagConfig struct {
+	SchemaVersion int                 `json:"schema_version,omitempty"`
+	Template      *TagTemplate        `json:"template,omitempty"`
+	Variables     map[string]any      `json:"variables,omitempty"`
+	SkipPatterns  []string            `json:"skip_patterns,omitempty"`
+	Env           map[string]string   `json:"env,omitempty"`
+	Hooks         map[string][]string `json:"hooks,omitempty"`
+}
+
+// TagTemplate describes the template origin recorded in .tagconfig.json.
+type TagTemplate struct {
+	Type      types.TemplateType `json:"type,omitempty"`
+	Source    string             `json:"source,omitempty"`
+	Name      string             `json:"name,omitempty"`
+	Version   string             `json:"version,omitempty"`
+	Ref       string             `json:"ref,omitempty"`
+	CommitSHA string             `json:"commit,omitempty"`
+}
+
+// LoadTagConfig reads and parses a .tagconfig.json from the given project directory.
+func LoadTagConfig(projectDir string) (*TagConfig, error) {
+	data, err := os.ReadFile(filepath.Join(projectDir, types.TagConfigFile))
+	if err != nil {
+		return nil, fmt.Errorf("read tagconfig: %w", err)
+	}
+
+	return ParseTagConfigJSON(data)
+}
+
+// ParseTagConfigJSON parses raw JSON bytes into a TagConfig.
+func ParseTagConfigJSON(data []byte) (*TagConfig, error) {
+	var cfg TagConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parse tagconfig: %w", err)
+	}
+
+	cfg.normalize()
+	return &cfg, nil
+}
+
+// normalize fills in defaults for legacy (pre-v1) configs.
+func (c *TagConfig) normalize() {
+	if c.SchemaVersion == 0 {
+		c.SchemaVersion = types.TagConfigSchemaVersion
+	}
+	if c.SkipPatterns == nil {
+		c.SkipPatterns = []string{}
+	}
+	if c.Template != nil && c.Template.Type == "" {
+		c.Template.Type = inferTemplateType(c.Template.Source)
+	}
+}
+
+// HasTemplateOrigin reports whether the config has enough template metadata
+// for the update system to resolve the original template.
+func (c *TagConfig) HasTemplateOrigin() bool {
+	return c.Template != nil && c.Template.Source != ""
+}
+
+// inferTemplateType guesses the template type from the source string.
+func inferTemplateType(source string) types.TemplateType {
+	for _, prefix := range []string{"gh:", "gl:", "bb:", "http://", "https://", "git@", "git://", "git+ssh://"} {
+		if strings.HasPrefix(source, prefix) {
+			return types.TemplateTypeRemote
+		}
+	}
+	return types.TemplateTypeLocal
 }

--- a/internal/scaffold/output_test.go
+++ b/internal/scaffold/output_test.go
@@ -671,7 +671,7 @@ func TestUT_ProcessFile_TemplateExecuteError(t *testing.T) {
 
 // --- GenerateTagConfig ---
 
-func TestUT_GenerateTagConfig_WithoutTemplateOrigin(t *testing.T) {
+func TestUT_GenerateTagConfig_DefaultOptions(t *testing.T) {
 	outputDir := t.TempDir()
 
 	err := GenerateTagConfig(outputDir, TagConfigOptions{})
@@ -683,6 +683,19 @@ func TestUT_GenerateTagConfig_WithoutTemplateOrigin(t *testing.T) {
 
 	var config map[string]any
 	require.NoError(t, json.Unmarshal(data, &config))
+
+	// Schema version always present
+	assert.Equal(t, float64(types.TagConfigSchemaVersion), config["schema_version"])
+
+	// Template section always present with type
+	tmpl, ok := config["template"].(map[string]any)
+	require.True(t, ok, "template should always be a map")
+	assert.Equal(t, string(types.TemplateTypeLocal), tmpl["type"])
+
+	// Skip patterns always present as empty array
+	skipPatterns, ok := config["skip_patterns"].([]any)
+	require.True(t, ok, "skip_patterns should be an array")
+	assert.Empty(t, skipPatterns)
 
 	// Verify env section
 	env, ok := config["env"].(map[string]any)
@@ -697,18 +710,20 @@ func TestUT_GenerateTagConfig_WithoutTemplateOrigin(t *testing.T) {
 	assert.NotNil(t, hooks["pre"])
 	assert.NotNil(t, hooks["post"])
 
-	// No template or variables fields when not provided
-	assert.Nil(t, config["template"])
+	// No variables when not provided
 	assert.Nil(t, config["variables"])
 }
 
-func TestUT_GenerateTagConfig_WithTemplateOrigin(t *testing.T) {
+func TestUT_GenerateTagConfig_RemoteTemplate(t *testing.T) {
 	outputDir := t.TempDir()
 
 	err := GenerateTagConfig(outputDir, TagConfigOptions{
+		TemplateType:    types.TemplateTypeRemote,
 		TemplateSource:  "gh:acme/nextjs-starter",
 		TemplateName:    "nextjs-starter",
 		TemplateVersion: "1.2.0",
+		TemplateRef:     "v1.2.0",
+		CommitSHA:       "abc123def456",
 		Variables: map[string]any{
 			"project_name": "my-app",
 			"use_docker":   true,
@@ -723,12 +738,18 @@ func TestUT_GenerateTagConfig_WithTemplateOrigin(t *testing.T) {
 	var config map[string]any
 	require.NoError(t, json.Unmarshal(data, &config))
 
+	// Schema version
+	assert.Equal(t, float64(types.TagConfigSchemaVersion), config["schema_version"])
+
 	// Verify template origin
 	tmpl, ok := config["template"].(map[string]any)
 	require.True(t, ok, "template should be a map")
+	assert.Equal(t, "remote", tmpl["type"])
 	assert.Equal(t, "gh:acme/nextjs-starter", tmpl["source"])
 	assert.Equal(t, "nextjs-starter", tmpl["name"])
 	assert.Equal(t, "1.2.0", tmpl["version"])
+	assert.Equal(t, "v1.2.0", tmpl["ref"])
+	assert.Equal(t, "abc123def456", tmpl["commit"])
 
 	// Verify variables
 	vars, ok := config["variables"].(map[string]any)
@@ -741,6 +762,7 @@ func TestUT_GenerateTagConfig_WithoutVersion(t *testing.T) {
 	outputDir := t.TempDir()
 
 	err := GenerateTagConfig(outputDir, TagConfigOptions{
+		TemplateType:   types.TemplateTypeRemote,
 		TemplateSource: "gh:acme/repo",
 		TemplateName:   "repo",
 	})
@@ -755,9 +777,131 @@ func TestUT_GenerateTagConfig_WithoutVersion(t *testing.T) {
 
 	tmpl, ok := config["template"].(map[string]any)
 	require.True(t, ok)
+	assert.Equal(t, "remote", tmpl["type"])
 	assert.Equal(t, "gh:acme/repo", tmpl["source"])
 	assert.Equal(t, "repo", tmpl["name"])
 	assert.Nil(t, tmpl["version"]) // version omitted when empty
+}
+
+func TestUT_GenerateTagConfig_SkipPatterns(t *testing.T) {
+	outputDir := t.TempDir()
+
+	err := GenerateTagConfig(outputDir, TagConfigOptions{
+		TemplateType:   types.TemplateTypeLocal,
+		TemplateSource: "./my-template",
+		SkipPatterns:   []string{"*.log", "temp/**"},
+	})
+	require.NoError(t, err)
+
+	configPath := filepath.Join(outputDir, ".tagconfig.json")
+	data, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+
+	var config map[string]any
+	require.NoError(t, json.Unmarshal(data, &config))
+
+	skipPatterns, ok := config["skip_patterns"].([]any)
+	require.True(t, ok)
+	assert.Len(t, skipPatterns, 2)
+	assert.Equal(t, "*.log", skipPatterns[0])
+	assert.Equal(t, "temp/**", skipPatterns[1])
+}
+
+func TestUT_LoadTagConfig_V1(t *testing.T) {
+	dir := t.TempDir()
+	configJSON := `{
+  "schema_version": 1,
+  "template": {
+    "type": "remote",
+    "source": "gh:acme/starter",
+    "name": "starter",
+    "version": "2.0.0",
+    "ref": "main",
+    "commit": "deadbeef1234"
+  },
+  "variables": {"project_name": "my-proj"},
+  "skip_patterns": ["*.bak"],
+  "env": {},
+  "hooks": {}
+}`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".tagconfig.json"), []byte(configJSON), 0o644))
+
+	cfg, err := LoadTagConfig(dir)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, cfg.SchemaVersion)
+	require.NotNil(t, cfg.Template)
+	assert.Equal(t, types.TemplateTypeRemote, cfg.Template.Type)
+	assert.Equal(t, "gh:acme/starter", cfg.Template.Source)
+	assert.Equal(t, "starter", cfg.Template.Name)
+	assert.Equal(t, "2.0.0", cfg.Template.Version)
+	assert.Equal(t, "main", cfg.Template.Ref)
+	assert.Equal(t, "deadbeef1234", cfg.Template.CommitSHA)
+	assert.Equal(t, []string{"*.bak"}, cfg.SkipPatterns)
+	assert.True(t, cfg.HasTemplateOrigin())
+}
+
+func TestUT_LoadTagConfig_LegacyV0(t *testing.T) {
+	dir := t.TempDir()
+	// Legacy format: no schema_version, no type, no skip_patterns
+	configJSON := `{
+  "template": {
+    "source": "gh:acme/old-template",
+    "name": "old-template"
+  },
+  "variables": {"name": "legacy"},
+  "env": {},
+  "hooks": {}
+}`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".tagconfig.json"), []byte(configJSON), 0o644))
+
+	cfg, err := LoadTagConfig(dir)
+	require.NoError(t, err)
+
+	// Normalize fills in defaults
+	assert.Equal(t, types.TagConfigSchemaVersion, cfg.SchemaVersion)
+	assert.Equal(t, types.TemplateTypeRemote, cfg.Template.Type) // inferred from "gh:" prefix
+	assert.Equal(t, []string{}, cfg.SkipPatterns)                // nil → empty slice
+	assert.True(t, cfg.HasTemplateOrigin())
+}
+
+func TestUT_LoadTagConfig_LegacyNoTemplate(t *testing.T) {
+	dir := t.TempDir()
+	// Legacy format: no template section at all
+	configJSON := `{
+  "env": {},
+  "hooks": {}
+}`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".tagconfig.json"), []byte(configJSON), 0o644))
+
+	cfg, err := LoadTagConfig(dir)
+	require.NoError(t, err)
+
+	assert.Nil(t, cfg.Template)
+	assert.False(t, cfg.HasTemplateOrigin())
+}
+
+func TestUT_InferTemplateType(t *testing.T) {
+	tests := []struct {
+		source   string
+		expected types.TemplateType
+	}{
+		{"gh:acme/repo", types.TemplateTypeRemote},
+		{"gl:acme/repo", types.TemplateTypeRemote},
+		{"bb:acme/repo", types.TemplateTypeRemote},
+		{"https://github.com/acme/repo", types.TemplateTypeRemote},
+		{"git@github.com:acme/repo.git", types.TemplateTypeRemote},
+		{"git://github.com/acme/repo.git", types.TemplateTypeRemote},
+		{"git+ssh://git@github.com/acme/repo.git", types.TemplateTypeRemote},
+		{"./local/path", types.TemplateTypeLocal},
+		{"/absolute/path", types.TemplateTypeLocal},
+		{"", types.TemplateTypeLocal},
+	}
+	for _, tt := range tests {
+		t.Run(tt.source, func(t *testing.T) {
+			assert.Equal(t, tt.expected, inferTemplateType(tt.source))
+		})
+	}
 }
 
 // --- buildTemplateContext ---

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -314,7 +314,12 @@ func (s *Scaffold) executeScaffold(ctx *runContext) (ScaffoldResult, error) {
 
 	// Generate config — filter out secret variables before writing to .tagconfig.json
 	configVars := replay.FilterSecrets(ctx.vars, secretKeys(ctx.config.Vars))
+	templateType := types.TemplateTypeLocal
+	if ctx.opts.IsRemote {
+		templateType = types.TemplateTypeRemote
+	}
 	tagConfigOpts := TagConfigOptions{
+		TemplateType:    templateType,
 		TemplateSource:  ctx.opts.TemplateRef,
 		TemplateName:    ctx.opts.TemplateName,
 		TemplateVersion: ctx.opts.TemplateVersion,

--- a/internal/types/constants.go
+++ b/internal/types/constants.go
@@ -40,6 +40,23 @@ const (
 
 	// HistoryBackupsDir is the subdirectory inside TemplatesDir where backups are stored.
 	HistoryBackupsDir = "history/backups"
+
+	// TagConfigFile is the name of the project-level scaffold configuration file.
+	TagConfigFile = ".tagconfig.json"
+
+	// TagConfigSchemaVersion is the current schema version for .tagconfig.json.
+	TagConfigSchemaVersion = 1
+)
+
+// TemplateType indicates the source type of a scaffolded template.
+type TemplateType string
+
+const (
+	// TemplateTypeLocal indicates a template sourced from a local directory.
+	TemplateTypeLocal TemplateType = "local"
+
+	// TemplateTypeRemote indicates a template sourced from a remote git/zip origin.
+	TemplateTypeRemote TemplateType = "remote"
 )
 
 // InjectClause represents where to inject content relative to a marker.


### PR DESCRIPTION
## Summary

- Add v1 schema for `.tagconfig.json` with `schema_version`, explicit `template.type` discriminator (`local`/`remote`), `template.ref`, `template.commit`, and `skip_patterns`
- Template section is now **always written** (not just for library templates), enabling the update system to track any template origin
- Add `TagConfig`/`TagTemplate` reader types with `normalize()` for backward-compatible parsing of legacy (pre-v1) configs
- Add `LoadTagConfig()`, `ParseTagConfigJSON()`, `HasTemplateOrigin()`, `inferTemplateType()` helpers
- Add `TemplateType` enum and `TagConfigSchemaVersion` constant to `internal/types/`

## What Changed

| File | Change |
|------|--------|
| `internal/types/constants.go` | `TagConfigFile`, `TagConfigSchemaVersion`, `TemplateType` enum |
| `internal/scaffold/output.go` | Enhanced `TagConfigOptions`, typed JSON structs, reader types, helpers |
| `internal/scaffold/scaffold.go` | Sets `TemplateType` from `opts.IsRemote` |
| `internal/scaffold/output_test.go` | 8 new/updated tests covering v1 schema, legacy compat, type inference |

## Design Decisions

- **Always write template section**: Enables update/check/diff for all template sources, not just library ones
- **Explicit `type` discriminator**: `"local"` or `"remote"` — no ambiguous empty fields
- **Typed structs over `map[string]any`**: Compile-time safety for serialization
- **`normalize()` for backward compat**: Legacy configs get `schema_version=1`, inferred type, `skip_patterns=[]`
- **`commit` and `ref` fields empty for now**: Will be populated by #247 (remote resolver SHA changes)

## Test Plan

- [x] `TestUT_GenerateTagConfig_DefaultOptions` — always has schema_version, template.type, skip_patterns
- [x] `TestUT_GenerateTagConfig_RemoteTemplate` — full remote config with all new fields
- [x] `TestUT_GenerateTagConfig_WithoutVersion` — omitempty behavior
- [x] `TestUT_GenerateTagConfig_SkipPatterns` — custom patterns
- [x] `TestUT_LoadTagConfig_V1` — new format round-trip
- [x] `TestUT_LoadTagConfig_LegacyV0` — backward compat with normalize()
- [x] `TestUT_LoadTagConfig_LegacyNoTemplate` — minimal legacy config
- [x] `TestUT_InferTemplateType` — 10 cases (gh:, gl:, bb:, https://, git@, git://, git+ssh://, local paths, empty)
- [x] `make lint` — 0 issues
- [x] `go test ./...` — all pass

Closes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)