### PR TITLE
feat: add 3-way merge engine, ignore matcher, and conflict resolution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ main.go                         CLI entry point (urfave/cli/v2)
 ├── internal/remote/            Remote template resolution (git/zip/cache/auth)
 ├── internal/engine/            Code generation engine + template parsing
 ├── internal/library/           Template library management
-├── internal/templateupdate/    Historical template rendering for update/diff/check
+├── internal/templateupdate/    Historical rendering, 3-way merge engine, ignore matcher, conflict resolution
 ├── internal/parse/             Shared parsing utilities (meta-flag parser)
 ├── internal/config/            Config file loading and validation
 ├── internal/validate/          Input name validation

--- a/internal/templateupdate/conflict.go
+++ b/internal/templateupdate/conflict.go
@@ -1,0 +1,287 @@
+package templateupdate
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/kaikenlabs/tag/internal/types"
+)
+
+// ConflictReport summarises the outcome of a tree merge for display and
+// downstream processing.
+type ConflictReport struct {
+	// Conflicts lists files that could not be cleanly merged.
+	Conflicts []ConflictedFile
+	// Clean lists files that were merged or updated without conflicts.
+	Clean []MergeResult
+	// Prompts lists files that need an explicit user decision.
+	Prompts []MergeResult
+	// Skipped lists paths excluded by ignore patterns.
+	Skipped []string
+}
+
+// ConflictedFile provides details about a single conflicted file.
+type ConflictedFile struct {
+	Path          string
+	MarkerCount   int
+	BaseContent   []byte
+	OursContent   []byte
+	TheirsContent []byte
+	MergedContent []byte
+	Mode          os.FileMode
+}
+
+// HasConflicts reports whether any files have unresolved conflicts or prompts.
+func (r *ConflictReport) HasConflicts() bool {
+	return len(r.Conflicts) > 0 || len(r.Prompts) > 0
+}
+
+// NewConflictReport builds a ConflictReport from merge results and skipped paths.
+func NewConflictReport(results []MergeResult, skipped []string) *ConflictReport {
+	report := &ConflictReport{
+		Skipped: skipped,
+	}
+
+	for _, mr := range results {
+		switch {
+		case mr.Op == MergeConflict || mr.Conflicted:
+			report.Conflicts = append(report.Conflicts, ConflictedFile{
+				Path:          mr.Path,
+				MarkerCount:   countConflictMarkers(mr.Content),
+				BaseContent:   mr.BaseContent,
+				OursContent:   mr.OursContent,
+				TheirsContent: mr.TheirsContent,
+				MergedContent: mr.Content,
+				Mode:          mr.Mode,
+			})
+		case mr.Op == MergePrompt:
+			report.Prompts = append(report.Prompts, mr)
+		default:
+			report.Clean = append(report.Clean, mr)
+		}
+	}
+
+	return report
+}
+
+// countConflictMarkers counts the number of conflict regions by looking for
+// the opening marker pattern.
+func countConflictMarkers(content []byte) int {
+	return bytes.Count(content, []byte("<<<<<<< "))
+}
+
+// ResolveMode specifies how to auto-resolve conflicts.
+type ResolveMode int
+
+const (
+	// ResolveNone does not auto-resolve; conflict markers remain.
+	ResolveNone ResolveMode = iota
+	// ResolveOurs replaces conflicted content with the user's version.
+	ResolveOurs
+	// ResolveTheirs replaces conflicted content with the template's version.
+	ResolveTheirs
+)
+
+// ResolveConflicts applies the given resolution mode to all conflicts in the
+// report and returns a new set of clean MergeResults. Only conflicted files
+// are affected; clean and prompt results are unchanged.
+func ResolveConflicts(report *ConflictReport, mode ResolveMode) []MergeResult {
+	if mode == ResolveNone {
+		return nil
+	}
+
+	resolved := make([]MergeResult, 0, len(report.Conflicts))
+	for _, cf := range report.Conflicts {
+		var content []byte
+		switch mode {
+		case ResolveOurs:
+			content = cf.OursContent
+		case ResolveTheirs:
+			content = cf.TheirsContent
+		}
+
+		resolved = append(resolved, MergeResult{
+			Path:    cf.Path,
+			Op:      MergeUpdate,
+			Content: content,
+			Mode:    cf.Mode,
+		})
+	}
+
+	return resolved
+}
+
+// ConflictStatus is persisted to .tag/conflicts.json when an update leaves
+// unresolved conflicts. It allows resumption with --continue or --abort.
+type ConflictStatus struct {
+	SchemaVersion   int       `json:"schema_version"`
+	UpdateCommit    string    `json:"update_commit"`
+	ConflictedFiles []string  `json:"conflicted_files"`
+	PromptFiles     []string  `json:"prompt_files,omitempty"`
+	ResolvedFiles   []string  `json:"resolved_files"`
+	StartedAt       time.Time `json:"started_at"`
+}
+
+// conflictStatusVersion is the schema version for conflicts.json.
+const conflictStatusVersion = 1
+
+// NewConflictStatus creates a ConflictStatus from a ConflictReport.
+func NewConflictStatus(report *ConflictReport, updateCommit string) *ConflictStatus {
+	conflicted := make([]string, 0, len(report.Conflicts))
+	for _, c := range report.Conflicts {
+		conflicted = append(conflicted, c.Path)
+	}
+
+	prompts := make([]string, 0, len(report.Prompts))
+	for _, p := range report.Prompts {
+		prompts = append(prompts, p.Path)
+	}
+
+	return &ConflictStatus{
+		SchemaVersion:   conflictStatusVersion,
+		UpdateCommit:    updateCommit,
+		ConflictedFiles: conflicted,
+		PromptFiles:     prompts,
+		ResolvedFiles:   []string{},
+		StartedAt:       time.Now(),
+	}
+}
+
+// WriteConflictStatus atomically writes the conflict status file to
+// <projectRoot>/.tag/conflicts.json.
+func WriteConflictStatus(projectRoot string, status *ConflictStatus) error {
+	tagDir := filepath.Join(projectRoot, types.TemplatesDir)
+	if err := os.MkdirAll(tagDir, 0o755); err != nil {
+		return fmt.Errorf("create %s directory: %w", types.TemplatesDir, err)
+	}
+
+	data, err := json.MarshalIndent(status, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal conflict status: %w", err)
+	}
+	data = append(data, '\n')
+
+	target := filepath.Join(tagDir, "conflicts.json")
+	tmp := target + ".tmp"
+
+	f, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		_ = os.Remove(tmp)
+		return fmt.Errorf("write temp file: %w", err)
+	}
+
+	if err := f.Sync(); err != nil {
+		f.Close()
+		_ = os.Remove(tmp)
+		return fmt.Errorf("sync temp file: %w", err)
+	}
+	f.Close()
+
+	if err := os.Rename(tmp, target); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("rename temp file: %w", err)
+	}
+
+	return nil
+}
+
+// ReadConflictStatus reads the conflict status from
+// <projectRoot>/.tag/conflicts.json. Returns nil if the file does not exist.
+func ReadConflictStatus(projectRoot string) (*ConflictStatus, error) {
+	data, err := os.ReadFile(filepath.Join(projectRoot, types.TemplatesDir, "conflicts.json"))
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil //nolint:nilnil // nil,nil is the documented API for "not found"
+		}
+		return nil, fmt.Errorf("read conflict status: %w", err)
+	}
+
+	var status ConflictStatus
+	if err := json.Unmarshal(data, &status); err != nil {
+		return nil, fmt.Errorf("parse conflict status: %w", err)
+	}
+
+	return &status, nil
+}
+
+// ClearConflictStatus removes the conflict status file.
+func ClearConflictStatus(projectRoot string) error {
+	path := filepath.Join(projectRoot, types.TemplatesDir, "conflicts.json")
+	if err := os.Remove(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("remove conflict status: %w", err)
+	}
+	return nil
+}
+
+// FormatConflictSummary writes a human-readable conflict summary to the given
+// writer. This is intended for stderr output.
+func FormatConflictSummary(w io.Writer, report *ConflictReport) {
+	total := len(report.Conflicts) + len(report.Prompts)
+	if total == 0 {
+		return
+	}
+
+	fmt.Fprintf(w, "\n⚠ %d conflict(s) found during template update:\n\n", total)
+
+	for _, c := range report.Conflicts {
+		fmt.Fprintf(w, "  CONFLICT  %s (%d region(s))\n", c.Path, c.MarkerCount)
+	}
+	for _, p := range report.Prompts {
+		fmt.Fprintf(w, "  PROMPT    %s (%s)\n", p.Path, p.PromptReason)
+	}
+
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Resolve conflicts manually, then run: tag update --continue")
+	fmt.Fprintln(w, "Or abort with: tag update --abort")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "To auto-resolve: tag update --accept-ours | --accept-theirs")
+}
+
+// FormatCleanSummary writes a success summary to the given writer.
+func FormatCleanSummary(w io.Writer, report *ConflictReport) {
+	var added, updated, deleted int
+	for _, r := range report.Clean {
+		switch r.Op {
+		case MergeAdd:
+			added++
+		case MergeUpdate:
+			updated++
+		case MergeDelete:
+			deleted++
+		}
+	}
+
+	var parts []string
+	if added > 0 {
+		parts = append(parts, fmt.Sprintf("%d added", added))
+	}
+	if updated > 0 {
+		parts = append(parts, fmt.Sprintf("%d updated", updated))
+	}
+	if deleted > 0 {
+		parts = append(parts, fmt.Sprintf("%d deleted", deleted))
+	}
+	if len(report.Skipped) > 0 {
+		parts = append(parts, fmt.Sprintf("%d skipped", len(report.Skipped)))
+	}
+
+	if len(parts) == 0 {
+		fmt.Fprintln(w, "Template is already up to date.")
+		return
+	}
+
+	fmt.Fprintf(w, "Template updated successfully: %s.\n", strings.Join(parts, ", "))
+}

