### PR TITLE
feat: add commit SHA resolution to remote resolver

### DIFF
--- a/internal/commands/info.go
+++ b/internal/commands/info.go
@@ -85,14 +85,14 @@ func resolveTemplateDir(c *cli.Context, ref string) (string, error) {
 		return "", app.Errorf("failed to create resolver: %w", err)
 	}
 
-	templateDir, err := resolver.Resolve(c.Context, ref, remote.ResolveOptions{
+	resolveResult, err := resolver.Resolve(c.Context, ref, remote.ResolveOptions{
 		ForceUpdate: c.Bool("update"),
 	})
 	if err != nil {
 		return "", app.Errorf("failed to resolve template %q: %w", ref, err)
 	}
 
-	return templateDir, nil
+	return resolveResult.Path, nil
 }
 
 // displayTemplateInfo orchestrates the display of all template information sections.

--- a/internal/commands/scaffold.go
+++ b/internal/commands/scaffold.go
@@ -181,12 +181,13 @@ func scaffoldFromRef(c *cli.Context, positional []string) error {
 		return app.Errorf("failed to create resolver: %w", err)
 	}
 
-	templateDir, err := resolver.Resolve(c.Context, templateRef, remote.ResolveOptions{
+	resolveResult, err := resolver.Resolve(c.Context, templateRef, remote.ResolveOptions{
 		ForceUpdate: c.Bool("update"),
 	})
 	if err != nil {
 		return app.Errorf("failed to resolve template: %w", err)
 	}
+	templateDir := resolveResult.Path
 
 	// Parse meta flags
 	meta, err := parse.ParseKeyValues(c.StringSlice("meta"), true)

--- a/internal/convert/cookiecutter.go
+++ b/internal/convert/cookiecutter.go
@@ -157,12 +157,12 @@ func (c *Converter) resolveSource(ctx context.Context, source string) (string, e
 	}
 
 	// Try to resolve as remote
-	resolvedPath, err := c.resolver.Resolve(ctx, source, remote.ResolveOptions{})
+	resolveResult, err := c.resolver.Resolve(ctx, source, remote.ResolveOptions{})
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve template: %w", err)
 	}
 
-	return resolvedPath, nil
+	return resolveResult.Path, nil
 }
 
 // processTemplateFiles walks the template directory and converts files.

--- a/internal/library/library.go
+++ b/internal/library/library.go
@@ -22,7 +22,7 @@ const templatesDir = "templates"
 
 // Resolver resolves template references to local directories.
 type Resolver interface {
-	Resolve(ctx context.Context, input string, opts remote.ResolveOptions) (string, error)
+	Resolve(ctx context.Context, input string, opts remote.ResolveOptions) (*remote.FetchResult, error)
 }
 
 // Library manages a persistent collection of installed templates.
@@ -99,12 +99,14 @@ func (l *Library) Add(ctx context.Context, opts AddOptions) (*AddResult, error) 
 		if l.resolver == nil {
 			return nil, &LibraryError{Name: name, Operation: "add", Err: errors.New("resolver not configured")}
 		}
-		resolvedDir, err = l.resolver.Resolve(ctx, opts.Ref, remote.ResolveOptions{
+		var resolveResult *remote.FetchResult
+		resolveResult, err = l.resolver.Resolve(ctx, opts.Ref, remote.ResolveOptions{
 			ForceUpdate: true,
 		})
 		if err != nil {
 			return nil, &LibraryError{Name: name, Operation: "add", Err: fmt.Errorf("resolve template: %w", err)}
 		}
+		resolvedDir = resolveResult.Path
 	}
 
 	destPath := filepath.Join(l.dataDir, templatesDir, name)

--- a/internal/library/library_test.go
+++ b/internal/library/library_test.go
@@ -30,19 +30,19 @@ func newWithDir(dataDir string, resolver Resolver) *Library {
 // localResolver is a test resolver that returns local paths as-is.
 type localResolver struct{}
 
-func (r *localResolver) Resolve(_ context.Context, input string, _ remote.ResolveOptions) (string, error) {
+func (r *localResolver) Resolve(_ context.Context, input string, _ remote.ResolveOptions) (*remote.FetchResult, error) {
 	// For local paths, just verify they exist and return them
 	if _, err := os.Stat(input); err != nil {
-		return "", fmt.Errorf("local path not found: %w", err)
+		return nil, fmt.Errorf("local path not found: %w", err)
 	}
-	return input, nil
+	return &remote.FetchResult{Path: input}, nil
 }
 
 // failResolver always returns an error.
 type failResolver struct{ err error }
 
-func (r *failResolver) Resolve(_ context.Context, _ string, _ remote.ResolveOptions) (string, error) {
-	return "", r.err
+func (r *failResolver) Resolve(_ context.Context, _ string, _ remote.ResolveOptions) (*remote.FetchResult, error) {
+	return nil, r.err
 }
 
 func TestUT_DeriveName(t *testing.T) {
@@ -846,14 +846,14 @@ type selectiveFailResolver struct {
 	failRefs map[string]bool
 }
 
-func (r *selectiveFailResolver) Resolve(_ context.Context, input string, _ remote.ResolveOptions) (string, error) {
+func (r *selectiveFailResolver) Resolve(_ context.Context, input string, _ remote.ResolveOptions) (*remote.FetchResult, error) {
 	if r.failRefs[input] {
-		return "", fmt.Errorf("simulated failure for %s", input)
+		return nil, fmt.Errorf("simulated failure for %s", input)
 	}
 	if _, err := os.Stat(input); err != nil {
-		return "", fmt.Errorf("local path not found: %w", err)
+		return nil, fmt.Errorf("local path not found: %w", err)
 	}
-	return input, nil
+	return &remote.FetchResult{Path: input}, nil
 }
 
 func TestUT_UpdateAll_PartialFailure(t *testing.T) {

--- a/internal/remote/cache.go
+++ b/internal/remote/cache.go
@@ -23,6 +23,7 @@ type CacheMeta struct {
 	OriginalRef string     `json:"original_ref"`
 	ResolvedURL string     `json:"resolved_url"`
 	Version     string     `json:"version,omitempty"`
+	CommitSHA   string     `json:"commit_sha,omitempty"` // Resolved git commit SHA
 	FetchedAt   time.Time  `json:"fetched_at"`
 	ExpiresAt   *time.Time `json:"expires_at,omitempty"` // nil = never expires (pinned)
 }

--- a/internal/remote/git.go
+++ b/internal/remote/git.go
@@ -30,17 +30,17 @@ func NewGitFetcher(auth AuthProvider) *GitFetcher {
 	return &GitFetcher{auth: auth, out: os.Stderr}
 }
 
-// Fetch clones the repository and returns the path to the template.
-// If ref.SubPath is set, returns the path to that subdirectory.
-func (f *GitFetcher) Fetch(ctx context.Context, ref *Reference) (string, error) {
+// Fetch clones the repository and returns the path to the template along with
+// the resolved commit SHA.
+func (f *GitFetcher) Fetch(ctx context.Context, ref *Reference) (*FetchResult, error) {
 	if ref.Type != ReferenceTypeGit {
-		return "", &FetchError{Ref: ref, Message: "not a Git reference"}
+		return nil, &FetchError{Ref: ref, Message: "not a Git reference"}
 	}
 
 	// Create temporary directory for clone
 	tmpDir, err := os.MkdirTemp("", "tag-git-*")
 	if err != nil {
-		return "", &FetchError{Ref: ref, Message: "cannot create temp directory", Err: err}
+		return nil, &FetchError{Ref: ref, Message: "cannot create temp directory", Err: err}
 	}
 
 	// Clean up on error
@@ -54,13 +54,22 @@ func (f *GitFetcher) Fetch(ctx context.Context, ref *Reference) (string, error) 
 	// Clone the repository (falls back to SSH on HTTPS auth failure)
 	repo, err := f.clone(ctx, ref, tmpDir)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	// Checkout specific version if requested
+	// Resolve commit SHA
+	var commitHash plumbing.Hash
 	if ref.Version != "" {
-		if err := f.checkout(repo, ref); err != nil {
-			return "", err
+		// Checkout specific version and get its resolved hash
+		commitHash, err = f.checkout(repo, ref)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		// No version specified — resolve HEAD of the default branch
+		commitHash, err = resolveHEAD(repo)
+		if err != nil {
+			return nil, &FetchError{Ref: ref, Message: "cannot resolve HEAD", Err: err}
 		}
 	}
 
@@ -72,16 +81,16 @@ func (f *GitFetcher) Fetch(ctx context.Context, ref *Reference) (string, error) 
 		info, err := os.Stat(resultPath)
 		if err != nil {
 			if os.IsNotExist(err) {
-				return "", &FetchError{
+				return nil, &FetchError{
 					Ref:     ref,
 					Message: fmt.Sprintf("subpath %q not found in repository", ref.SubPath),
 					Err:     ErrSubPathNotFound,
 				}
 			}
-			return "", &FetchError{Ref: ref, Message: "cannot access subpath", Err: err}
+			return nil, &FetchError{Ref: ref, Message: "cannot access subpath", Err: err}
 		}
 		if !info.IsDir() {
-			return "", &FetchError{
+			return nil, &FetchError{
 				Ref:     ref,
 				Message: fmt.Sprintf("subpath %q is not a directory", ref.SubPath),
 			}
@@ -89,7 +98,49 @@ func (f *GitFetcher) Fetch(ctx context.Context, ref *Reference) (string, error) 
 	}
 
 	success = true
-	return resultPath, nil
+	return &FetchResult{
+		Path:      resultPath,
+		CommitSHA: commitHash.String(),
+		Version:   ref.Version,
+	}, nil
+}
+
+// FetchAtCommit clones a repository and checks out a specific commit SHA.
+// Unlike Fetch, this performs a full clone (not shallow) since the target commit
+// may not be reachable from advertised refs in a shallow clone.
+func (f *GitFetcher) FetchAtCommit(ctx context.Context, url, commitSHA, destDir string) (string, error) {
+	if !looksLikeCommitSHA(commitSHA) || len(commitSHA) != 40 {
+		return "", fmt.Errorf("invalid commit SHA (must be full 40-character hex): %q", commitSHA)
+	}
+
+	// Full clone (no depth limit) to ensure the commit is available
+	opts := &git.CloneOptions{
+		URL:      url,
+		Progress: f.progressWriter(),
+	}
+
+	// Get auth if possible (best-effort, URL-based ref)
+	ref := &Reference{URL: url, Type: ReferenceTypeGit}
+	if auth, err := f.auth.GitAuth(ref); err == nil {
+		opts.Auth = auth
+	}
+
+	repo, err := git.PlainCloneContext(ctx, destDir, false, opts)
+	if err != nil {
+		return "", fmt.Errorf("clone for commit checkout: %s", sanitizeErrorMessage(err.Error()))
+	}
+
+	wt, err := repo.Worktree()
+	if err != nil {
+		return "", fmt.Errorf("get worktree: %w", err)
+	}
+
+	hash := plumbing.NewHash(commitSHA)
+	if err := wt.Checkout(&git.CheckoutOptions{Hash: hash, Force: true}); err != nil {
+		return "", fmt.Errorf("checkout commit %s: %w", commitSHA, err)
+	}
+
+	return destDir, nil
 }
 
 // clone performs the Git clone operation.
@@ -173,11 +224,12 @@ func isAuthError(err error) bool {
 		strings.Contains(errStr, "403")
 }
 
-// checkout checks out a specific version (tag, branch, or commit).
-func (f *GitFetcher) checkout(repo *git.Repository, ref *Reference) error {
+// checkout checks out a specific version (tag, branch, or commit) and returns
+// the resolved commit hash.
+func (f *GitFetcher) checkout(repo *git.Repository, ref *Reference) (plumbing.Hash, error) {
 	wt, err := repo.Worktree()
 	if err != nil {
-		return &FetchError{Ref: ref, Message: "cannot get worktree", Err: err}
+		return plumbing.ZeroHash, &FetchError{Ref: ref, Message: "cannot get worktree", Err: err}
 	}
 
 	// Try different reference types in order:
@@ -193,7 +245,7 @@ func (f *GitFetcher) checkout(repo *git.Repository, ref *Reference) error {
 			Force:  true,
 		})
 		if err == nil {
-			return nil
+			return resolveHEAD(repo)
 		}
 	}
 
@@ -205,7 +257,7 @@ func (f *GitFetcher) checkout(repo *git.Repository, ref *Reference) error {
 			Force:  true,
 		})
 		if err == nil {
-			return nil
+			return resolveHEAD(repo)
 		}
 	}
 
@@ -217,15 +269,24 @@ func (f *GitFetcher) checkout(repo *git.Repository, ref *Reference) error {
 			Force: true,
 		})
 		if err == nil {
-			return nil
+			return hash, nil
 		}
 	}
 
-	return &FetchError{
+	return plumbing.ZeroHash, &FetchError{
 		Ref:     ref,
 		Message: fmt.Sprintf("version %q not found (tried as tag, branch, and commit)", ref.Version),
 		Err:     ErrVersionNotFound,
 	}
+}
+
+// resolveHEAD returns the commit hash that HEAD currently points to.
+func resolveHEAD(repo *git.Repository) (plumbing.Hash, error) {
+	head, err := repo.Head()
+	if err != nil {
+		return plumbing.ZeroHash, fmt.Errorf("resolve HEAD: %w", err)
+	}
+	return head.Hash(), nil
 }
 
 // wrapCloneError wraps clone errors with helpful messages.
@@ -320,9 +381,16 @@ func looksLikeCommitSHA(s string) bool {
 	return true
 }
 
+// FetchResult contains the result of a fetch operation.
+type FetchResult struct {
+	Path      string // Local filesystem path to template
+	CommitSHA string // Resolved git commit SHA (empty for zip/local)
+	Version   string // Tag/branch/commit ref used
+}
+
 // Fetcher is the interface for all fetchers.
 type Fetcher interface {
-	Fetch(ctx context.Context, ref *Reference) (path string, err error)
+	Fetch(ctx context.Context, ref *Reference) (*FetchResult, error)
 }
 
 // Ensure GitFetcher implements Fetcher.

--- a/internal/remote/git_test.go
+++ b/internal/remote/git_test.go
@@ -31,8 +31,9 @@ func TestUT_GitFetcher_FetchWrongType(t *testing.T) {
 		URL:  "https://example.com/template.zip",
 	}
 
-	_, err := fetcher.Fetch(context.Background(), ref)
+	result, err := fetcher.Fetch(context.Background(), ref)
 	require.Error(t, err)
+	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "not a Git reference")
 }
 
@@ -110,6 +111,41 @@ func TestUT_CleanupTempDir_SafetyCheck(t *testing.T) {
 	assert.True(t, os.IsNotExist(err))
 }
 
+func TestUT_GitFetcher_FetchAtCommit_InvalidSHA(t *testing.T) {
+	fetcher := NewGitFetcher(nil)
+	ctx := context.Background()
+
+	tests := []struct {
+		name string
+		sha  string
+	}{
+		{"empty", ""},
+		{"too short", "abc1234"},
+		{"short but valid hex", "abc123def456789012345678901234567890abc"}, // 39 chars
+		{"non-hex chars", "xyz123def456789012345678901234567890abcd"},      // 40 but invalid
+		{"41 chars", "abc123def456789012345678901234567890abcde"},          // too long
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := fetcher.FetchAtCommit(ctx, "https://github.com/user/repo.git", tt.sha, t.TempDir())
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid commit SHA")
+		})
+	}
+}
+
+func TestUT_GitFetcher_FetchAtCommit_ValidSHAFormat(t *testing.T) {
+	fetcher := NewGitFetcher(nil)
+
+	// Valid 40-char hex should pass validation (will fail on clone, but proves validation passes)
+	validSHA := "abc123def456789012345678901234567890abcd"
+	_, err := fetcher.FetchAtCommit(context.Background(), "https://invalid-host-for-test.example/repo.git", validSHA, t.TempDir())
+	require.Error(t, err)
+	// Error should be from clone, not from SHA validation
+	assert.NotContains(t, err.Error(), "invalid commit SHA")
+}
+
 func TestUT_GitFetcher_SubPathValidation(t *testing.T) {
 	// This test verifies the subpath logic without actually cloning
 	// We create a fake repo directory structure and verify path resolution
@@ -157,23 +193,26 @@ func TestIT_GitFetcher_PublicGitHubRepo(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	path, err := fetcher.Fetch(ctx, ref)
+	result, err := fetcher.Fetch(ctx, ref)
 	if err != nil {
 		// Network errors are acceptable in CI
 		t.Logf("Clone failed (may be network issue): %v", err)
 		t.Skip("skipping due to network error")
 	}
 
-	defer func() { _ = CleanupTempDir(path) }()
+	defer func() { _ = CleanupTempDir(result.Path) }()
 
 	// Verify we got something
-	info, err := os.Stat(path)
+	info, err := os.Stat(result.Path)
 	require.NoError(t, err)
 	assert.True(t, info.IsDir())
 
 	// Verify README exists (known file in that repo)
-	_, err = os.Stat(filepath.Join(path, "README"))
+	_, err = os.Stat(filepath.Join(result.Path, "README"))
 	assert.NoError(t, err)
+
+	// Verify commit SHA is populated for git sources
+	assert.NotEmpty(t, result.CommitSHA, "commit SHA should be populated for git repos")
 }
 
 // --- Unit Tests for sanitizeErrorMessage ---

--- a/internal/remote/remote.go
+++ b/internal/remote/remote.go
@@ -49,18 +49,18 @@ func NewResolverWithOptions(cacheDir string, auth AuthProvider) (*Resolver, erro
 	}, nil
 }
 
-// Resolve takes a template reference string and returns a local path.
-// This is the main entry point for remote template resolution.
-func (r *Resolver) Resolve(ctx context.Context, input string, opts ResolveOptions) (string, error) {
+// Resolve takes a template reference string and returns a FetchResult containing
+// the local path and, for git sources, the resolved commit SHA.
+func (r *Resolver) Resolve(ctx context.Context, input string, opts ResolveOptions) (*FetchResult, error) {
 	// 1. Parse the reference
 	ref, err := Parse(input)
 	if err != nil {
-		return "", fmt.Errorf("invalid template reference: %w", err)
+		return nil, fmt.Errorf("invalid template reference: %w", err)
 	}
 
 	// 2. If local directory, just return the path
 	if ref.Type == ReferenceTypeLocal && !isZipFile(ref.URL) {
-		return ref.URL, nil
+		return &FetchResult{Path: ref.URL}, nil
 	}
 
 	// For local zip files, we still need to extract them
@@ -76,15 +76,14 @@ func (r *Resolver) Resolve(ctx context.Context, input string, opts ResolveOption
 	cacheKey := ref.CacheKey()
 	skipCache := opts.ForceUpdate || ref.Version == ""
 	if !skipCache {
-		if path, found, err := r.cache.Get(cacheKey); err == nil && found { //nolint:govet // shadow in if-init is idiomatic
-			// Apply subpath to cached path
-			return r.applySubPath(path, ref.SubPath)
+		if result, ok := r.tryCache(cacheKey, ref); ok {
+			return result, nil
 		}
 	}
 
 	// 4. If offline mode, fail
 	if opts.Offline {
-		return "", &FetchError{
+		return nil, &FetchError{
 			Ref:     ref,
 			Message: "not cached and offline mode is enabled",
 			Err:     ErrNotCached,
@@ -94,15 +93,18 @@ func (r *Resolver) Resolve(ctx context.Context, input string, opts ResolveOption
 	// 5. Fetch using appropriate fetcher
 	fetcher, ok := r.fetchers[ref.Type]
 	if !ok {
-		return "", &FetchError{
+		return nil, &FetchError{
 			Ref:     ref,
 			Message: fmt.Sprintf("unsupported reference type: %s", ref.Type),
 		}
 	}
 
-	tempPath, err := fetcher.Fetch(ctx, ref)
+	fetchResult, err := fetcher.Fetch(ctx, ref)
 	if err != nil {
-		return "", err
+		return nil, err
+	}
+	if fetchResult == nil {
+		return nil, &FetchError{Ref: ref, Message: "fetcher returned nil result"}
 	}
 
 	// 6. Store in cache
@@ -110,17 +112,18 @@ func (r *Resolver) Resolve(ctx context.Context, input string, opts ResolveOption
 		OriginalRef: ref.Original,
 		ResolvedURL: ref.URL,
 		Version:     ref.Version,
+		CommitSHA:   fetchResult.CommitSHA,
 		FetchedAt:   time.Now(),
 	}
 
-	cachedPath, err := r.cache.Set(cacheKey, tempPath, meta)
+	cachedPath, err := r.cache.Set(cacheKey, fetchResult.Path, meta)
 	if err != nil {
 		slog.Warn("could not cache template", "ref", ref.Original, "error", err)
-		return tempPath, nil
+		return fetchResult, nil
 	}
 
 	// 7. Clean up temp directory (ignore error - best effort)
-	_ = CleanupTempDir(tempPath)
+	_ = CleanupTempDir(fetchResult.Path)
 
 	// 8. Opportunistic cleanup of expired cache entries
 	if fsCache, ok := r.cache.(*FSCache); ok {
@@ -129,15 +132,41 @@ func (r *Resolver) Resolve(ctx context.Context, input string, opts ResolveOption
 		}
 	}
 
-	// 9. Return cached path (subpath is already in the cached content)
-	return cachedPath, nil
+	// 9. Return cached path with commit SHA
+	return &FetchResult{
+		Path:      cachedPath,
+		CommitSHA: fetchResult.CommitSHA,
+		Version:   fetchResult.Version,
+	}, nil
+}
+
+// tryCache attempts to return a cached result for the given key.
+// Returns the FetchResult and true if a valid cache entry was found.
+func (r *Resolver) tryCache(cacheKey string, ref *Reference) (*FetchResult, bool) {
+	path, found, err := r.cache.Get(cacheKey)
+	if err != nil || !found {
+		return nil, false
+	}
+
+	resolvedPath, subErr := r.applySubPath(path, ref.SubPath)
+	if subErr != nil {
+		return nil, false
+	}
+
+	result := &FetchResult{Path: resolvedPath, Version: ref.Version}
+	if fsCache, ok := r.cache.(*FSCache); ok {
+		if meta, metaErr := fsCache.readMeta(cacheKey); metaErr == nil {
+			result.CommitSHA = meta.CommitSHA
+		}
+	}
+	return result, true
 }
 
 // fetchAndReturn fetches without caching (for local zip files).
-func (r *Resolver) fetchAndReturn(ctx context.Context, ref *Reference) (string, error) {
+func (r *Resolver) fetchAndReturn(ctx context.Context, ref *Reference) (*FetchResult, error) {
 	fetcher, ok := r.fetchers[ref.Type]
 	if !ok {
-		return "", &FetchError{
+		return nil, &FetchError{
 			Ref:     ref,
 			Message: fmt.Sprintf("unsupported reference type: %s", ref.Type),
 		}

--- a/internal/remote/remote_test.go
+++ b/internal/remote/remote_test.go
@@ -35,11 +35,13 @@ func TestUT_Resolver_ResolveLocalDir(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	path, err := resolver.Resolve(ctx, templateDir, ResolveOptions{})
+	result, err := resolver.Resolve(ctx, templateDir, ResolveOptions{})
 	require.NoError(t, err)
 
 	// Should return the same path (local dirs don't get cached)
-	assert.Equal(t, templateDir, path)
+	assert.Equal(t, templateDir, result.Path)
+	// Local dirs have no commit SHA
+	assert.Empty(t, result.CommitSHA)
 }
 
 func TestUT_Resolver_ResolveLocalZip(t *testing.T) {
@@ -56,16 +58,19 @@ func TestUT_Resolver_ResolveLocalZip(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	path, err := resolver.Resolve(ctx, zipPath, ResolveOptions{})
+	result, err := resolver.Resolve(ctx, zipPath, ResolveOptions{})
 	require.NoError(t, err)
-	defer os.RemoveAll(path)
+	defer os.RemoveAll(result.Path)
 
 	// Should be extracted to a temp directory
-	assert.NotEqual(t, zipPath, path)
+	assert.NotEqual(t, zipPath, result.Path)
 
 	// Verify content was extracted
-	_, err = os.Stat(filepath.Join(path, "tag.template.json"))
+	_, err = os.Stat(filepath.Join(result.Path, "tag.template.json"))
 	assert.NoError(t, err)
+
+	// Zip sources have no commit SHA
+	assert.Empty(t, result.CommitSHA)
 }
 
 func TestUT_Resolver_CacheHit(t *testing.T) {
@@ -81,11 +86,12 @@ func TestUT_Resolver_CacheHit(t *testing.T) {
 	require.NoError(t, os.MkdirAll(srcDir, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "tag.template.json"), []byte(`{}`), 0o644))
 
-	// Cache it under the pinned key
+	// Cache it under the pinned key with a commit SHA
 	_, err = cache.Set("gh_user_repo@v1.0.0", srcDir, &CacheMeta{
 		OriginalRef: "gh:user/repo@v1.0.0",
 		FetchedAt:   time.Now(),
 		Version:     "v1.0.0",
+		CommitSHA:   "abc123def456789012345678901234567890abcd",
 	})
 	require.NoError(t, err)
 
@@ -95,19 +101,60 @@ func TestUT_Resolver_CacheHit(t *testing.T) {
 
 	// Mock fetcher that should NOT be called for a pinned ref
 	mockFetcher := &mockFetcher{
-		fetchFunc: func(ctx context.Context, ref *Reference) (string, error) {
+		fetchFunc: func(_ context.Context, _ *Reference) (*FetchResult, error) {
 			t.Fatal("Fetcher should not be called for pinned cache hit")
-			return "", nil
+			return nil, nil //nolint:nilnil // unreachable after t.Fatal
 		},
 	}
 	resolver.fetchers[ReferenceTypeGit] = mockFetcher
 
 	// Resolve pinned ref - should hit cache
 	ctx := context.Background()
-	path, err := resolver.Resolve(ctx, "gh:user/repo@v1.0.0", ResolveOptions{})
+	result, err := resolver.Resolve(ctx, "gh:user/repo@v1.0.0", ResolveOptions{})
 	require.NoError(t, err)
 
-	assert.Equal(t, filepath.Join(cacheDir, "gh_user_repo@v1.0.0"), path)
+	assert.Equal(t, filepath.Join(cacheDir, "gh_user_repo@v1.0.0"), result.Path)
+	assert.Equal(t, "abc123def456789012345678901234567890abcd", result.CommitSHA)
+	assert.Equal(t, "v1.0.0", result.Version)
+}
+
+func TestUT_Resolver_CacheHit_BackwardCompatMeta(t *testing.T) {
+	tmpDir := t.TempDir()
+	cacheDir := filepath.Join(tmpDir, "cache")
+
+	// Pre-populate cache with old-style meta (no commit_sha field)
+	cache, err := NewFSCache(cacheDir)
+	require.NoError(t, err)
+
+	srcDir := filepath.Join(tmpDir, "src")
+	require.NoError(t, os.MkdirAll(srcDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "tag.template.json"), []byte(`{}`), 0o644))
+
+	_, err = cache.Set("gh_user_repo@v1.0.0", srcDir, &CacheMeta{
+		OriginalRef: "gh:user/repo@v1.0.0",
+		FetchedAt:   time.Now(),
+		Version:     "v1.0.0",
+		// No CommitSHA — simulates old cache entries
+	})
+	require.NoError(t, err)
+
+	resolver, err := NewResolverWithOptions(cacheDir, nil)
+	require.NoError(t, err)
+
+	mockFetcher := &mockFetcher{
+		fetchFunc: func(_ context.Context, _ *Reference) (*FetchResult, error) {
+			t.Fatal("Fetcher should not be called for pinned cache hit")
+			return nil, nil //nolint:nilnil // unreachable after t.Fatal
+		},
+	}
+	resolver.fetchers[ReferenceTypeGit] = mockFetcher
+
+	ctx := context.Background()
+	result, err := resolver.Resolve(ctx, "gh:user/repo@v1.0.0", ResolveOptions{})
+	require.NoError(t, err)
+
+	assert.Equal(t, filepath.Join(cacheDir, "gh_user_repo@v1.0.0"), result.Path)
+	assert.Empty(t, result.CommitSHA, "old cache entries should deserialize with empty CommitSHA")
 }
 
 func TestUT_Resolver_FloatingRefAlwaysFetches(t *testing.T) {
@@ -137,9 +184,9 @@ func TestUT_Resolver_FloatingRefAlwaysFetches(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(newContent, "tag.template.json"), []byte(`{}`), 0o644))
 
 	mockFetcher := &mockFetcher{
-		fetchFunc: func(ctx context.Context, ref *Reference) (string, error) {
+		fetchFunc: func(_ context.Context, _ *Reference) (*FetchResult, error) {
 			fetchCalled = true
-			return newContent, nil
+			return &FetchResult{Path: newContent, CommitSHA: "abc123"}, nil
 		},
 	}
 	resolver.fetchers[ReferenceTypeGit] = mockFetcher
@@ -181,9 +228,9 @@ func TestUT_Resolver_ForceUpdate(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(newContent, "file.txt"), []byte("new"), 0o644))
 
 	mockFetcher := &mockFetcher{
-		fetchFunc: func(ctx context.Context, ref *Reference) (string, error) {
+		fetchFunc: func(_ context.Context, _ *Reference) (*FetchResult, error) {
 			fetchCalled = true
-			return newContent, nil
+			return &FetchResult{Path: newContent, CommitSHA: "def456"}, nil
 		},
 	}
 	resolver.fetchers[ReferenceTypeGit] = mockFetcher
@@ -277,14 +324,50 @@ func TestUT_IsLocal(t *testing.T) {
 	}
 }
 
-// mockFetcher is a test double for Fetcher
-type mockFetcher struct {
-	fetchFunc func(ctx context.Context, ref *Reference) (string, error)
+func TestUT_Resolver_CommitSHA_StoredInCache(t *testing.T) {
+	tmpDir := t.TempDir()
+	cacheDir := filepath.Join(tmpDir, "cache")
+
+	resolver, err := NewResolverWithOptions(cacheDir, nil)
+	require.NoError(t, err)
+
+	newContent := filepath.Join(tmpDir, "content")
+	require.NoError(t, os.MkdirAll(newContent, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(newContent, "file.txt"), []byte("data"), 0o644))
+
+	expectedSHA := "abc123def456789012345678901234567890abcd"
+	mockFetcher := &mockFetcher{
+		fetchFunc: func(_ context.Context, _ *Reference) (*FetchResult, error) {
+			return &FetchResult{
+				Path:      newContent,
+				CommitSHA: expectedSHA,
+				Version:   "v2.0.0",
+			}, nil
+		},
+	}
+	resolver.fetchers[ReferenceTypeGit] = mockFetcher
+
+	ctx := context.Background()
+	result, err := resolver.Resolve(ctx, "gh:user/repo@v2.0.0", ResolveOptions{})
+	require.NoError(t, err)
+
+	assert.Equal(t, expectedSHA, result.CommitSHA)
+
+	// Verify SHA is persisted in cache metadata
+	fsCache := resolver.cache.(*FSCache)
+	meta, err := fsCache.readMeta("gh_user_repo@v2.0.0")
+	require.NoError(t, err)
+	assert.Equal(t, expectedSHA, meta.CommitSHA)
 }
 
-func (m *mockFetcher) Fetch(ctx context.Context, ref *Reference) (string, error) {
+// mockFetcher is a test double for Fetcher
+type mockFetcher struct {
+	fetchFunc func(ctx context.Context, ref *Reference) (*FetchResult, error)
+}
+
+func (m *mockFetcher) Fetch(ctx context.Context, ref *Reference) (*FetchResult, error) {
 	if m.fetchFunc != nil {
 		return m.fetchFunc(ctx, ref)
 	}
-	return "", nil
+	return &FetchResult{}, nil
 }

--- a/internal/remote/zip.go
+++ b/internal/remote/zip.go
@@ -49,9 +49,10 @@ func NewZipFetcher() *ZipFetcher {
 
 // Fetch downloads (if remote) and extracts the zip file.
 // Returns the path to the extracted template directory.
-func (f *ZipFetcher) Fetch(ctx context.Context, ref *Reference) (string, error) {
+// CommitSHA is always empty for zip sources.
+func (f *ZipFetcher) Fetch(ctx context.Context, ref *Reference) (*FetchResult, error) {
 	if ref.Type != ReferenceTypeZip {
-		return "", &FetchError{Ref: ref, Message: "not a Zip reference"}
+		return nil, &FetchError{Ref: ref, Message: "not a Zip reference"}
 	}
 
 	// Determine if remote or local
@@ -60,7 +61,7 @@ func (f *ZipFetcher) Fetch(ctx context.Context, ref *Reference) (string, error) 
 
 	// Security: reject insecure HTTP URLs for remote downloads
 	if strings.HasPrefix(urlLower, "http://") {
-		return "", &FetchError{
+		return nil, &FetchError{
 			Ref:     ref,
 			Message: "insecure HTTP URL rejected; use HTTPS instead",
 		}
@@ -75,7 +76,7 @@ func (f *ZipFetcher) Fetch(ctx context.Context, ref *Reference) (string, error) 
 		f.writeStatus("Downloading template...")
 		zipPath, err = f.download(ctx, ref.URL)
 		if err != nil {
-			return "", &FetchError{Ref: ref, Message: "download failed", Err: err}
+			return nil, &FetchError{Ref: ref, Message: "download failed", Err: err}
 		}
 		tmpZip = true
 	} else {
@@ -89,7 +90,7 @@ func (f *ZipFetcher) Fetch(ctx context.Context, ref *Reference) (string, error) 
 		if tmpZip {
 			os.Remove(zipPath)
 		}
-		return "", &FetchError{Ref: ref, Message: "cannot create temp directory", Err: err}
+		return nil, &FetchError{Ref: ref, Message: "cannot create temp directory", Err: err}
 	}
 
 	// Clean up on error
@@ -106,13 +107,13 @@ func (f *ZipFetcher) Fetch(ctx context.Context, ref *Reference) (string, error) 
 	// Extract zip
 	f.writeStatus("Extracting template...")
 	if err := f.extract(zipPath, tmpDir); err != nil { //nolint:govet // shadow in if-init is idiomatic
-		return "", &FetchError{Ref: ref, Message: "extraction failed", Err: err}
+		return nil, &FetchError{Ref: ref, Message: "extraction failed", Err: err}
 	}
 
 	// Handle single root directory (unwrap if needed)
 	resultPath, err := f.unwrapSingleRoot(tmpDir)
 	if err != nil {
-		return "", &FetchError{Ref: ref, Message: "cannot unwrap root", Err: err}
+		return nil, &FetchError{Ref: ref, Message: "cannot unwrap root", Err: err}
 	}
 
 	// Apply subpath if specified
@@ -121,16 +122,16 @@ func (f *ZipFetcher) Fetch(ctx context.Context, ref *Reference) (string, error) 
 		info, err := os.Stat(resultPath)
 		if err != nil {
 			if os.IsNotExist(err) {
-				return "", &FetchError{
+				return nil, &FetchError{
 					Ref:     ref,
 					Message: fmt.Sprintf("subpath %q not found in archive", ref.SubPath),
 					Err:     ErrSubPathNotFound,
 				}
 			}
-			return "", &FetchError{Ref: ref, Message: "cannot access subpath", Err: err}
+			return nil, &FetchError{Ref: ref, Message: "cannot access subpath", Err: err}
 		}
 		if !info.IsDir() {
-			return "", &FetchError{
+			return nil, &FetchError{
 				Ref:     ref,
 				Message: fmt.Sprintf("subpath %q is not a directory", ref.SubPath),
 			}
@@ -139,7 +140,10 @@ func (f *ZipFetcher) Fetch(ctx context.Context, ref *Reference) (string, error) 
 
 	f.writeStatus("") // Clear status line
 	success = true
-	return resultPath, nil
+	return &FetchResult{
+		Path:    resultPath,
+		Version: ref.Version,
+	}, nil
 }
 
 // download fetches a remote zip file to a temporary location.

--- a/internal/remote/zip_test.go
+++ b/internal/remote/zip_test.go
@@ -81,8 +81,9 @@ func TestUT_ZipFetcher_FetchWrongType(t *testing.T) {
 		URL:  "https://github.com/user/repo.git",
 	}
 
-	_, err := fetcher.Fetch(context.Background(), ref)
+	result, err := fetcher.Fetch(context.Background(), ref)
 	require.Error(t, err)
+	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "not a Zip reference")
 }
 
@@ -105,18 +106,21 @@ func TestUT_ZipFetcher_LocalZip(t *testing.T) {
 		URL:      zipPath,
 	}
 
-	path, err := fetcher.Fetch(context.Background(), ref)
+	result, err := fetcher.Fetch(context.Background(), ref)
 	require.NoError(t, err)
-	defer os.RemoveAll(path)
+	defer os.RemoveAll(result.Path)
 
 	// Verify extracted content
-	content, err := os.ReadFile(filepath.Join(path, "file.txt"))
+	content, err := os.ReadFile(filepath.Join(result.Path, "file.txt"))
 	require.NoError(t, err)
 	assert.Equal(t, "content", string(content))
 
-	nested, err := os.ReadFile(filepath.Join(path, "subdir", "nested.txt"))
+	nested, err := os.ReadFile(filepath.Join(result.Path, "subdir", "nested.txt"))
 	require.NoError(t, err)
 	assert.Equal(t, "nested content", string(nested))
+
+	// Zip sources should have empty commit SHA
+	assert.Empty(t, result.CommitSHA)
 }
 
 func TestUT_ZipFetcher_UnwrapSingleRoot(t *testing.T) {
@@ -137,17 +141,17 @@ func TestUT_ZipFetcher_UnwrapSingleRoot(t *testing.T) {
 		URL:      zipPath,
 	}
 
-	path, err := fetcher.Fetch(context.Background(), ref)
+	result, err := fetcher.Fetch(context.Background(), ref)
 	require.NoError(t, err)
-	defer os.RemoveAll(filepath.Dir(path)) // Clean up parent temp dir
+	defer os.RemoveAll(filepath.Dir(result.Path)) // Clean up parent temp dir
 
 	// Path should point to the unwrapped content
-	content, err := os.ReadFile(filepath.Join(path, "file.txt"))
+	content, err := os.ReadFile(filepath.Join(result.Path, "file.txt"))
 	require.NoError(t, err)
 	assert.Equal(t, "content", string(content))
 
 	// Verify we're in the unwrapped directory (my-template-main)
-	assert.True(t, filepath.Base(path) == "my-template-main")
+	assert.Equal(t, "my-template-main", filepath.Base(result.Path))
 }
 
 func TestUT_ZipFetcher_NoUnwrapMultipleRoots(t *testing.T) {
@@ -168,14 +172,14 @@ func TestUT_ZipFetcher_NoUnwrapMultipleRoots(t *testing.T) {
 		URL:      zipPath,
 	}
 
-	path, err := fetcher.Fetch(context.Background(), ref)
+	result, err := fetcher.Fetch(context.Background(), ref)
 	require.NoError(t, err)
-	defer os.RemoveAll(path)
+	defer os.RemoveAll(result.Path)
 
 	// Both files should be at root
-	_, err = os.Stat(filepath.Join(path, "file1.txt"))
+	_, err = os.Stat(filepath.Join(result.Path, "file1.txt"))
 	assert.NoError(t, err)
-	_, err = os.Stat(filepath.Join(path, "file2.txt"))
+	_, err = os.Stat(filepath.Join(result.Path, "file2.txt"))
 	assert.NoError(t, err)
 }
 
@@ -201,12 +205,12 @@ func TestUT_ZipFetcher_SubPath(t *testing.T) {
 		SubPath:  "templates/go",
 	}
 
-	path, err := fetcher.Fetch(context.Background(), ref)
+	result, err := fetcher.Fetch(context.Background(), ref)
 	require.NoError(t, err)
-	defer os.RemoveAll(filepath.Dir(filepath.Dir(filepath.Dir(path)))) // Clean up root temp dir
+	defer os.RemoveAll(filepath.Dir(filepath.Dir(filepath.Dir(result.Path)))) // Clean up root temp dir
 
 	// Should be in the subpath
-	content, err := os.ReadFile(filepath.Join(path, "main.go.tmpl"))
+	content, err := os.ReadFile(filepath.Join(result.Path, "main.go.tmpl"))
 	require.NoError(t, err)
 	assert.Equal(t, "package main", string(content))
 }
@@ -312,12 +316,12 @@ func TestUT_ZipFetcher_SkipsHiddenAndMacOS(t *testing.T) {
 		URL:      zipPath,
 	}
 
-	path, err := fetcher.Fetch(context.Background(), ref)
+	result, err := fetcher.Fetch(context.Background(), ref)
 	require.NoError(t, err)
-	defer os.RemoveAll(filepath.Dir(path))
+	defer os.RemoveAll(filepath.Dir(result.Path))
 
 	// Should unwrap to template/ since __MACOSX and .hidden are skipped
-	assert.Equal(t, "template", filepath.Base(path))
+	assert.Equal(t, "template", filepath.Base(result.Path))
 }
 
 func TestUT_ZipFetcher_RejectsHTTP(t *testing.T) {
@@ -354,7 +358,7 @@ func TestIT_ZipFetcher_RemoteDownload(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create HTTPS test server (HTTP is rejected by HTTPS enforcement)
-	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/zip")
 		_, _ = w.Write(zipContent)
 	}))
@@ -370,12 +374,12 @@ func TestIT_ZipFetcher_RemoteDownload(t *testing.T) {
 		URL:      server.URL + "/template.zip",
 	}
 
-	path, err := fetcher.Fetch(context.Background(), ref)
+	result, err := fetcher.Fetch(context.Background(), ref)
 	require.NoError(t, err)
-	defer os.RemoveAll(path)
+	defer os.RemoveAll(result.Path)
 
 	// Verify downloaded content
-	content, err := os.ReadFile(filepath.Join(path, "file.txt"))
+	content, err := os.ReadFile(filepath.Join(result.Path, "file.txt"))
 	require.NoError(t, err)
 	assert.Equal(t, "remote content", string(content))
 }
@@ -386,7 +390,7 @@ func TestIT_ZipFetcher_RemoteDownloadError(t *testing.T) {
 	}
 
 	// Create HTTPS test server that returns 404
-	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 	}))
 	defer server.Close()


### PR DESCRIPTION
## Summary

- Add `FetchResult` struct (`Path`, `CommitSHA`, `Version`) as the return type for `Fetcher.Fetch()` and `Resolver.Resolve()`, replacing bare string paths
- Store resolved git commit SHA in `CacheMeta` for persistence across cache hits
- Add `FetchAtCommit()` method on `GitFetcher` for checking out specific historical commits (full clone, required for 3-way merge in update system)
- Update all callers (`scaffold`, `info`, `library`, `convert`) to use the new `FetchResult.Path`
- Non-git sources (zip, local) gracefully return empty `CommitSHA`

## Security

- `FetchAtCommit` clone errors are sanitized via `sanitizeErrorMessage` to prevent credential leaks
- `FetchAtCommit` requires full 40-character SHA to avoid ambiguous short-SHA resolution
- Defensive nil check on fetcher results to prevent nil pointer panics from interface misuse

## Files Changed (12)

| File | Change |
|------|--------|
| `internal/remote/git.go` | `FetchResult` type, updated `Fetch`/`checkout`/`resolveHEAD`, new `FetchAtCommit` |
| `internal/remote/remote.go` | `Resolve` returns `*FetchResult`, cache hit reads SHA from meta, extracted `tryCache` |
| `internal/remote/cache.go` | `CommitSHA` field added to `CacheMeta` (backward-compatible via `omitempty`) |
| `internal/remote/zip.go` | `Fetch` returns `*FetchResult` with empty `CommitSHA` |
| `internal/commands/scaffold.go` | Caller updated to use `.Path` |
| `internal/commands/info.go` | Caller updated to use `.Path` |
| `internal/convert/cookiecutter.go` | Caller updated to use `.Path` |
| `internal/library/library.go` | `Resolver` interface + caller updated |
| Test files (4) | Mocks, assertions, and new tests for SHA resolution |

## Test plan

- [x] All existing unit tests pass with updated signatures
- [x] New `TestUT_Resolver_CacheHit` verifies SHA returned from cache metadata
- [x] New `TestUT_Resolver_CacheHit_BackwardCompatMeta` verifies old cache entries without SHA field
- [x] New `TestUT_Resolver_CommitSHA_StoredInCache` verifies SHA persisted in cache metadata
- [x] New `TestUT_GitFetcher_FetchAtCommit_InvalidSHA` verifies rejection of invalid/short SHAs
- [x] New `TestUT_GitFetcher_FetchAtCommit_ValidSHAFormat` verifies valid SHA passes validation
- [x] Integration test verifies commit SHA populated for git repos
- [x] `make lint` passes (0 issues)
- [x] `make test-unit` passes (all packages)

Closes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)