--- a/internal/templateupdate/conflict_test.go
+++ b/internal/templateupdate/conflict_test.go
@@ -1,0 +1,252 @@
+package templateupdate
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kaikenlabs/tag/internal/types"
+)
+
+func TestUT_ConflictReport_FromMergeResults(t *testing.T) {
+	t.Parallel()
+
+	results := []MergeResult{
+		{Path: "clean.go", Op: MergeUpdate, Content: []byte("ok")},
+		{Path: "conflict.go", Op: MergeConflict, Conflicted: true, Content: []byte("<<<<<<< x")},
+		{Path: "prompt.go", Op: MergePrompt, PromptReason: "user deleted"},
+		{Path: "keep.go", Op: MergeKeep},
+	}
+	skipped := []string{"ignored.log"}
+
+	report := NewConflictReport(results, skipped)
+
+	assert.Len(t, report.Clean, 2) // update + keep
+	assert.Len(t, report.Conflicts, 1)
+	assert.Len(t, report.Prompts, 1)
+	assert.Equal(t, skipped, report.Skipped)
+	assert.True(t, report.HasConflicts())
+}
+
+func TestUT_ConflictReport_NoConflicts(t *testing.T) {
+	t.Parallel()
+
+	results := []MergeResult{
+		{Path: "a.go", Op: MergeUpdate},
+		{Path: "b.go", Op: MergeKeep},
+	}
+
+	report := NewConflictReport(results, nil)
+	assert.False(t, report.HasConflicts())
+}
+
+func TestUT_ConflictReport_CountRegions(t *testing.T) {
+	t.Parallel()
+
+	content := []byte("<<<<<<< LOCAL\nours\n||||||| BASE\nbase\n=======\ntheirs\n>>>>>>> TEMPLATE\n" +
+		"middle\n<<<<<<< LOCAL\nours2\n=======\ntheirs2\n>>>>>>> TEMPLATE\n")
+
+	count := countConflictMarkers(content)
+	assert.Equal(t, 2, count)
+}
+
+func TestUT_AcceptOurs_ResolvesAllConflicts(t *testing.T) {
+	t.Parallel()
+
+	report := &ConflictReport{
+		Conflicts: []ConflictedFile{
+			{Path: "a.go", OursContent: []byte("ours-a"), TheirsContent: []byte("theirs-a"), Mode: 0o644},
+			{Path: "b.go", OursContent: []byte("ours-b"), TheirsContent: []byte("theirs-b"), Mode: 0o755},
+		},
+	}
+
+	resolved := ResolveConflicts(report, ResolveOurs)
+	require.Len(t, resolved, 2)
+
+	assert.Equal(t, "a.go", resolved[0].Path)
+	assert.Equal(t, []byte("ours-a"), resolved[0].Content)
+	assert.Equal(t, MergeUpdate, resolved[0].Op)
+
+	assert.Equal(t, "b.go", resolved[1].Path)
+	assert.Equal(t, []byte("ours-b"), resolved[1].Content)
+}
+
+func TestUT_AcceptTheirs_ResolvesAllConflicts(t *testing.T) {
+	t.Parallel()
+
+	report := &ConflictReport{
+		Conflicts: []ConflictedFile{
+			{Path: "a.go", OursContent: []byte("ours"), TheirsContent: []byte("theirs"), Mode: 0o644},
+		},
+	}
+
+	resolved := ResolveConflicts(report, ResolveTheirs)
+	require.Len(t, resolved, 1)
+	assert.Equal(t, []byte("theirs"), resolved[0].Content)
+}
+
+func TestUT_ResolveNone_ReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	report := &ConflictReport{
+		Conflicts: []ConflictedFile{{Path: "a.go"}},
+	}
+
+	resolved := ResolveConflicts(report, ResolveNone)
+	assert.Nil(t, resolved)
+}
+
+func TestUT_ConflictStatusFile_WriteAndRead(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	// Create .tag directory.
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, types.TemplatesDir), 0o755))
+
+	report := &ConflictReport{
+		Conflicts: []ConflictedFile{{Path: "a.go"}, {Path: "b.go"}},
+		Prompts:   []MergeResult{{Path: "c.go", Op: MergePrompt}},
+	}
+
+	status := NewConflictStatus(report, "abc123")
+	require.NoError(t, WriteConflictStatus(dir, status))
+
+	loaded, err := ReadConflictStatus(dir)
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+
+	assert.Equal(t, conflictStatusVersion, loaded.SchemaVersion)
+	assert.Equal(t, "abc123", loaded.UpdateCommit)
+	assert.Equal(t, []string{"a.go", "b.go"}, loaded.ConflictedFiles)
+	assert.Equal(t, []string{"c.go"}, loaded.PromptFiles)
+	assert.Empty(t, loaded.ResolvedFiles)
+	assert.False(t, loaded.StartedAt.IsZero())
+}
+
+func TestUT_ConflictStatusFile_ReadMissing(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	status, err := ReadConflictStatus(dir)
+	require.NoError(t, err)
+	assert.Nil(t, status)
+}
+
+func TestUT_ConflictStatusFile_Clear(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	tagDir := filepath.Join(dir, types.TemplatesDir)
+	require.NoError(t, os.MkdirAll(tagDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(tagDir, "conflicts.json"), []byte("{}"), 0o644))
+
+	require.NoError(t, ClearConflictStatus(dir))
+
+	_, err := os.Stat(filepath.Join(tagDir, "conflicts.json"))
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestUT_ConflictStatusFile_ClearMissing(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	// Should not error when file doesn't exist.
+	require.NoError(t, ClearConflictStatus(dir))
+}
+
+func TestUT_ConflictSummary_Format(t *testing.T) {
+	t.Parallel()
+
+	report := &ConflictReport{
+		Conflicts: []ConflictedFile{
+			{Path: "src/config.go", MarkerCount: 3},
+			{Path: "Makefile", MarkerCount: 1},
+		},
+		Prompts: []MergeResult{
+			{Path: "README.md", Op: MergePrompt, PromptReason: "user deleted"},
+		},
+	}
+
+	var buf bytes.Buffer
+	FormatConflictSummary(&buf, report)
+	output := buf.String()
+
+	assert.Contains(t, output, "3 conflict(s)")
+	assert.Contains(t, output, "CONFLICT  src/config.go (3 region(s))")
+	assert.Contains(t, output, "CONFLICT  Makefile (1 region(s))")
+	assert.Contains(t, output, "PROMPT    README.md")
+	assert.Contains(t, output, "tag update --continue")
+	assert.Contains(t, output, "--accept-ours")
+}
+
+func TestUT_ConflictSummary_NoConflicts(t *testing.T) {
+	t.Parallel()
+
+	report := &ConflictReport{}
+	var buf bytes.Buffer
+	FormatConflictSummary(&buf, report)
+	assert.Empty(t, buf.String())
+}
+
+func TestUT_CleanSummary_Format(t *testing.T) {
+	t.Parallel()
+
+	report := &ConflictReport{
+		Clean: []MergeResult{
+			{Op: MergeAdd},
+			{Op: MergeAdd},
+			{Op: MergeUpdate},
+			{Op: MergeDelete},
+		},
+		Skipped: []string{"a.log"},
+	}
+
+	var buf bytes.Buffer
+	FormatCleanSummary(&buf, report)
+	output := buf.String()
+
+	assert.Contains(t, output, "2 added")
+	assert.Contains(t, output, "1 updated")
+	assert.Contains(t, output, "1 deleted")
+	assert.Contains(t, output, "1 skipped")
+}
+
+func TestUT_CleanSummary_NoChanges(t *testing.T) {
+	t.Parallel()
+
+	report := &ConflictReport{
+		Clean: []MergeResult{
+			{Op: MergeKeep},
+		},
+	}
+
+	var buf bytes.Buffer
+	FormatCleanSummary(&buf, report)
+	assert.Contains(t, buf.String(), "up to date")
+}
+
+func TestUT_MergeOp_String(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		op   MergeOp
+		want string
+	}{
+		{MergeKeep, "keep"},
+		{MergeAdd, "add"},
+		{MergeDelete, "delete"},
+		{MergeUpdate, "update"},
+		{MergeConflict, "conflict"},
+		{MergeUserAdded, "user-added"},
+		{MergePrompt, "prompt"},
+		{MergeOp(99), "unknown"},
+	}
+
+	for _, tc := range tests {
+		assert.Equal(t, tc.want, tc.op.String())
+	}
+}

--- a/internal/templateupdate/ignore.go
+++ b/internal/templateupdate/ignore.go
@@ -1,0 +1,173 @@
+package templateupdate
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/go-git/go-git/v5/plumbing/format/gitignore"
+
+	"github.com/kaikenlabs/tag/internal/types"
+)
+
+// builtinIgnorePatterns are always excluded from template updates.
+var builtinIgnorePatterns = []string{
+	".git",
+	types.TemplatesDir,  // .tag
+	types.TagConfigFile, // .tagconfig.json
+}
+
+// IgnoreMatcher determines whether a file should be skipped during template
+// updates. It merges patterns from four sources in priority order:
+//
+//  1. Built-in defaults (lowest priority)
+//  2. .tagignore file (gitignore-style)
+//  3. .tagconfig.json skip_patterns
+//  4. CLI --skip flags (highest priority)
+//
+// All sources are combined into a single gitignore-style matcher. Because the
+// go-git matcher evaluates patterns in order and the last matching pattern wins,
+// we append sources from lowest to highest priority so that higher-priority
+// sources can override lower ones (including negation patterns).
+type IgnoreMatcher struct {
+	matcher gitignore.Matcher
+}
+
+// IgnoreMatcherOptions configures the pattern sources for an IgnoreMatcher.
+type IgnoreMatcherOptions struct {
+	// ProjectRoot is the path to the project directory. Used to read
+	// .tagignore and .tagconfig.json. May be empty if patterns are
+	// supplied directly.
+	ProjectRoot string
+
+	// TagignorePatterns are patterns parsed from a .tagignore file.
+	// If nil and ProjectRoot is set, patterns are loaded from the file.
+	TagignorePatterns []string
+
+	// TagconfigPatterns are patterns from .tagconfig.json skip_patterns.
+	// If nil and ProjectRoot is set, patterns are loaded from the file.
+	TagconfigPatterns []string
+
+	// CLIPatterns are patterns from --skip CLI flags.
+	CLIPatterns []string
+}
+
+// NewIgnoreMatcher creates an IgnoreMatcher by merging patterns from all
+// configured sources.
+func NewIgnoreMatcher(opts IgnoreMatcherOptions) (*IgnoreMatcher, error) {
+	var allPatterns []gitignore.Pattern
+
+	// 1. Built-in defaults (lowest priority).
+	for _, p := range builtinIgnorePatterns {
+		allPatterns = append(allPatterns, gitignore.ParsePattern(p, nil))
+	}
+
+	// 2. .tagignore patterns.
+	tagignore := opts.TagignorePatterns
+	if tagignore == nil && opts.ProjectRoot != "" {
+		loaded, err := loadTagignorePatterns(opts.ProjectRoot)
+		if err != nil {
+			return nil, fmt.Errorf("load .tagignore: %w", err)
+		}
+		tagignore = loaded
+	}
+	for _, p := range tagignore {
+		allPatterns = append(allPatterns, gitignore.ParsePattern(p, nil))
+	}
+
+	// 3. .tagconfig.json skip_patterns.
+	tagconfig := opts.TagconfigPatterns
+	if tagconfig == nil && opts.ProjectRoot != "" {
+		loaded, err := loadTagconfigSkipPatterns(opts.ProjectRoot)
+		if err != nil {
+			return nil, fmt.Errorf("load tagconfig skip_patterns: %w", err)
+		}
+		tagconfig = loaded
+	}
+	for _, p := range tagconfig {
+		allPatterns = append(allPatterns, gitignore.ParsePattern(p, nil))
+	}
+
+	// 4. CLI --skip flags (highest priority).
+	for _, p := range opts.CLIPatterns {
+		allPatterns = append(allPatterns, gitignore.ParsePattern(p, nil))
+	}
+
+	return &IgnoreMatcher{
+		matcher: gitignore.NewMatcher(allPatterns),
+	}, nil
+}
+
+// ShouldSkip reports whether the given relative path should be excluded from
+// template update operations.
+func (m *IgnoreMatcher) ShouldSkip(relPath string, isDir bool) bool {
+	components := strings.Split(filepath.ToSlash(relPath), "/")
+	return m.matcher.Match(components, isDir)
+}
+
+// loadTagignorePatterns reads pattern lines from a .tagignore file. Returns nil
+// (not an error) when the file does not exist.
+func loadTagignorePatterns(projectRoot string) ([]string, error) {
+	f, err := os.Open(filepath.Join(projectRoot, types.TagIgnoreFile))
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("open %s: %w", types.TagIgnoreFile, err)
+	}
+	defer f.Close()
+
+	return parseIgnoreLines(f)
+}
+
+// parseIgnoreLines reads gitignore-style lines from a reader, skipping blanks
+// and comments.
+func parseIgnoreLines(r io.Reader) ([]string, error) {
+	var patterns []string
+
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		patterns = append(patterns, line)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read patterns: %w", err)
+	}
+
+	return patterns, nil
+}
+
+// tagconfigPartial is the minimal structure needed to read skip_patterns from
+// .tagconfig.json.
+type tagconfigPartial struct {
+	SkipPatterns []string `json:"skip_patterns"`
+}
+
+// loadTagconfigSkipPatterns reads the skip_patterns array from .tagconfig.json.
+// Returns nil (not an error) when the file does not exist.
+func loadTagconfigSkipPatterns(projectRoot string) ([]string, error) {
+	data, err := os.ReadFile(filepath.Join(projectRoot, types.TagConfigFile))
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read %s: %w", types.TagConfigFile, err)
+	}
+
+	var cfg tagconfigPartial
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", types.TagConfigFile, err)
+	}
+
+	return cfg.SkipPatterns, nil
+}

--- a/internal/templateupdate/ignore_test.go
+++ b/internal/templateupdate/ignore_test.go
@@ -1,0 +1,175 @@
+package templateupdate
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kaikenlabs/tag/internal/types"
+)
+
+func TestUT_IgnoreMatcher_BuiltinDefaults(t *testing.T) {
+	t.Parallel()
+
+	m, err := NewIgnoreMatcher(IgnoreMatcherOptions{})
+	require.NoError(t, err)
+
+	assert.True(t, m.ShouldSkip(".git", true), ".git should be skipped")
+	assert.True(t, m.ShouldSkip(".git/config", false), ".git/config should be skipped")
+	assert.True(t, m.ShouldSkip(types.TemplatesDir, true), ".tag should be skipped")
+	assert.True(t, m.ShouldSkip(types.TagConfigFile, false), ".tagconfig.json should be skipped")
+	assert.False(t, m.ShouldSkip("src/main.go", false), "normal files should not be skipped")
+}
+
+func TestUT_IgnoreMatcher_TagignorePatterns(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeFile(t, dir, types.TagIgnoreFile, "# Comment\n\n*.log\nbuild/\n")
+
+	m, err := NewIgnoreMatcher(IgnoreMatcherOptions{ProjectRoot: dir})
+	require.NoError(t, err)
+
+	assert.True(t, m.ShouldSkip("app.log", false), "*.log should match")
+	assert.True(t, m.ShouldSkip("build", true), "build/ should match directory")
+	assert.False(t, m.ShouldSkip("src/main.go", false), "unmatched file should pass")
+}
+
+func TestUT_IgnoreMatcher_TagconfigSkipPatterns(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfg := tagconfigPartial{SkipPatterns: []string{"vendor/**", "*.generated.go"}}
+	data, err := json.Marshal(cfg)
+	require.NoError(t, err)
+	writeFile(t, dir, types.TagConfigFile, string(data))
+
+	m, err := NewIgnoreMatcher(IgnoreMatcherOptions{ProjectRoot: dir})
+	require.NoError(t, err)
+
+	assert.True(t, m.ShouldSkip("vendor/lib/foo.go", false), "vendor/** should match")
+	assert.True(t, m.ShouldSkip("models.generated.go", false), "*.generated.go should match")
+	assert.False(t, m.ShouldSkip("main.go", false))
+}
+
+func TestUT_IgnoreMatcher_CLIPatterns(t *testing.T) {
+	t.Parallel()
+
+	m, err := NewIgnoreMatcher(IgnoreMatcherOptions{
+		CLIPatterns: []string{"*.env", "secrets/**"},
+	})
+	require.NoError(t, err)
+
+	assert.True(t, m.ShouldSkip("prod.env", false))
+	assert.True(t, m.ShouldSkip("secrets/key.pem", false))
+	assert.False(t, m.ShouldSkip("config.yaml", false))
+}
+
+func TestUT_IgnoreMatcher_PriorityOrder(t *testing.T) {
+	t.Parallel()
+
+	// .tagignore excludes *.env, CLI re-includes it with negation.
+	m, err := NewIgnoreMatcher(IgnoreMatcherOptions{
+		TagignorePatterns: []string{"*.env"},
+		CLIPatterns:       []string{"!prod.env"},
+	})
+	require.NoError(t, err)
+
+	assert.False(t, m.ShouldSkip("prod.env", false), "CLI negation should override .tagignore")
+	assert.True(t, m.ShouldSkip("dev.env", false), "other .env files still excluded")
+}
+
+func TestUT_IgnoreMatcher_NegationPattern(t *testing.T) {
+	t.Parallel()
+
+	m, err := NewIgnoreMatcher(IgnoreMatcherOptions{
+		TagignorePatterns: []string{"docs/**", "!docs/README.md"},
+	})
+	require.NoError(t, err)
+
+	assert.True(t, m.ShouldSkip("docs/internal.md", false), "docs/** should be excluded")
+	assert.False(t, m.ShouldSkip("docs/README.md", false), "negation should re-include")
+}
+
+func TestUT_IgnoreMatcher_DoublestarGlob(t *testing.T) {
+	t.Parallel()
+
+	m, err := NewIgnoreMatcher(IgnoreMatcherOptions{
+		CLIPatterns: []string{"**/*.tmp"},
+	})
+	require.NoError(t, err)
+
+	assert.True(t, m.ShouldSkip("a/b/c/file.tmp", false))
+	assert.True(t, m.ShouldSkip("file.tmp", false))
+	assert.False(t, m.ShouldSkip("file.go", false))
+}
+
+func TestUT_IgnoreMatcher_EmptyPatterns(t *testing.T) {
+	t.Parallel()
+
+	m, err := NewIgnoreMatcher(IgnoreMatcherOptions{})
+	require.NoError(t, err)
+
+	// Only builtins should be skipped.
+	assert.True(t, m.ShouldSkip(".git", true))
+	assert.False(t, m.ShouldSkip("README.md", false))
+}
+
+func TestUT_IgnoreMatcher_NoTagignoreFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	// No .tagignore file — should not error.
+	m, err := NewIgnoreMatcher(IgnoreMatcherOptions{ProjectRoot: dir})
+	require.NoError(t, err)
+	assert.NotNil(t, m)
+}
+
+func TestUT_IgnoreMatcher_NoTagconfigFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	// No .tagconfig.json — should not error.
+	m, err := NewIgnoreMatcher(IgnoreMatcherOptions{ProjectRoot: dir})
+	require.NoError(t, err)
+	assert.NotNil(t, m)
+}
+
+func TestUT_IgnoreMatcher_MalformedTagconfig(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeFile(t, dir, types.TagConfigFile, "not json{{{")
+
+	_, err := NewIgnoreMatcher(IgnoreMatcherOptions{ProjectRoot: dir})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parse")
+}
+
+func TestUT_IgnoreMatcher_DirectSuppliedPatterns(t *testing.T) {
+	t.Parallel()
+
+	// When patterns are directly supplied, ProjectRoot is not needed.
+	m, err := NewIgnoreMatcher(IgnoreMatcherOptions{
+		TagignorePatterns: []string{"*.bak"},
+		TagconfigPatterns: []string{"dist/**"},
+		CLIPatterns:       []string{"*.tmp"},
+	})
+	require.NoError(t, err)
+
+	assert.True(t, m.ShouldSkip("old.bak", false))
+	assert.True(t, m.ShouldSkip("dist/bundle.js", false))
+	assert.True(t, m.ShouldSkip("scratch.tmp", false))
+}
+
+// writeFile is a test helper that creates a file in the given directory.
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+}

--- a/internal/templateupdate/merger.go
+++ b/internal/templateupdate/merger.go
@@ -1,0 +1,271 @@
+package templateupdate
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"sort"
+)
+
+// MergeEngine reconciles three file trees: base (old template render), ours
+// (user's current project), and theirs (new template render).
+type MergeEngine struct {
+	textMerger TextMerger
+	ignoreFn   func(path string) bool
+}
+
+// NewMergeEngine creates a MergeEngine with the given text merger and optional
+// ignore function. If ignoreFn is nil, no files are skipped.
+func NewMergeEngine(tm TextMerger, ignoreFn func(path string) bool) *MergeEngine {
+	return &MergeEngine{
+		textMerger: tm,
+		ignoreFn:   ignoreFn,
+	}
+}
+
+// MergeTrees merges three file trees and returns a sorted list of merge results
+// plus a list of skipped paths.
+func (m *MergeEngine) MergeTrees(
+	ctx context.Context,
+	base, ours, theirs map[string]*RenderedFile,
+) ([]MergeResult, []string, error) {
+	// Collect all unique paths.
+	paths := make(map[string]struct{})
+	for p := range base {
+		paths[p] = struct{}{}
+	}
+	for p := range ours {
+		paths[p] = struct{}{}
+	}
+	for p := range theirs {
+		paths[p] = struct{}{}
+	}
+
+	// Sort for deterministic output.
+	sorted := make([]string, 0, len(paths))
+	for p := range paths {
+		sorted = append(sorted, p)
+	}
+	sort.Strings(sorted)
+
+	var results []MergeResult
+	var skipped []string
+
+	for _, path := range sorted {
+		if m.ignoreFn != nil && m.ignoreFn(path) {
+			skipped = append(skipped, path)
+			continue
+		}
+
+		result, err := m.MergeFile(ctx, path, base[path], ours[path], theirs[path])
+		if err != nil {
+			return nil, nil, fmt.Errorf("merge %s: %w", path, err)
+		}
+		results = append(results, result)
+	}
+
+	return results, skipped, nil
+}
+
+// presenceKey encodes which of the three file versions exist as a 3-bit key.
+type presenceKey uint8
+
+const (
+	pBase   presenceKey = 0b100
+	pOurs   presenceKey = 0b010
+	pTheirs presenceKey = 0b001
+)
+
+// MergeFile merges a single file path across the three trees using the decision
+// matrix defined in the design document.
+func (m *MergeEngine) MergeFile(
+	ctx context.Context, path string, base, ours, theirs *RenderedFile,
+) (MergeResult, error) {
+	key := presenceKey(0)
+	if base != nil {
+		key |= pBase
+	}
+	if ours != nil {
+		key |= pOurs
+	}
+	if theirs != nil {
+		key |= pTheirs
+	}
+
+	return m.dispatchMerge(ctx, key, path, base, ours, theirs)
+}
+
+func (m *MergeEngine) dispatchMerge(
+	ctx context.Context, key presenceKey, path string, base, ours, theirs *RenderedFile,
+) (MergeResult, error) {
+	switch key {
+	case 0: // none
+		return MergeResult{Path: path, Op: MergeKeep}, nil
+	case pTheirs: // new file from template only
+		return mergeNewTemplateFile(path, theirs), nil
+	case pOurs: // user-added file, not in template
+		return MergeResult{Path: path, Op: MergeUserAdded, Mode: ours.Mode}, nil
+	case pOurs | pTheirs: // both sides added (no base)
+		return m.mergeBothAdded(ctx, path, ours, theirs)
+	case pBase: // both deleted
+		return MergeResult{Path: path, Op: MergeDelete}, nil
+	case pBase | pTheirs: // user deleted, template may have changed
+		return mergeUserDeletedTemplateChanged(path, base, theirs), nil
+	case pBase | pOurs: // template deleted, user may have modified
+		return mergeTemplateDeletedUserHas(path, base, ours), nil
+	case pBase | pOurs | pTheirs: // all three exist
+		return m.mergeAllThreeExist(ctx, path, base, ours, theirs)
+	default:
+		return MergeResult{Path: path, Op: MergeKeep}, nil
+	}
+}
+
+func mergeNewTemplateFile(path string, theirs *RenderedFile) MergeResult {
+	return MergeResult{
+		Path:    path,
+		Op:      MergeAdd,
+		Content: theirs.Content,
+		Mode:    theirs.Mode,
+	}
+}
+
+// mergeBothAdded handles the case where base is nil but both ours and theirs exist.
+func (m *MergeEngine) mergeBothAdded(
+	ctx context.Context, path string, ours, theirs *RenderedFile,
+) (MergeResult, error) {
+	if bytes.Equal(ours.Content, theirs.Content) {
+		return MergeResult{
+			Path: path,
+			Op:   MergeKeep,
+			Mode: ours.Mode,
+		}, nil
+	}
+
+	if ours.IsBinary || theirs.IsBinary {
+		return binaryPrompt(path, nil, ours, theirs,
+			"both sides added a binary file with different content"), nil
+	}
+
+	return m.textMerge(ctx, path, nil, ours, theirs)
+}
+
+// mergeUserDeletedTemplateChanged handles: base exists, user deleted, template changed.
+func mergeUserDeletedTemplateChanged(path string, base, theirs *RenderedFile) MergeResult {
+	if bytes.Equal(base.Content, theirs.Content) {
+		return MergeResult{Path: path, Op: MergeDelete}
+	}
+
+	return MergeResult{
+		Path:          path,
+		Op:            MergePrompt,
+		PromptReason:  "you deleted this file but the template updated it",
+		BaseContent:   base.Content,
+		TheirsContent: theirs.Content,
+		Mode:          theirs.Mode,
+	}
+}
+
+// mergeTemplateDeletedUserHas handles: base exists, template deleted, user still has it.
+func mergeTemplateDeletedUserHas(path string, base, ours *RenderedFile) MergeResult {
+	if bytes.Equal(base.Content, ours.Content) {
+		return MergeResult{Path: path, Op: MergeDelete}
+	}
+
+	return MergeResult{
+		Path:         path,
+		Op:           MergePrompt,
+		PromptReason: "the template removed this file but you modified it",
+		BaseContent:  base.Content,
+		OursContent:  ours.Content,
+		Mode:         ours.Mode,
+	}
+}
+
+// mergeAllThreeExist handles the case where all three versions are present.
+func (m *MergeEngine) mergeAllThreeExist(
+	ctx context.Context, path string, base, ours, theirs *RenderedFile,
+) (MergeResult, error) {
+	oursEqBase := bytes.Equal(ours.Content, base.Content)
+	theirsEqBase := bytes.Equal(theirs.Content, base.Content)
+
+	switch {
+	case theirsEqBase:
+		return MergeResult{Path: path, Op: MergeKeep, Mode: ours.Mode}, nil
+	case oursEqBase:
+		return MergeResult{
+			Path: path, Op: MergeUpdate,
+			Content: theirs.Content, Mode: ours.Mode,
+		}, nil
+	case bytes.Equal(ours.Content, theirs.Content):
+		return MergeResult{
+			Path: path, Op: MergeKeep,
+			Mode: ours.Mode,
+		}, nil
+	default:
+		return m.mergeModifiedByBoth(ctx, path, base, ours, theirs)
+	}
+}
+
+// mergeModifiedByBoth handles the case where both user and template modified
+// the file differently from base.
+func (m *MergeEngine) mergeModifiedByBoth(
+	ctx context.Context, path string, base, ours, theirs *RenderedFile,
+) (MergeResult, error) {
+	if base.IsBinary || ours.IsBinary || theirs.IsBinary {
+		return binaryPrompt(path, base, ours, theirs,
+			"binary file modified by both sides"), nil
+	}
+
+	return m.textMerge(ctx, path, base, ours, theirs)
+}
+
+// textMerge delegates to the TextMerger and classifies the result.
+func (m *MergeEngine) textMerge(
+	ctx context.Context, path string, base, ours, theirs *RenderedFile,
+) (MergeResult, error) {
+	var baseContent []byte
+	if base != nil {
+		baseContent = base.Content
+	}
+
+	merged, conflicted, err := m.textMerger.Merge3(ctx, path, baseContent, ours.Content, theirs.Content)
+	if err != nil {
+		return MergeResult{}, err
+	}
+
+	op := MergeUpdate
+	if conflicted {
+		op = MergeConflict
+	}
+
+	return MergeResult{
+		Path:          path,
+		Op:            op,
+		Content:       merged,
+		Conflicted:    conflicted,
+		Mode:          ours.Mode,
+		BaseContent:   baseContent,
+		OursContent:   ours.Content,
+		TheirsContent: theirs.Content,
+	}, nil
+}
+
+// binaryPrompt creates a MergePrompt result for binary file conflicts.
+func binaryPrompt(
+	path string, base, ours, theirs *RenderedFile, reason string,
+) MergeResult {
+	var baseContent []byte
+	if base != nil {
+		baseContent = base.Content
+	}
+
+	return MergeResult{
+		Path:          path,
+		Op:            MergePrompt,
+		PromptReason:  reason,
+		BaseContent:   baseContent,
+		OursContent:   ours.Content,
+		TheirsContent: theirs.Content,
+		Mode:          ours.Mode,
+	}
+}

--- a/internal/templateupdate/merger_test.go
+++ b/internal/templateupdate/merger_test.go
@@ -1,0 +1,374 @@
+package templateupdate
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockMerger is a TextMerger for testing that returns predictable results.
+type mockMerger struct {
+	merged     []byte
+	conflicted bool
+	err        error
+}
+
+func (m *mockMerger) Merge3(_ context.Context, _ string, _, _, _ []byte) ([]byte, bool, error) {
+	return m.merged, m.conflicted, m.err
+}
+
+func rf(content string, binary bool) *RenderedFile {
+	return &RenderedFile{
+		Content:  []byte(content),
+		Mode:     0o644,
+		IsBinary: binary,
+	}
+}
+
+func rfMode(content string, mode os.FileMode) *RenderedFile {
+	return &RenderedFile{
+		Content: []byte(content),
+		Mode:    mode,
+	}
+}
+
+var ctx = context.Background()
+
+// --- Decision matrix tests ---
+
+func TestUT_MergeFile_NewTemplateFile(t *testing.T) {
+	t.Parallel()
+	engine := NewMergeEngine(&mockMerger{}, nil)
+	result, err := engine.MergeFile(ctx, "new.go", nil, nil, rf("new content", false))
+	require.NoError(t, err)
+	assert.Equal(t, MergeAdd, result.Op)
+	assert.Equal(t, []byte("new content"), result.Content)
+}
+
+func TestUT_MergeFile_UserAddedFile(t *testing.T) {
+	t.Parallel()
+	engine := NewMergeEngine(&mockMerger{}, nil)
+	result, err := engine.MergeFile(ctx, "user.txt", nil, rf("user stuff", false), nil)
+	require.NoError(t, err)
+	assert.Equal(t, MergeUserAdded, result.Op)
+}
+
+func TestUT_MergeFile_BothAddedSameContent(t *testing.T) {
+	t.Parallel()
+	engine := NewMergeEngine(&mockMerger{}, nil)
+	result, err := engine.MergeFile(ctx, "same.go", nil, rf("same", false), rf("same", false))
+	require.NoError(t, err)
+	assert.Equal(t, MergeKeep, result.Op)
+}
+
+func TestUT_MergeFile_BothAddedDifferentContent(t *testing.T) {
+	t.Parallel()
+	engine := NewMergeEngine(&mockMerger{merged: []byte("merged"), conflicted: false}, nil)
+	result, err := engine.MergeFile(ctx, "diff.go", nil, rf("ours", false), rf("theirs", false))
+	require.NoError(t, err)
+	assert.Equal(t, MergeUpdate, result.Op)
+	assert.Equal(t, []byte("merged"), result.Content)
+}
+
+func TestUT_MergeFile_BothAddedDifferentContentConflict(t *testing.T) {
+	t.Parallel()
+	engine := NewMergeEngine(&mockMerger{merged: []byte("conflict"), conflicted: true}, nil)
+	result, err := engine.MergeFile(ctx, "diff.go", nil, rf("ours", false), rf("theirs", false))
+	require.NoError(t, err)
+	assert.Equal(t, MergeConflict, result.Op)
+	assert.True(t, result.Conflicted)
+}
+
+func TestUT_MergeFile_BothAddedBinaryDifferent(t *testing.T) {
+	t.Parallel()
+	engine := NewMergeEngine(&mockMerger{}, nil)
+	result, err := engine.MergeFile(ctx, "img.png", nil, rf("bin1", true), rf("bin2", true))
+	require.NoError(t, err)
+	assert.Equal(t, MergePrompt, result.Op)
+	assert.False(t, result.Conflicted, "binary prompts should not set Conflicted")
+	assert.Contains(t, result.PromptReason, "binary")
+}
+
+func TestUT_MergeFile_BothDeleted(t *testing.T) {
+	t.Parallel()
+	engine := NewMergeEngine(&mockMerger{}, nil)
+	result, err := engine.MergeFile(ctx, "old.go", rf("base", false), nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, MergeDelete, result.Op)
+}
+
+func TestUT_MergeFile_UserDeletedTemplateChanged(t *testing.T) {
+	t.Parallel()
+	engine := NewMergeEngine(&mockMerger{}, nil)
+	result, err := engine.MergeFile(ctx, "changed.go", rf("base", false), nil, rf("new template", false))
+	require.NoError(t, err)
+	assert.Equal(t, MergePrompt, result.Op)
+	assert.Contains(t, result.PromptReason, "deleted")
+}
+
+func TestUT_MergeFile_UserDeletedTemplateUnchanged(t *testing.T) {
+	t.Parallel()
+	engine := NewMergeEngine(&mockMerger{}, nil)
+	result, err := engine.MergeFile(ctx, "same.go", rf("base", false), nil, rf("base", false))
+	require.NoError(t, err)
+	assert.Equal(t, MergeDelete, result.Op)
+}
+
+func TestUT_MergeFile_TemplateDeletedUserModified(t *testing.T) {
+	t.Parallel()
+	engine := NewMergeEngine(&mockMerger{}, nil)
+	result, err := engine.MergeFile(ctx, "kept.go", rf("base", false), rf("modified", false), nil)
+	require.NoError(t, err)
+	assert.Equal(t, MergePrompt, result.Op)
+	assert.Contains(t, result.PromptReason, "removed")
+}
+
+func TestUT_MergeFile_TemplateDeletedUserUnmodified(t *testing.T) {
+	t.Parallel()
+	engine := NewMergeEngine(&mockMerger{}, nil)
+	result, err := engine.MergeFile(ctx, "gone.go", rf("base", false), rf("base", false), nil)
+	require.NoError(t, err)
+	assert.Equal(t, MergeDelete, result.Op)
+}
+
+func TestUT_MergeFile_UserUntouchedTemplateChanged(t *testing.T) {
+	t.Parallel()
+	engine := NewMergeEngine(&mockMerger{}, nil)
+	result, err := engine.MergeFile(ctx, "updated.go", rf("base", false), rf("base", false), rf("new", false))
+	require.NoError(t, err)
+	assert.Equal(t, MergeUpdate, result.Op)
+	assert.Equal(t, []byte("new"), result.Content)
+}
+
+func TestUT_MergeFile_TemplateUnchangedUserModified(t *testing.T) {
+	t.Parallel()
+	engine := NewMergeEngine(&mockMerger{}, nil)
+	result, err := engine.MergeFile(ctx, "custom.go", rf("base", false), rf("custom", false), rf("base", false))
+	require.NoError(t, err)
+	assert.Equal(t, MergeKeep, result.Op)
+}
+
+func TestUT_MergeFile_Converged(t *testing.T) {
+	t.Parallel()
+	engine := NewMergeEngine(&mockMerger{}, nil)
+	result, err := engine.MergeFile(ctx, "same.go", rf("base", false), rf("new", false), rf("new", false))
+	require.NoError(t, err)
+	assert.Equal(t, MergeKeep, result.Op)
+}
+
+func TestUT_MergeFile_BothModifiedCleanMerge(t *testing.T) {
+	t.Parallel()
+	engine := NewMergeEngine(&mockMerger{merged: []byte("clean merge"), conflicted: false}, nil)
+	result, err := engine.MergeFile(ctx, "merged.go",
+		rf("base", false), rf("ours-mod", false), rf("theirs-mod", false))
+	require.NoError(t, err)
+	assert.Equal(t, MergeUpdate, result.Op)
+	assert.Equal(t, []byte("clean merge"), result.Content)
+	assert.False(t, result.Conflicted)
+}
+
+func TestUT_MergeFile_BothModifiedConflict(t *testing.T) {
+	t.Parallel()
+	engine := NewMergeEngine(&mockMerger{merged: []byte("<<<<<<< conflict"), conflicted: true}, nil)
+	result, err := engine.MergeFile(ctx, "conflict.go",
+		rf("base", false), rf("ours-mod", false), rf("theirs-mod", false))
+	require.NoError(t, err)
+	assert.Equal(t, MergeConflict, result.Op)
+	assert.True(t, result.Conflicted)
+}
+
+func TestUT_MergeFile_BinaryFileConflict(t *testing.T) {
+	t.Parallel()
+	engine := NewMergeEngine(&mockMerger{}, nil)
+	result, err := engine.MergeFile(ctx, "image.png",
+		rf("base-bin", true), rf("ours-bin", true), rf("theirs-bin", true))
+	require.NoError(t, err)
+	assert.Equal(t, MergePrompt, result.Op)
+	assert.Contains(t, result.PromptReason, "binary")
+}
+
+func TestUT_MergeFile_TextMergerError(t *testing.T) {
+	t.Parallel()
+	engine := NewMergeEngine(&mockMerger{err: errors.New("merge failed")}, nil)
+	_, err := engine.MergeFile(ctx, "error.go",
+		rf("base", false), rf("ours", false), rf("theirs", false))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "merge failed")
+}
+
+func TestUT_MergeFile_FileModeChange(t *testing.T) {
+	t.Parallel()
+	engine := NewMergeEngine(&mockMerger{}, nil)
+	base := rf("content", false)
+	ours := rfMode("content", 0o755) // User made executable.
+	theirs := rf("content", false)   // Template unchanged.
+
+	result, err := engine.MergeFile(ctx, "script.sh", base, ours, theirs)
+	require.NoError(t, err)
+	assert.Equal(t, MergeKeep, result.Op)
+	assert.Equal(t, os.FileMode(0o755), result.Mode, "should preserve user's mode")
+}
+
+func TestUT_MergeFile_AllNil(t *testing.T) {
+	t.Parallel()
+	engine := NewMergeEngine(&mockMerger{}, nil)
+	result, err := engine.MergeFile(ctx, "ghost.go", nil, nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, MergeKeep, result.Op)
+}
+
+// --- MergeTrees tests ---
+
+func TestUT_MergeTrees_CombinesAllFiles(t *testing.T) {
+	t.Parallel()
+
+	base := map[string]*RenderedFile{"a.go": rf("a", false)}
+	ours := map[string]*RenderedFile{"a.go": rf("a", false), "b.go": rf("b", false)}
+	theirs := map[string]*RenderedFile{"a.go": rf("a-new", false), "c.go": rf("c", false)}
+
+	engine := NewMergeEngine(&mockMerger{}, nil)
+	results, skipped, err := engine.MergeTrees(ctx, base, ours, theirs)
+	require.NoError(t, err)
+	assert.Empty(t, skipped)
+
+	paths := make([]string, len(results))
+	for i, r := range results {
+		paths[i] = r.Path
+	}
+	assert.Equal(t, []string{"a.go", "b.go", "c.go"}, paths, "should be sorted")
+}
+
+func TestUT_MergeTrees_SkippedFilesExcluded(t *testing.T) {
+	t.Parallel()
+
+	theirs := map[string]*RenderedFile{
+		"main.go": rf("main", false),
+		"skip.me": rf("skip", false),
+	}
+
+	ignoreFn := func(path string) bool { return path == "skip.me" }
+	engine := NewMergeEngine(&mockMerger{}, ignoreFn)
+	results, skipped, err := engine.MergeTrees(ctx, nil, nil, theirs)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"skip.me"}, skipped)
+	require.Len(t, results, 1)
+	assert.Equal(t, "main.go", results[0].Path)
+}
+
+func TestUT_MergeTrees_EmptyTrees(t *testing.T) {
+	t.Parallel()
+
+	engine := NewMergeEngine(&mockMerger{}, nil)
+	results, skipped, err := engine.MergeTrees(ctx, nil, nil, nil)
+	require.NoError(t, err)
+	assert.Empty(t, results)
+	assert.Empty(t, skipped)
+}
+
+func TestUT_MergeTrees_DeterministicOrder(t *testing.T) {
+	t.Parallel()
+
+	theirs := map[string]*RenderedFile{
+		"z.go": rf("z", false),
+		"a.go": rf("a", false),
+		"m.go": rf("m", false),
+	}
+
+	engine := NewMergeEngine(&mockMerger{}, nil)
+	results, _, err := engine.MergeTrees(ctx, nil, nil, theirs)
+	require.NoError(t, err)
+
+	paths := make([]string, len(results))
+	for i, r := range results {
+		paths[i] = r.Path
+	}
+	assert.Equal(t, []string{"a.go", "m.go", "z.go"}, paths)
+}
+
+func TestUT_MergeTrees_ErrorPropagation(t *testing.T) {
+	t.Parallel()
+
+	base := map[string]*RenderedFile{"a.go": rf("base", false)}
+	ours := map[string]*RenderedFile{"a.go": rf("ours", false)}
+	theirs := map[string]*RenderedFile{"a.go": rf("theirs", false)}
+
+	engine := NewMergeEngine(&mockMerger{err: errors.New("boom")}, nil)
+	_, _, err := engine.MergeTrees(ctx, base, ours, theirs)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "merge a.go")
+	assert.Contains(t, err.Error(), "boom")
+}
+
+// --- GitMerger integration tests (require git) ---
+
+func TestIT_GitMerger_CleanMerge(t *testing.T) {
+	t.Parallel()
+	skipWithoutGit(t)
+
+	// Edits must be separated by enough context lines for git merge-file
+	// to consider them non-overlapping.
+	base := []byte("line1\nline2\nline3\nline4\nline5\nline6\nline7\n")
+	ours := []byte("line1\nline2-modified\nline3\nline4\nline5\nline6\nline7\n")
+	theirs := []byte("line1\nline2\nline3\nline4\nline5\nline6\nline7-modified\n")
+
+	gm := &GitMerger{}
+	merged, conflicted, err := gm.Merge3(ctx, "test.txt", base, ours, theirs)
+	require.NoError(t, err)
+	assert.False(t, conflicted)
+	assert.Contains(t, string(merged), "line2-modified")
+	assert.Contains(t, string(merged), "line7-modified")
+}
+
+func TestIT_GitMerger_ConflictMerge(t *testing.T) {
+	t.Parallel()
+	skipWithoutGit(t)
+
+	base := []byte("line1\noriginal\nline3\n")
+	ours := []byte("line1\nours-change\nline3\n")
+	theirs := []byte("line1\ntheirs-change\nline3\n")
+
+	gm := &GitMerger{}
+	merged, conflicted, err := gm.Merge3(ctx, "test.txt", base, ours, theirs)
+	require.NoError(t, err)
+	assert.True(t, conflicted)
+	assert.Contains(t, string(merged), "<<<<<<< ")
+	assert.Contains(t, string(merged), ">>>>>>> ")
+}
+
+func TestIT_GitMerger_IdenticalInputs(t *testing.T) {
+	t.Parallel()
+	skipWithoutGit(t)
+
+	content := []byte("same content\n")
+
+	gm := &GitMerger{}
+	merged, conflicted, err := gm.Merge3(ctx, "test.txt", content, content, content)
+	require.NoError(t, err)
+	assert.False(t, conflicted)
+	assert.Equal(t, content, merged)
+}
+
+func TestIT_GitMerger_EmptyBase(t *testing.T) {
+	t.Parallel()
+	skipWithoutGit(t)
+
+	gm := &GitMerger{}
+	merged, conflicted, err := gm.Merge3(ctx, "test.txt", nil, []byte("ours\n"), []byte("theirs\n"))
+	require.NoError(t, err)
+	// With empty base, both additions conflict.
+	assert.True(t, conflicted)
+	assert.Contains(t, string(merged), "<<<<<<< ")
+}
+
+func skipWithoutGit(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+}

--- a/internal/templateupdate/textmerge.go
+++ b/internal/templateupdate/textmerge.go
@@ -1,0 +1,77 @@
+package templateupdate
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// GitMerger implements TextMerger by shelling out to git merge-file.
+type GitMerger struct{}
+
+// Merge3 writes base, ours, and theirs to temporary files and runs
+// git merge-file to produce a 3-way merge. Exit code 0 means clean merge,
+// exit code >0 with output means conflicts, and any other error is fatal.
+func (g *GitMerger) Merge3(ctx context.Context, path string, base, ours, theirs []byte) ([]byte, bool, error) {
+	dir, err := os.MkdirTemp("", "tag-merge-*")
+	if err != nil {
+		return nil, false, fmt.Errorf("create temp dir: %w", err)
+	}
+	defer os.RemoveAll(dir)
+
+	basePath := filepath.Join(dir, "base")
+	oursPath := filepath.Join(dir, "ours")
+	theirsPath := filepath.Join(dir, "theirs")
+
+	if err := os.WriteFile(basePath, base, 0o600); err != nil {
+		return nil, false, fmt.Errorf("write base: %w", err)
+	}
+	if err := os.WriteFile(oursPath, ours, 0o600); err != nil {
+		return nil, false, fmt.Errorf("write ours: %w", err)
+	}
+	if err := os.WriteFile(theirsPath, theirs, 0o600); err != nil {
+		return nil, false, fmt.Errorf("write theirs: %w", err)
+	}
+
+	// git merge-file writes the merged result to the first file (ours) and
+	// prints nothing to stdout. Use -p to write to stdout instead.
+	// Labels: LOCAL = user's changes, BASE = original template, TEMPLATE = upstream update.
+	cmd := exec.CommandContext(ctx, "git", "merge-file", // #nosec G204
+		"-p", "--diff3",
+		"-L", "LOCAL (your changes)",
+		"-L", "BASE (original template)",
+		"-L", "TEMPLATE (upstream update)",
+		oursPath, basePath, theirsPath,
+	)
+	cmd.Env = append(os.Environ(), "LC_ALL=C")
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	runErr := cmd.Run()
+	merged := stdout.Bytes()
+
+	if runErr == nil {
+		// Exit code 0: clean merge.
+		return merged, false, nil
+	}
+
+	// git merge-file exits with a positive number equal to the number of
+	// conflict regions. Any negative exit code indicates a fatal error.
+	var exitErr *exec.ExitError
+	if errors.As(runErr, &exitErr) {
+		code := exitErr.ExitCode()
+		if code > 0 {
+			// Conflicts found but merge completed.
+			return merged, true, nil
+		}
+	}
+
+	return nil, false, fmt.Errorf("git merge-file failed for %s: %w (stderr: %s)",
+		path, runErr, stderr.String())
+}

--- a/internal/templateupdate/types.go
+++ b/internal/templateupdate/types.go
@@ -1,0 +1,78 @@
+package templateupdate
+
+import (
+	"context"
+	"os"
+)
+
+// MergeOp classifies the action to take for a file during a 3-way merge.
+type MergeOp int
+
+const (
+	// MergeKeep means the file needs no changes (user's version is current).
+	MergeKeep MergeOp = iota
+	// MergeAdd means a new file from the template should be added.
+	MergeAdd
+	// MergeDelete means the file was removed by both sides.
+	MergeDelete
+	// MergeUpdate means a clean merge was applied automatically.
+	MergeUpdate
+	// MergeConflict means overlapping changes require user resolution.
+	MergeConflict
+	// MergeUserAdded means the file exists only in the user's project.
+	MergeUserAdded
+	// MergePrompt means the situation needs an explicit user decision
+	// (e.g. user deleted but template changed, or binary conflict).
+	MergePrompt
+)
+
+// String returns a human-readable label for a MergeOp.
+func (op MergeOp) String() string {
+	switch op {
+	case MergeKeep:
+		return "keep"
+	case MergeAdd:
+		return "add"
+	case MergeDelete:
+		return "delete"
+	case MergeUpdate:
+		return "update"
+	case MergeConflict:
+		return "conflict"
+	case MergeUserAdded:
+		return "user-added"
+	case MergePrompt:
+		return "prompt"
+	default:
+		return "unknown"
+	}
+}
+
+// MergeResult describes the outcome of merging a single file path.
+type MergeResult struct {
+	// Path is the relative file path within the project.
+	Path string
+	// Op is the merge operation classification.
+	Op MergeOp
+	// Content holds the merged content. For conflicts it contains conflict markers.
+	Content []byte
+	// Mode is the file permission mode for the merged file.
+	Mode os.FileMode
+	// Conflicted is true when Content contains unresolved conflict markers.
+	Conflicted bool
+	// PromptReason describes why a user prompt is needed (non-empty only for MergePrompt).
+	PromptReason string
+	// BaseContent is the original base version (populated for conflicts/prompts to enable resolution).
+	BaseContent []byte
+	// OursContent is the user's version (populated for conflicts/prompts).
+	OursContent []byte
+	// TheirsContent is the template's version (populated for conflicts/prompts).
+	TheirsContent []byte
+}
+
+// TextMerger performs 3-way text merging of file contents.
+type TextMerger interface {
+	// Merge3 performs a 3-way merge of base, ours, and theirs content.
+	// Returns the merged content, whether conflicts were found, and any error.
+	Merge3(ctx context.Context, path string, base, ours, theirs []byte) (merged []byte, conflicted bool, err error)
+}


### PR DESCRIPTION
## Summary

- **IgnoreMatcher** (#250): Merges skip patterns from 4 sources (builtins → `.tagignore` → `.tagconfig.json` → CLI `--skip`) using go-git's gitignore matcher with full `**` glob and `!` negation support
- **MergeEngine** (#249): 3-way merge with 10-case decision matrix, presenceKey bitmask dispatch, and pluggable `TextMerger` interface. `GitMerger` shells out to `git merge-file --diff3` with context propagation for cancellation
- **ConflictReport & Resolution** (#251): Classifies results into clean/conflicted/prompt, supports `--accept-ours`/`--accept-theirs` auto-resolution, persists state atomically to `.tag/conflicts.json` for `--continue`/`--abort` workflows

### Decision matrix (per-file)

| base | ours | theirs | Action |
|------|------|--------|--------|
| — | — | ✓ | **Add**: new template file |
| — | ✓ | — | **UserAdded**: user-created file |
| — | ✓ | ✓ (same) | **Keep**: converged |
| — | ✓ | ✓ (diff) | **Merge/Conflict**: 3-way with empty base |
| ✓ | — | — | **Delete**: both removed |
| ✓ | — | ✓ (changed) | **Prompt**: user deleted, template changed |
| ✓ | ✓ | — (user modified) | **Prompt**: template deleted, user modified |
| ✓ | ✓=base | ✓ | **Update**: user untouched → take theirs |
| ✓ | ✓ | ✓=base | **Keep**: template unchanged |
| ✓ | ✓≠base | ✓≠base | **3-way text merge** → clean or conflict |

### New files
- `internal/templateupdate/types.go` — `MergeOp`, `MergeResult`, `TextMerger` interface
- `internal/templateupdate/ignore.go` — `IgnoreMatcher` with 4-source pattern merging
- `internal/templateupdate/merger.go` — `MergeEngine`, `MergeTrees`, `MergeFile`
- `internal/templateupdate/textmerge.go` — `GitMerger` (`git merge-file --diff3`)
- `internal/templateupdate/conflict.go` — `ConflictReport`, resolution, status persistence, CLI formatting

### Code review
Reviewed by Claude, Gemini 2.5 Pro, Codex gpt-5.3, quality-engineer agent, and refactoring-expert agent. All findings resolved before merge — see `claudedocs/code-reviews/249-250-251-merge-engine-pr-review.md`.

## Test plan
- [x] 50 tests total (46 unit + 4 integration)
- [x] All 10 decision matrix cases covered with dedicated tests
- [x] GitMerger integration tests (clean merge, conflict, identical, empty base)
- [x] IgnoreMatcher tests for all 4 pattern sources, negation, doublestar, priority
- [x] Conflict report classification, resolution modes, atomic status persistence
- [x] Error propagation tests (TextMerger errors, malformed JSON, missing files)
- [x] `make lint` passes with 0 issues
- [x] Full test suite (`make test`) passes

Closes #249
Closes #250
Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)