### PR TITLE
feat: add template lifecycle commands — check, diff, update

### DIFF
--- a/.skill/SKILL.md
+++ b/.skill/SKILL.md
@@ -202,7 +202,10 @@ my-project/
 | `tag undo` | Revert the last generation |
 | `tag undo --list` | Show generation history |
 | `tag undo --id <id>` | Revert a specific generation |
-| `tag update` | Self-update to latest release |
+| `tag check` | Check if upstream template changed. Exit 0 = up-to-date, 1 = updates available |
+| `tag diff` | Show what would change if you ran `tag update` (read-only) |
+| `tag update` | Apply upstream template changes via 3-way merge |
+| `tag upgrade` | Self-upgrade to latest release |
 | `tag version [--check]` | Print version, check for updates |
 
 ### Key Flags
@@ -217,7 +220,7 @@ my-project/
 | `-l` / `--lib` | template new | Target library template |
 | `-B` / `--in-bundle` | template new generator | Create inside bundle |
 | `-s` / `--self-contained` | template new bundle | Self-contained bundle |
-| `--dry-run` / `-d` | scaffold, generate, convert | Preview without writing |
+| `--dry-run` / `-d` | scaffold, generate, convert, update | Preview without writing |
 | `--all` | generate list, template list | Show all generators/bundles, including those with unmet requirements |
 | `--on-existing` | generate | Existing file policy: `fail` (default), `skip`, `overwrite` |
 | `-v` / `--verbose` | generate | Print per-file operation details in summary |

--- a/.skill/reference.md
+++ b/.skill/reference.md
@@ -476,10 +476,40 @@ tag undo --partial                     # Revert unmodified files, skip conflicti
 
 **Backup location**: `.tag/history/backups/<generation-id>/` — stores pre-modification copies for inject/append operations.
 
-### Self-Update
+### Template Lifecycle (Check, Diff, Update)
+
+Commands for keeping scaffolded projects in sync with upstream template changes.
 
 ```bash
-tag update                             # Download and install latest release
+tag check                              # Check if upstream has newer commits (exit 0/1)
+tag check --quiet                      # CI mode: exit code only, no output
+tag check --ref main                   # Check against a specific branch/tag
+
+tag diff                               # Show unified diff of proposed changes
+tag diff --stat                        # Show compact diffstat summary
+tag diff --no-color                    # Pipe-friendly (no ANSI)
+tag diff --ref v2.0.0                  # Diff against a specific ref
+
+tag update                             # Apply upstream template changes (3-way merge)
+tag update --dry-run                   # Preview changes without applying
+tag update --accept-ours               # Auto-resolve conflicts with your version
+tag update --accept-theirs             # Auto-resolve conflicts with template version
+tag update --set author="Jane"         # Override variables during update
+tag update --skip "*.md"               # Skip patterns for this run
+tag update --continue                  # Resume after manual conflict resolution
+tag update --abort                     # Abort and restore from backup
+```
+
+**How update works**: Renders the template at the old commit SHA and the new commit SHA (both with your variables), reads your current project files, then performs a 3-way merge (base=old template, ours=your files, theirs=new template). Conflicts are written with standard `<<<<<<<`/`=======`/`>>>>>>>` markers.
+
+**Conflict workflow**: If conflicts occur, resolve them manually in the affected files, then run `tag update --continue` to finalize. Or run `tag update --abort` to restore from backup.
+
+**`.tagconfig.json` tracking**: After a successful update, `.tagconfig.json` is updated with the new `commit` SHA. The `tag check` command compares this SHA against the latest remote commit.
+
+### Self-Upgrade
+
+```bash
+tag upgrade                            # Download and install latest release
 tag version --check                    # Check if update available
 ```
 

--- a/internal/commands/check.go
+++ b/internal/commands/check.go
@@ -1,0 +1,98 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/kaikenlabs/tag/internal/remote"
+	"github.com/kaikenlabs/tag/internal/templateupdate"
+	"github.com/kaikenlabs/tag/pkg/app"
+)
+
+// CheckCommand returns the check command definition.
+func CheckCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "check",
+		Usage: "Check if upstream template has changed since last update",
+		Description: `Checks whether the upstream template has newer commits than the
+version recorded in .tagconfig.json. Useful in CI pipelines to detect template drift.
+
+Exit codes:
+  0  Project is up to date
+  1  Updates are available (or error occurred)
+
+Examples:
+  # Check current project
+  tag check
+
+  # Check with no output (CI mode)
+  tag check --quiet
+
+  # Check against a specific branch
+  tag check --ref main`,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:  "dir",
+				Value: ".",
+				Usage: "Project directory to check",
+			},
+			&cli.StringFlag{
+				Name:  "ref",
+				Usage: "Override the template ref to check against",
+			},
+			&cli.BoolFlag{
+				Name:  "quiet",
+				Usage: "Suppress output, only set exit code",
+			},
+		},
+		Action: checkAction,
+	}
+}
+
+func checkAction(c *cli.Context) error {
+	resolver := newGitResolver()
+	checker := templateupdate.NewChecker(resolver)
+	result, err := checker.Check(c.Context, templateupdate.CheckOptions{
+		ProjectDir: c.String("dir"),
+		Ref:        c.String("ref"),
+	})
+	if err != nil {
+		return app.Errorf("check: %w", err)
+	}
+
+	quiet := c.Bool("quiet")
+
+	if result.UpToDate {
+		if !quiet {
+			fmt.Fprintf(os.Stdout, "✓ Project is up to date with template (commit %s)\n", shortCommitSHA(result.CurrentSHA))
+		}
+		return nil
+	}
+
+	// Updates available — exit 1.
+	if !quiet {
+		fmt.Fprintf(os.Stdout, "✗ Template updates available\n")
+		fmt.Fprintf(os.Stdout, "  Template: %s\n", result.Source)
+		fmt.Fprintf(os.Stdout, "  Current:  %s\n", shortCommitSHA(result.CurrentSHA))
+		fmt.Fprintf(os.Stdout, "  Latest:   %s\n", shortCommitSHA(result.LatestSHA))
+		fmt.Fprintf(os.Stdout, "  Run 'tag diff' to see changes, 'tag update' to apply.\n")
+	}
+
+	return cli.Exit("", 1)
+}
+
+// newGitResolver creates a GitFetcher suitable for commit resolution.
+func newGitResolver() remote.LatestCommitResolver {
+	auth := remote.NewEnvAuthProvider()
+	return remote.NewGitFetcher(auth)
+}
+
+// shortCommitSHA returns first 7 chars of a SHA.
+func shortCommitSHA(sha string) string {
+	if len(sha) > 7 {
+		return sha[:7]
+	}
+	return sha
+}

--- a/internal/commands/diff.go
+++ b/internal/commands/diff.go
@@ -1,0 +1,94 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/urfave/cli/v2"
+	"golang.org/x/term"
+
+	"github.com/kaikenlabs/tag/internal/remote"
+	"github.com/kaikenlabs/tag/internal/templateupdate"
+	"github.com/kaikenlabs/tag/pkg/app"
+)
+
+// DiffCommand returns the diff command definition.
+func DiffCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "diff",
+		Usage: "Show what would change if you ran 'tag update'",
+		Description: `Performs a dry-run 3-way merge and displays a diff of proposed changes.
+This is a read-only operation with no side effects.
+
+Examples:
+  # Show full diff
+  tag diff
+
+  # Show compact summary
+  tag diff --stat
+
+  # Pipe-friendly output (no colors)
+  tag diff --no-color
+
+  # Check against a specific ref
+  tag diff --ref v2.0.0`,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:  "dir",
+				Value: ".",
+				Usage: "Project directory",
+			},
+			&cli.StringFlag{
+				Name:  "ref",
+				Usage: "Override template ref",
+			},
+			&cli.BoolFlag{
+				Name:  "stat",
+				Usage: "Show diffstat summary instead of full diff",
+			},
+			&cli.BoolFlag{
+				Name:  "no-color",
+				Usage: "Disable color output",
+			},
+		},
+		Action: diffAction,
+	}
+}
+
+func diffAction(c *cli.Context) error {
+	resolver := newGitResolver()
+	auth := remote.NewEnvAuthProvider()
+	fetcher := remote.NewGitFetcher(auth)
+	renderer := templateupdate.NewHistoricalRenderer(fetcher)
+
+	differ := templateupdate.NewDiffer(renderer, resolver)
+	result, err := differ.Diff(c.Context, templateupdate.DiffOptions{
+		ProjectDir: c.String("dir"),
+		Ref:        c.String("ref"),
+	})
+	if err != nil {
+		return app.Errorf("diff: %w", err)
+	}
+
+	// No changes.
+	if result.OldSHA == result.NewSHA {
+		fmt.Fprintln(os.Stdout, "Already up to date.")
+		return nil
+	}
+
+	// Determine color output.
+	useColor := !c.Bool("no-color") && isStdoutTTY()
+
+	templateupdate.FormatDiff(result.Results, result.Source, result.OldSHA, result.NewSHA, templateupdate.FormatOptions{
+		Color:  useColor,
+		Stat:   c.Bool("stat"),
+		Writer: os.Stdout,
+	})
+
+	return nil
+}
+
+// isStdoutTTY checks if stdout is a terminal.
+func isStdoutTTY() bool {
+	return term.IsTerminal(int(os.Stdout.Fd())) //nolint:gosec // Fd() returns a valid file descriptor
+}

--- a/internal/commands/doctor.go
+++ b/internal/commands/doctor.go
@@ -169,7 +169,7 @@ func doctorCheckTAGVersion(ctx context.Context, version string) doctorResult {
 		return doctorResultWarn(label, fmt.Sprintf("could not check for updates: %v", err))
 	}
 	if strings.TrimPrefix(version, "v") != strings.TrimPrefix(latest, "v") {
-		return doctorResultWarn(label, fmt.Sprintf("update available: %s → %s  (run: tag update)", version, latest))
+		return doctorResultWarn(label, fmt.Sprintf("update available: %s → %s  (run: tag upgrade)", version, latest))
 	}
 	return doctorResultPass(label)
 }

--- a/internal/commands/update_template.go
+++ b/internal/commands/update_template.go
@@ -1,0 +1,214 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/kaikenlabs/tag/internal/remote"
+	"github.com/kaikenlabs/tag/internal/templateupdate"
+	"github.com/kaikenlabs/tag/pkg/app"
+)
+
+// UpdateTemplateCommand returns the template update command definition.
+func UpdateTemplateCommand() *cli.Command {
+	return &cli.Command{
+		Name:    "update",
+		Aliases: []string{"up"},
+		Usage:   "Apply upstream template changes to your project",
+		Description: `Applies upstream template changes using 3-way merge. Detects what
+changed in the template since you scaffolded (or last updated), compares with
+your local modifications, and merges them together.
+
+Examples:
+  # Apply latest template changes
+  tag update
+
+  # Preview without applying
+  tag update --dry-run
+
+  # Auto-resolve conflicts with your version
+  tag update --accept-ours
+
+  # Auto-resolve conflicts with template version
+  tag update --accept-theirs
+
+  # Override variables during update
+  tag update --set author="Jane Doe" --set license=MIT
+
+  # Resume after resolving conflicts manually
+  tag update --continue
+
+  # Abort and restore from backup
+  tag update --abort`,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:  "dir",
+				Value: ".",
+				Usage: "Project directory",
+			},
+			&cli.StringFlag{
+				Name:  "ref",
+				Usage: "Override template ref to update to",
+			},
+			&cli.StringSliceFlag{
+				Name:  "set",
+				Usage: "Override/add variable values (key=value)",
+			},
+			&cli.BoolFlag{
+				Name:  "accept-ours",
+				Usage: "Auto-resolve conflicts with your version",
+			},
+			&cli.BoolFlag{
+				Name:  "accept-theirs",
+				Usage: "Auto-resolve conflicts with template version",
+			},
+			&cli.StringSliceFlag{
+				Name:  "skip",
+				Usage: "Additional skip patterns for this run",
+			},
+			&cli.BoolFlag{
+				Name:  "dry-run",
+				Usage: "Show what would change without applying",
+			},
+			&cli.BoolFlag{
+				Name:  "backup",
+				Value: true,
+				Usage: "Create backup before applying changes",
+			},
+			&cli.BoolFlag{
+				Name:  "continue",
+				Usage: "Resume after manual conflict resolution",
+			},
+			&cli.BoolFlag{
+				Name:  "abort",
+				Usage: "Abort in-progress update, restore backup",
+			},
+		},
+		Action: updateTemplateAction,
+	}
+}
+
+func updateTemplateAction(c *cli.Context) error {
+	// Validate mutually exclusive flags.
+	if c.Bool("continue") && c.Bool("abort") {
+		return app.Errorf("cannot use --continue and --abort together")
+	}
+	if c.Bool("accept-ours") && c.Bool("accept-theirs") {
+		return app.Errorf("cannot use --accept-ours and --accept-theirs together")
+	}
+
+	// Determine update mode.
+	mode := templateupdate.UpdateModeApply
+	if c.Bool("continue") {
+		mode = templateupdate.UpdateModeContinue
+	} else if c.Bool("abort") {
+		mode = templateupdate.UpdateModeAbort
+	}
+
+	// Determine resolve mode.
+	resolveMode := templateupdate.ResolveNone
+	if c.Bool("accept-ours") {
+		resolveMode = templateupdate.ResolveOurs
+	} else if c.Bool("accept-theirs") {
+		resolveMode = templateupdate.ResolveTheirs
+	}
+
+	// Parse --set overrides using the same key=value parser as --meta.
+	varOverrides, err := parseSetFlags(c.StringSlice("set"))
+	if err != nil {
+		return err
+	}
+
+	resolver := newGitResolver()
+	auth := remote.NewEnvAuthProvider()
+	fetcher := remote.NewGitFetcher(auth)
+	renderer := templateupdate.NewHistoricalRenderer(fetcher)
+
+	updater := templateupdate.NewUpdater(renderer, resolver)
+	result, err := updater.Update(c.Context, templateupdate.UpdateOptions{
+		ProjectDir:   c.String("dir"),
+		Ref:          c.String("ref"),
+		VarOverrides: varOverrides,
+		ResolveMode:  resolveMode,
+		SkipPatterns: c.StringSlice("skip"),
+		DryRun:       c.Bool("dry-run"),
+		Backup:       c.Bool("backup"),
+		Mode:         mode,
+	})
+	if err != nil {
+		return app.Errorf("update: %w", err)
+	}
+
+	// Handle abort.
+	if mode == templateupdate.UpdateModeAbort {
+		fmt.Fprintln(os.Stdout, "Update aborted. Backup restored.")
+		return nil
+	}
+
+	// Handle continue.
+	if mode == templateupdate.UpdateModeContinue {
+		fmt.Fprintln(os.Stdout, "All conflicts resolved.")
+		fmt.Fprintf(os.Stdout, "  ✓ .tagconfig.json updated (commit: %s)\n", shortCommitSHA(result.NewSHA))
+		return nil
+	}
+
+	// No changes needed.
+	if result.OldSHA == result.NewSHA {
+		fmt.Fprintln(os.Stdout, "Already up to date.")
+		return nil
+	}
+
+	// Print results.
+	if c.Bool("dry-run") {
+		fmt.Fprintf(os.Stdout, "Would update from %s → %s\n", shortCommitSHA(result.OldSHA), shortCommitSHA(result.NewSHA))
+	} else {
+		fmt.Fprintf(os.Stdout, "Updating from template (%s → %s)\n", shortCommitSHA(result.OldSHA), shortCommitSHA(result.NewSHA))
+	}
+
+	printUpdateSummary(result)
+
+	if result.Conflicts != nil && result.Conflicts.HasConflicts() {
+		fmt.Fprintf(os.Stdout, "\n⚠ %d conflict(s) found. Resolve manually, then run: tag update --continue\n", len(result.Conflicts.Conflicts))
+		fmt.Fprintln(os.Stdout, "  Or: tag update --accept-ours | --accept-theirs")
+		return cli.Exit("", 1)
+	}
+
+	if !c.Bool("dry-run") {
+		fmt.Fprintf(os.Stdout, "\nTemplate update complete. %d file(s) updated, %d added, %d deleted.\n",
+			result.UpdatedFiles, result.NewFiles, result.DeletedFiles)
+	}
+
+	return nil
+}
+
+// parseSetFlags parses key=value pairs from --set flags.
+func parseSetFlags(args []string) (map[string]string, error) {
+	result := make(map[string]string, len(args))
+	for _, kv := range args {
+		parts := strings.SplitN(kv, "=", 2)
+		if len(parts) != 2 { //nolint:mnd // key=value requires exactly 2 parts
+			return nil, app.Errorf("invalid --set value %q: expected key=value format", kv)
+		}
+		result[parts[0]] = parts[1]
+	}
+	return result, nil
+}
+
+// printUpdateSummary prints the file-by-file status.
+func printUpdateSummary(result *templateupdate.UpdateResult) {
+	for _, r := range result.Applied {
+		switch r.Op {
+		case templateupdate.MergeAdd:
+			fmt.Fprintf(os.Stdout, "  + %s (added)\n", r.Path)
+		case templateupdate.MergeUpdate:
+			fmt.Fprintf(os.Stdout, "  ✓ %s (updated)\n", r.Path)
+		case templateupdate.MergeDelete:
+			fmt.Fprintf(os.Stdout, "  - %s (deleted)\n", r.Path)
+		case templateupdate.MergeConflict:
+			fmt.Fprintf(os.Stdout, "  ⚠ %s (conflict)\n", r.Path)
+		}
+	}
+}

--- a/internal/commands/upgrade.go
+++ b/internal/commands/upgrade.go
@@ -13,11 +13,12 @@ import (
 	"github.com/kaikenlabs/tag/pkg/app"
 )
 
-// UpdateCommand returns the CLI command for self-updating TAG.
-func UpdateCommand(version string) *cli.Command {
+// UpgradeCommand returns the CLI command for self-updating TAG.
+func UpgradeCommand(version string) *cli.Command {
 	return &cli.Command{
-		Name:  "update",
-		Usage: "Update TAG to the latest version",
+		Name:    "upgrade",
+		Aliases: []string{"u"},
+		Usage:   "Upgrade TAG to the latest version",
 		Description: `Downloads and installs the latest TAG release from GitHub.
 
 Checks the current version against the latest release, downloads the
@@ -25,14 +26,14 @@ appropriate binary for the current platform, verifies its SHA256 checksum,
 and replaces the running binary in-place.
 
 Examples:
-  tag update`,
+  tag upgrade`,
 		Action: func(c *cli.Context) error {
-			return updateAction(c, os.Stdout, version, defaultGitHubRepo)
+			return upgradeAction(c, os.Stdout, version, defaultGitHubRepo)
 		},
 	}
 }
 
-func updateAction(c *cli.Context, w io.Writer, currentVersion, repoURL string) error {
+func upgradeAction(c *cli.Context, w io.Writer, currentVersion, repoURL string) error {
 	fmt.Fprintln(w, "Checking for latest version...")
 
 	latest, err := fetchLatestVersion(c.Context, repoURL)
@@ -49,9 +50,9 @@ func updateAction(c *cli.Context, w io.Writer, currentVersion, repoURL string) e
 	}
 
 	if isDevBuild(currentVersion) {
-		fmt.Fprintf(w, "Development build detected, updating to latest release v%s...\n", latestClean)
+		fmt.Fprintf(w, "Development build detected, upgrading to latest release v%s...\n", latestClean)
 	} else {
-		fmt.Fprintf(w, "Updating tag v%s → v%s...\n", current, latestClean)
+		fmt.Fprintf(w, "Upgrading tag v%s → v%s...\n", current, latestClean)
 	}
 
 	binaryPath, err := resolveBinaryPath()
@@ -61,10 +62,10 @@ func updateAction(c *cli.Context, w io.Writer, currentVersion, repoURL string) e
 
 	updater := update.New(repoURL, w)
 	if err := updater.Update(c.Context, latest, binaryPath); err != nil {
-		return app.Errorf("update failed: %w", err)
+		return app.Errorf("upgrade failed: %w", err)
 	}
 
-	fmt.Fprintf(w, "Successfully updated to v%s!\n", latestClean)
+	fmt.Fprintf(w, "Successfully upgraded to v%s!\n", latestClean)
 
 	return nil
 }

--- a/internal/commands/upgrade_test.go
+++ b/internal/commands/upgrade_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func TestUT_UpdateAction_AlreadyUpToDate(t *testing.T) {
+func TestUT_UpgradeAction_AlreadyUpToDate(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "https://github.com/kaikenlabs/tag/releases/tag/v1.0.0", http.StatusFound)
 	}))
@@ -20,10 +20,10 @@ func TestUT_UpdateAction_AlreadyUpToDate(t *testing.T) {
 	app := &cli.App{
 		Commands: []*cli.Command{
 			{
-				Name: "update",
+				Name: "upgrade",
 				Action: func(c *cli.Context) error {
 					var buf bytes.Buffer
-					err := updateAction(c, &buf, "v1.0.0", srv.URL)
+					err := upgradeAction(c, &buf, "v1.0.0", srv.URL)
 					require.NoError(t, err)
 					assert.Contains(t, buf.String(), "Already up to date!")
 					return nil
@@ -31,13 +31,13 @@ func TestUT_UpdateAction_AlreadyUpToDate(t *testing.T) {
 			},
 		},
 	}
-	require.NoError(t, app.Run([]string{"app", "update"}))
+	require.NoError(t, app.Run([]string{"app", "upgrade"}))
 }
 
-func TestUT_UpdateAction_DevBuildProceeds(t *testing.T) {
-	// For dev builds, updateAction should NOT say "already up to date" — it should
-	// proceed to the update. We test that it at least reaches the "Development build"
-	// message and attempts to update (which will fail since we don't serve the archive).
+func TestUT_UpgradeAction_DevBuildProceeds(t *testing.T) {
+	// For dev builds, upgradeAction should NOT say "already up to date" — it should
+	// proceed to the upgrade. We test that it at least reaches the "Development build"
+	// message and attempts to upgrade (which will fail since we don't serve the archive).
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/releases/latest" {
 			http.Redirect(w, r, "https://github.com/kaikenlabs/tag/releases/tag/v2.0.0", http.StatusFound)
@@ -50,10 +50,10 @@ func TestUT_UpdateAction_DevBuildProceeds(t *testing.T) {
 	app := &cli.App{
 		Commands: []*cli.Command{
 			{
-				Name: "update",
+				Name: "upgrade",
 				Action: func(c *cli.Context) error {
 					var buf bytes.Buffer
-					err := updateAction(c, &buf, "dev", srv.URL)
+					err := upgradeAction(c, &buf, "dev", srv.URL)
 					// Will error because download fails, but should show dev build message.
 					assert.Contains(t, buf.String(), "Development build detected")
 					assert.Error(t, err)
@@ -62,10 +62,10 @@ func TestUT_UpdateAction_DevBuildProceeds(t *testing.T) {
 			},
 		},
 	}
-	require.NoError(t, app.Run([]string{"app", "update"}))
+	require.NoError(t, app.Run([]string{"app", "upgrade"}))
 }
 
-func TestUT_UpdateAction_UpdateAvailable(t *testing.T) {
+func TestUT_UpgradeAction_UpgradeAvailable(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/releases/latest" {
 			http.Redirect(w, r, "https://github.com/kaikenlabs/tag/releases/tag/v2.0.0", http.StatusFound)
@@ -79,29 +79,29 @@ func TestUT_UpdateAction_UpdateAvailable(t *testing.T) {
 	app := &cli.App{
 		Commands: []*cli.Command{
 			{
-				Name: "update",
+				Name: "upgrade",
 				Action: func(c *cli.Context) error {
 					var buf bytes.Buffer
-					err := updateAction(c, &buf, "v1.0.0", srv.URL)
-					// Will error because download fails, but should show update message.
-					assert.Contains(t, buf.String(), "Updating tag v1.0.0 → v2.0.0")
+					err := upgradeAction(c, &buf, "v1.0.0", srv.URL)
+					// Will error because download fails, but should show upgrade message.
+					assert.Contains(t, buf.String(), "Upgrading tag v1.0.0 → v2.0.0")
 					assert.Error(t, err)
 					return nil
 				},
 			},
 		},
 	}
-	require.NoError(t, app.Run([]string{"app", "update"}))
+	require.NoError(t, app.Run([]string{"app", "upgrade"}))
 }
 
-func TestUT_UpdateAction_FetchVersionError(t *testing.T) {
+func TestUT_UpgradeAction_FetchVersionError(t *testing.T) {
 	app := &cli.App{
 		Commands: []*cli.Command{
 			{
-				Name: "update",
+				Name: "upgrade",
 				Action: func(c *cli.Context) error {
 					var buf bytes.Buffer
-					err := updateAction(c, &buf, "v1.0.0", "http://127.0.0.1:1")
+					err := upgradeAction(c, &buf, "v1.0.0", "http://127.0.0.1:1")
 					require.Error(t, err)
 					assert.Contains(t, err.Error(), "failed to check for updates")
 					return nil
@@ -109,5 +109,5 @@ func TestUT_UpdateAction_FetchVersionError(t *testing.T) {
 			},
 		},
 	}
-	require.NoError(t, app.Run([]string{"app", "update"}))
+	require.NoError(t, app.Run([]string{"app", "upgrade"}))
 }

--- a/internal/commands/version.go
+++ b/internal/commands/version.go
@@ -76,7 +76,7 @@ func versionCheckAction(ctx context.Context, w io.Writer, currentVersion, repoUR
 	}
 
 	fmt.Fprintf(w, "Update available: v%s → v%s\n\n", current, latestClean)
-	fmt.Fprintf(w, "  tag update\n")
+	fmt.Fprintf(w, "  tag upgrade\n")
 
 	return nil
 }

--- a/internal/commands/version_test.go
+++ b/internal/commands/version_test.go
@@ -107,7 +107,7 @@ func TestUT_VersionCheckAction_UpdateAvailable(t *testing.T) {
 	err := versionCheckAction(context.Background(), &buf, "v1.0.0", srv.URL)
 	require.NoError(t, err)
 	assert.Contains(t, buf.String(), "Update available: v1.0.0 → v2.0.0")
-	assert.Contains(t, buf.String(), "tag update")
+	assert.Contains(t, buf.String(), "tag upgrade")
 }
 
 func TestUT_VersionCheckAction_DevBuild(t *testing.T) {

--- a/internal/remote/resolve.go
+++ b/internal/remote/resolve.go
@@ -1,0 +1,135 @@
+package remote
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/go-git/go-git/v5"
+	gitconfig "github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/storage/memory"
+)
+
+// LatestCommitResolver can resolve the latest commit SHA for a template
+// reference without performing a full clone.
+type LatestCommitResolver interface {
+	ResolveLatestCommit(ctx context.Context, ref *Reference) (string, error)
+}
+
+// ResolveLatestCommit resolves the latest commit SHA for the given reference
+// using git ls-remote. It does not clone the repository.
+//
+// Resolution precedence: exact tag match > exact branch match > HEAD (when ref
+// has no version). Annotated tags are peeled to their target commit.
+func (f *GitFetcher) ResolveLatestCommit(ctx context.Context, ref *Reference) (string, error) {
+	if ref == nil {
+		return "", errors.New("nil reference")
+	}
+
+	url := ref.URL
+	if url == "" {
+		return "", fmt.Errorf("empty URL in reference %q", ref.Original)
+	}
+
+	sha, err := f.lsRemoteResolve(ctx, ref, url)
+	if err != nil && canFallbackToSSH(ref) {
+		sshURL := fmt.Sprintf("git@%s:%s/%s.git", ref.Host, ref.Owner, ref.Repo)
+		sshRef := &Reference{URL: sshURL, Provider: ref.Provider, Version: ref.Version}
+		sha, err = f.lsRemoteResolve(ctx, sshRef, sshURL)
+	}
+	return sha, err
+}
+
+// lsRemoteResolve performs the actual ls-remote and resolves the ref version.
+func (f *GitFetcher) lsRemoteResolve(ctx context.Context, ref *Reference, url string) (string, error) {
+	remote := git.NewRemote(memory.NewStorage(), &gitconfig.RemoteConfig{
+		Name: "origin",
+		URLs: []string{url},
+	})
+
+	listOpts := &git.ListOptions{}
+	if auth, err := f.auth.GitAuth(ref); err == nil {
+		listOpts.Auth = auth
+	}
+
+	refs, err := remote.ListContext(ctx, listOpts)
+	if err != nil {
+		return "", fmt.Errorf("ls-remote %s: %s", url, sanitizeErrorMessage(err.Error()))
+	}
+
+	version := ref.Version
+	if version == "" {
+		return resolveHEADFromRefs(refs)
+	}
+
+	// Build lookup maps: tag refs and branch refs, peeling annotated tags.
+	tagCommits := make(map[string]string)    // tag name → commit SHA
+	branchCommits := make(map[string]string) // branch name → commit SHA
+	peeledTags := make(map[string]string)    // tag name → peeled commit SHA
+
+	for _, r := range refs {
+		name := r.Name().String()
+
+		switch {
+		case strings.HasPrefix(name, "refs/tags/"):
+			tagName := strings.TrimPrefix(name, "refs/tags/")
+			// Peeled refs (annotated tags) end with ^{}
+			if base, found := strings.CutSuffix(tagName, "^{}"); found {
+				peeledTags[base] = r.Hash().String()
+			} else {
+				tagCommits[tagName] = r.Hash().String()
+			}
+		case strings.HasPrefix(name, "refs/heads/"):
+			branchName := strings.TrimPrefix(name, "refs/heads/")
+			branchCommits[branchName] = r.Hash().String()
+		}
+	}
+
+	// Precedence: peeled tag > tag > branch
+	if sha, ok := peeledTags[version]; ok {
+		return sha, nil
+	}
+	if sha, ok := tagCommits[version]; ok {
+		return sha, nil
+	}
+	if sha, ok := branchCommits[version]; ok {
+		return sha, nil
+	}
+
+	return "", &FetchError{
+		Ref:     ref,
+		Message: fmt.Sprintf("ref %q not found (tried as tag and branch)", version),
+		Err:     ErrVersionNotFound,
+	}
+}
+
+// resolveHEADFromRefs finds HEAD in the ls-remote output.
+func resolveHEADFromRefs(refs []*plumbing.Reference) (string, error) {
+	// First pass: find HEAD directly.
+	var headTarget plumbing.ReferenceName
+	for _, r := range refs {
+		if r.Name() == plumbing.HEAD {
+			if r.Type() == plumbing.SymbolicReference {
+				headTarget = r.Target()
+				break
+			}
+			return r.Hash().String(), nil
+		}
+	}
+
+	// Second pass: resolve symbolic HEAD target.
+	if headTarget != "" {
+		for _, r := range refs {
+			if r.Name() == headTarget {
+				return r.Hash().String(), nil
+			}
+		}
+	}
+
+	return "", errors.New("HEAD not found in remote refs")
+}
+
+// Ensure GitFetcher implements LatestCommitResolver.
+var _ LatestCommitResolver = (*GitFetcher)(nil)

--- a/internal/remote/resolve_test.go
+++ b/internal/remote/resolve_test.go
@@ -1,0 +1,47 @@
+package remote
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUT_ResolveLatestCommit_NilReference(t *testing.T) {
+	fetcher := NewGitFetcher(NewEnvAuthProvider())
+	_, err := fetcher.ResolveLatestCommit(context.Background(), nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nil reference")
+}
+
+func TestUT_ResolveLatestCommit_EmptyURL(t *testing.T) {
+	fetcher := NewGitFetcher(NewEnvAuthProvider())
+	ref := &Reference{Original: "test", URL: ""}
+	_, err := fetcher.ResolveLatestCommit(context.Background(), ref)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty URL")
+}
+
+func TestUT_ResolveLatestCommit_InvalidHost(t *testing.T) {
+	fetcher := NewGitFetcher(NewEnvAuthProvider())
+	ref := &Reference{
+		Original: "invalid",
+		URL:      "https://invalid-host-for-test-12345.example/repo.git",
+		Version:  "main",
+	}
+	_, err := fetcher.ResolveLatestCommit(context.Background(), ref)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ls-remote")
+}
+
+func TestUT_ResolveHEADFromRefs_Empty(t *testing.T) {
+	_, err := resolveHEADFromRefs(nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "HEAD not found")
+}
+
+func TestUT_LatestCommitResolver_Interface(t *testing.T) {
+	// Verify GitFetcher satisfies LatestCommitResolver at compile time.
+	var _ LatestCommitResolver = (*GitFetcher)(nil)
+}

--- a/internal/templateupdate/backup.go
+++ b/internal/templateupdate/backup.go
@@ -1,0 +1,117 @@
+package templateupdate
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/kaikenlabs/tag/internal/types"
+)
+
+const backupDir = ".tag"
+
+// CreateBackup copies the specified files from projectDir into
+// .tag/backup/{timestamp}/ for restoration on --abort.
+// Returns the backup directory path.
+func CreateBackup(projectDir string, filePaths []string) (string, error) {
+	timestamp := time.Now().Format("20060102-150405")
+	backupPath := filepath.Join(projectDir, backupDir, "backup", timestamp)
+
+	if err := os.MkdirAll(backupPath, types.DirMode); err != nil {
+		return "", fmt.Errorf("create backup directory: %w", err)
+	}
+
+	for _, relPath := range filePaths {
+		srcPath := filepath.Join(projectDir, relPath)
+		dstPath := filepath.Join(backupPath, relPath)
+
+		// Skip files that don't exist (they're new files from template).
+		if _, err := os.Stat(srcPath); os.IsNotExist(err) {
+			continue
+		}
+
+		// Create parent directory in backup.
+		if err := os.MkdirAll(filepath.Dir(dstPath), types.DirMode); err != nil {
+			return "", fmt.Errorf("create backup dir for %s: %w", relPath, err)
+		}
+
+		if err := copyFile(srcPath, dstPath); err != nil {
+			return "", fmt.Errorf("backup %s: %w", relPath, err)
+		}
+	}
+
+	return backupPath, nil
+}
+
+// RestoreBackup restores files from a backup directory to the project.
+func RestoreBackup(projectDir, backupPath string) error {
+	if _, err := os.Stat(backupPath); os.IsNotExist(err) {
+		return fmt.Errorf("backup not found at %s", backupPath)
+	}
+
+	return filepath.WalkDir(backupPath, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+
+		relPath, err := filepath.Rel(backupPath, path)
+		if err != nil {
+			return fmt.Errorf("get relative path: %w", err)
+		}
+
+		if relPath == "." {
+			return nil
+		}
+
+		dstPath := filepath.Join(projectDir, relPath)
+
+		if d.IsDir() {
+			return os.MkdirAll(dstPath, types.DirMode)
+		}
+
+		return copyFile(path, dstPath)
+	})
+}
+
+// FindLatestBackup returns the path of the most recent backup directory,
+// or empty string if none exists.
+func FindLatestBackup(projectDir string) (string, error) {
+	backupsDir := filepath.Join(projectDir, backupDir, "backup")
+	entries, err := os.ReadDir(backupsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("read backup directory: %w", err)
+	}
+
+	if len(entries) == 0 {
+		return "", nil
+	}
+
+	// Entries are sorted lexically; timestamps sort correctly.
+	latest := entries[len(entries)-1]
+	return filepath.Join(backupsDir, latest.Name()), nil
+}
+
+// RemoveBackup removes a backup directory.
+func RemoveBackup(backupPath string) error {
+	return os.RemoveAll(backupPath)
+}
+
+// copyFile copies src to dst preserving file mode.
+func copyFile(src, dst string) error {
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return err
+	}
+
+	info, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(dst, data, info.Mode())
+}

--- a/internal/templateupdate/backup_test.go
+++ b/internal/templateupdate/backup_test.go
@@ -1,0 +1,89 @@
+package templateupdate
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUT_Backup_CreateAndRestore(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create files to back up.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "file1.txt"), []byte("original1"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "sub"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "sub", "file2.txt"), []byte("original2"), 0o644))
+
+	// Create backup.
+	backupPath, err := CreateBackup(dir, []string{"file1.txt", "sub/file2.txt"})
+	require.NoError(t, err)
+	assert.NotEmpty(t, backupPath)
+
+	// Modify original files.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "file1.txt"), []byte("modified1"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "sub", "file2.txt"), []byte("modified2"), 0o644))
+
+	// Restore.
+	require.NoError(t, RestoreBackup(dir, backupPath))
+
+	// Verify restoration.
+	content1, err := os.ReadFile(filepath.Join(dir, "file1.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "original1", string(content1))
+
+	content2, err := os.ReadFile(filepath.Join(dir, "sub", "file2.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "original2", string(content2))
+}
+
+func TestUT_Backup_SkipsNonexistentFiles(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "existing.txt"), []byte("data"), 0o644))
+
+	backupPath, err := CreateBackup(dir, []string{"existing.txt", "nonexistent.txt"})
+	require.NoError(t, err)
+
+	// Only existing file should be backed up.
+	_, err = os.Stat(filepath.Join(backupPath, "existing.txt"))
+	assert.NoError(t, err)
+	_, err = os.Stat(filepath.Join(backupPath, "nonexistent.txt"))
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestUT_Backup_Restore_MissingBackup(t *testing.T) {
+	dir := t.TempDir()
+	err := RestoreBackup(dir, filepath.Join(dir, "nonexistent-backup"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "backup not found")
+}
+
+func TestUT_Backup_FindLatestBackup(t *testing.T) {
+	dir := t.TempDir()
+
+	// No backups yet.
+	path, err := FindLatestBackup(dir)
+	require.NoError(t, err)
+	assert.Empty(t, path)
+
+	// Create backup directories.
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".tag", "backup", "20260101-100000"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".tag", "backup", "20260201-100000"), 0o755))
+
+	path, err = FindLatestBackup(dir)
+	require.NoError(t, err)
+	assert.Contains(t, path, "20260201-100000")
+}
+
+func TestUT_Backup_RemoveBackup(t *testing.T) {
+	dir := t.TempDir()
+	backupDir := filepath.Join(dir, "backup")
+	require.NoError(t, os.MkdirAll(backupDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(backupDir, "file.txt"), []byte("x"), 0o644))
+
+	require.NoError(t, RemoveBackup(backupDir))
+	_, err := os.Stat(backupDir)
+	assert.True(t, os.IsNotExist(err))
+}

--- a/internal/templateupdate/checker.go
+++ b/internal/templateupdate/checker.go
@@ -1,0 +1,95 @@
+package templateupdate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/kaikenlabs/tag/internal/remote"
+	"github.com/kaikenlabs/tag/internal/scaffold"
+)
+
+// CheckOptions configures the check operation.
+type CheckOptions struct {
+	ProjectDir string // Project directory (default: ".")
+	Ref        string // Override the template ref to check against
+}
+
+// CheckResult contains the outcome of a template freshness check.
+type CheckResult struct {
+	UpToDate   bool   // true if project matches latest template commit
+	CurrentSHA string // commit SHA stored in .tagconfig.json
+	LatestSHA  string // latest commit SHA from remote
+	Source     string // template source string
+}
+
+// Checker checks whether a project's template is up to date with upstream.
+type Checker struct {
+	resolver remote.LatestCommitResolver
+}
+
+// NewChecker creates a Checker with the given commit resolver.
+func NewChecker(resolver remote.LatestCommitResolver) *Checker {
+	return &Checker{resolver: resolver}
+}
+
+// Check reads the project's .tagconfig.json, resolves the latest upstream
+// commit, and compares them.
+func (c *Checker) Check(ctx context.Context, opts CheckOptions) (*CheckResult, error) {
+	projectDir := opts.ProjectDir
+	if projectDir == "" {
+		projectDir = "."
+	}
+
+	cfg, err := scaffold.LoadTagConfig(projectDir)
+	if err != nil {
+		return nil, fmt.Errorf("load project config: %w", err)
+	}
+
+	if valErr := validateTagConfig(cfg); valErr != nil {
+		return nil, valErr
+	}
+
+	// Build a reference for resolution.
+	ref, err := remote.Parse(cfg.Template.Source)
+	if err != nil {
+		return nil, fmt.Errorf("parse template source %q: %w", cfg.Template.Source, err)
+	}
+
+	// Override ref version if --ref flag provided.
+	if opts.Ref != "" {
+		ref.Version = opts.Ref
+	} else if cfg.Template.Ref != "" {
+		ref.Version = cfg.Template.Ref
+	}
+
+	latestSHA, err := c.resolver.ResolveLatestCommit(ctx, ref)
+	if err != nil {
+		return nil, fmt.Errorf("resolve latest commit: %w", err)
+	}
+
+	return &CheckResult{
+		UpToDate:   cfg.Template.CommitSHA == latestSHA,
+		CurrentSHA: cfg.Template.CommitSHA,
+		LatestSHA:  latestSHA,
+		Source:     cfg.Template.Source,
+	}, nil
+}
+
+// validateTagConfig checks that the tagconfig has the required fields for
+// template lifecycle operations.
+func validateTagConfig(cfg *scaffold.TagConfig) error {
+	if cfg.Template == nil {
+		return errors.New("no template metadata in .tagconfig.json — this project may predate template tracking")
+	}
+
+	if cfg.Template.Source == "" {
+		return errors.New("no template source in .tagconfig.json — cannot determine upstream template")
+	}
+
+	if cfg.Template.CommitSHA == "" {
+		return errors.New("no commit SHA in .tagconfig.json — this project was scaffolded before update tracking was added; re-scaffold or manually add a 'commit' field")
+	}
+
+	return nil
+}

--- a/internal/templateupdate/checker_test.go
+++ b/internal/templateupdate/checker_test.go
@@ -1,0 +1,157 @@
+package templateupdate
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kaikenlabs/tag/internal/remote"
+	"github.com/kaikenlabs/tag/internal/scaffold"
+	"github.com/kaikenlabs/tag/internal/types"
+)
+
+// mockResolver is a test double for LatestCommitResolver.
+type mockResolver struct {
+	sha string
+	err error
+}
+
+func (m *mockResolver) ResolveLatestCommit(_ context.Context, _ *remote.Reference) (string, error) {
+	return m.sha, m.err
+}
+
+func writeTagConfig(t *testing.T, dir string, cfg *scaffold.TagConfig) {
+	t.Helper()
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, types.TagConfigFile), data, 0o644))
+}
+
+func TestUT_Checker_Check_UpToDate(t *testing.T) {
+	dir := t.TempDir()
+	writeTagConfig(t, dir, &scaffold.TagConfig{
+		SchemaVersion: 1,
+		Template: &scaffold.TagTemplate{
+			Source:    "gh:acme/template",
+			CommitSHA: "abc123def456789012345678901234567890abcd",
+		},
+	})
+
+	resolver := &mockResolver{sha: "abc123def456789012345678901234567890abcd"}
+	checker := NewChecker(resolver)
+
+	result, err := checker.Check(context.Background(), CheckOptions{ProjectDir: dir})
+	require.NoError(t, err)
+	assert.True(t, result.UpToDate)
+	assert.Equal(t, "abc123def456789012345678901234567890abcd", result.CurrentSHA)
+	assert.Equal(t, "abc123def456789012345678901234567890abcd", result.LatestSHA)
+}
+
+func TestUT_Checker_Check_OutOfDate(t *testing.T) {
+	dir := t.TempDir()
+	writeTagConfig(t, dir, &scaffold.TagConfig{
+		SchemaVersion: 1,
+		Template: &scaffold.TagTemplate{
+			Source:    "gh:acme/template",
+			CommitSHA: "abc123def456789012345678901234567890abcd",
+		},
+	})
+
+	resolver := &mockResolver{sha: "def456789012345678901234567890abcdef12345"}
+	checker := NewChecker(resolver)
+
+	result, err := checker.Check(context.Background(), CheckOptions{ProjectDir: dir})
+	require.NoError(t, err)
+	assert.False(t, result.UpToDate)
+	assert.Equal(t, "abc123def456789012345678901234567890abcd", result.CurrentSHA)
+	assert.Equal(t, "def456789012345678901234567890abcdef12345", result.LatestSHA)
+}
+
+func TestUT_Checker_Check_MissingConfig(t *testing.T) {
+	dir := t.TempDir()
+	resolver := &mockResolver{sha: "abc123"}
+	checker := NewChecker(resolver)
+
+	_, err := checker.Check(context.Background(), CheckOptions{ProjectDir: dir})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "load project config")
+}
+
+func TestUT_Checker_Check_NoCommitSHA(t *testing.T) {
+	dir := t.TempDir()
+	writeTagConfig(t, dir, &scaffold.TagConfig{
+		SchemaVersion: 1,
+		Template: &scaffold.TagTemplate{
+			Source: "gh:acme/template",
+			// No CommitSHA
+		},
+	})
+
+	resolver := &mockResolver{sha: "abc123"}
+	checker := NewChecker(resolver)
+
+	_, err := checker.Check(context.Background(), CheckOptions{ProjectDir: dir})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no commit SHA")
+}
+
+func TestUT_Checker_Check_NoTemplate(t *testing.T) {
+	dir := t.TempDir()
+	writeTagConfig(t, dir, &scaffold.TagConfig{
+		SchemaVersion: 1,
+		// No Template
+	})
+
+	resolver := &mockResolver{sha: "abc123"}
+	checker := NewChecker(resolver)
+
+	_, err := checker.Check(context.Background(), CheckOptions{ProjectDir: dir})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no template metadata")
+}
+
+func TestUT_Checker_Check_ResolverError(t *testing.T) {
+	dir := t.TempDir()
+	writeTagConfig(t, dir, &scaffold.TagConfig{
+		SchemaVersion: 1,
+		Template: &scaffold.TagTemplate{
+			Source:    "gh:acme/template",
+			CommitSHA: "abc123def456789012345678901234567890abcd",
+		},
+	})
+
+	resolver := &mockResolver{err: assert.AnError}
+	checker := NewChecker(resolver)
+
+	_, err := checker.Check(context.Background(), CheckOptions{ProjectDir: dir})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "resolve latest commit")
+}
+
+func TestUT_Checker_Check_RefOverride(t *testing.T) {
+	dir := t.TempDir()
+	writeTagConfig(t, dir, &scaffold.TagConfig{
+		SchemaVersion: 1,
+		Template: &scaffold.TagTemplate{
+			Source:    "gh:acme/template",
+			CommitSHA: "abc123def456789012345678901234567890abcd",
+			Ref:       "main",
+		},
+	})
+
+	// Resolver always returns different SHA to verify the ref override is used.
+	resolver := &mockResolver{sha: "different_sha_for_different_ref_1234567"}
+	checker := NewChecker(resolver)
+
+	result, err := checker.Check(context.Background(), CheckOptions{
+		ProjectDir: dir,
+		Ref:        "v2.0",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.UpToDate)
+}

--- a/internal/templateupdate/differ.go
+++ b/internal/templateupdate/differ.go
@@ -1,0 +1,121 @@
+package templateupdate
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kaikenlabs/tag/internal/remote"
+	"github.com/kaikenlabs/tag/internal/scaffold"
+)
+
+// DiffOptions configures the diff operation.
+type DiffOptions struct {
+	ProjectDir string // Project directory (default: ".")
+	Ref        string // Override template ref
+}
+
+// DiffResult contains the outcome of a template diff operation.
+type DiffResult struct {
+	OldSHA  string        // commit SHA from .tagconfig.json
+	NewSHA  string        // latest commit SHA from remote
+	Source  string        // template source string
+	Results []MergeResult // merge results from dry-run
+	Skipped []string      // paths skipped by ignore rules
+}
+
+// Differ performs a dry-run 3-way merge to show what would change on update.
+type Differ struct {
+	renderer *HistoricalRenderer
+	resolver remote.LatestCommitResolver
+}
+
+// NewDiffer creates a Differ with the given renderer and resolver.
+func NewDiffer(renderer *HistoricalRenderer, resolver remote.LatestCommitResolver) *Differ {
+	return &Differ{renderer: renderer, resolver: resolver}
+}
+
+// Diff computes the differences between the current project and the latest
+// template version. It performs a full 3-way merge in dry-run mode.
+func (d *Differ) Diff(ctx context.Context, opts DiffOptions) (*DiffResult, error) {
+	projectDir := opts.ProjectDir
+	if projectDir == "" {
+		projectDir = "."
+	}
+
+	cfg, err := scaffold.LoadTagConfig(projectDir)
+	if err != nil {
+		return nil, fmt.Errorf("load project config: %w", err)
+	}
+
+	if valErr := validateTagConfig(cfg); valErr != nil {
+		return nil, valErr
+	}
+
+	// Resolve latest commit.
+	ref, err := remote.Parse(cfg.Template.Source)
+	if err != nil {
+		return nil, fmt.Errorf("parse template source: %w", err)
+	}
+
+	if opts.Ref != "" {
+		ref.Version = opts.Ref
+	} else if cfg.Template.Ref != "" {
+		ref.Version = cfg.Template.Ref
+	}
+
+	latestSHA, err := d.resolver.ResolveLatestCommit(ctx, ref)
+	if err != nil {
+		return nil, fmt.Errorf("resolve latest commit: %w", err)
+	}
+
+	if cfg.Template.CommitSHA == latestSHA {
+		return &DiffResult{
+			OldSHA: cfg.Template.CommitSHA,
+			NewSHA: latestSHA,
+			Source: cfg.Template.Source,
+		}, nil
+	}
+
+	// Build template URL for rendering.
+	templateURL := ref.URL
+
+	// Render base (old commit) and theirs (new commit).
+	base, theirs, err := d.renderer.RenderPair(ctx, templateURL, cfg.Template.CommitSHA, latestSHA, cfg.Variables)
+	if err != nil {
+		return nil, fmt.Errorf("render templates: %w", err)
+	}
+
+	// Read user's project files as "ours".
+	ours, err := ReadProjectFiles(projectDir)
+	if err != nil {
+		return nil, fmt.Errorf("read project files: %w", err)
+	}
+
+	// Build ignore matcher.
+	ignoreMatcher, err := NewIgnoreMatcher(IgnoreMatcherOptions{
+		ProjectRoot:       projectDir,
+		TagconfigPatterns: cfg.SkipPatterns,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("build ignore matcher: %w", err)
+	}
+
+	// Run 3-way merge. Adapt IgnoreMatcher to MergeEngine's signature
+	// (files in the merge tree are never directories).
+	ignoreFn := func(path string) bool {
+		return ignoreMatcher.ShouldSkip(path, false)
+	}
+	merger := NewMergeEngine(&GitMerger{}, ignoreFn)
+	results, skipped, err := merger.MergeTrees(ctx, base, ours, theirs)
+	if err != nil {
+		return nil, fmt.Errorf("merge trees: %w", err)
+	}
+
+	return &DiffResult{
+		OldSHA:  cfg.Template.CommitSHA,
+		NewSHA:  latestSHA,
+		Source:  cfg.Template.Source,
+		Results: results,
+		Skipped: skipped,
+	}, nil
+}

--- a/internal/templateupdate/format.go
+++ b/internal/templateupdate/format.go
@@ -1,0 +1,223 @@
+package templateupdate
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/kaikenlabs/tag/internal/chalk"
+)
+
+// FormatOptions controls diff output formatting.
+type FormatOptions struct {
+	Color  bool // Enable ANSI color output
+	Stat   bool // Show diffstat instead of full diff
+	Writer io.Writer
+}
+
+// FormatDiff writes the diff output for the given merge results.
+func FormatDiff(results []MergeResult, source, oldSHA, newSHA string, opts FormatOptions) {
+	w := opts.Writer
+	if w == nil {
+		return
+	}
+
+	// Header.
+	header := fmt.Sprintf("Template: %s (%s → %s)\n", source, shortSHA(oldSHA), shortSHA(newSHA))
+	if opts.Color {
+		fmt.Fprintf(w, "%s\n", chalk.Cyan(header))
+	} else {
+		fmt.Fprintf(w, "%s\n", header)
+	}
+
+	if opts.Stat {
+		formatDiffstat(w, results, opts.Color)
+		return
+	}
+
+	formatUnified(w, results, opts.Color)
+}
+
+// formatUnified writes unified diff output.
+func formatUnified(w io.Writer, results []MergeResult, color bool) {
+	for _, r := range results {
+		switch r.Op {
+		case MergeAdd:
+			formatFileAdd(w, r, color)
+		case MergeDelete:
+			formatFileDelete(w, r, color)
+		case MergeUpdate:
+			formatFileUpdate(w, r, color)
+		case MergeConflict:
+			formatFileConflict(w, r, color)
+		case MergeKeep, MergeUserAdded:
+			// No output for unchanged files.
+		}
+	}
+}
+
+// formatFileAdd formats a newly added file.
+func formatFileAdd(w io.Writer, r MergeResult, color bool) {
+	header := "--- /dev/null\n+++ b/" + r.Path
+	if color {
+		fmt.Fprintln(w, chalk.Cyan(header))
+	} else {
+		fmt.Fprintln(w, header)
+	}
+
+	for line := range strings.SplitSeq(string(r.Content), "\n") {
+		added := "+" + line
+		if color {
+			fmt.Fprintln(w, chalk.Green(added))
+		} else {
+			fmt.Fprintln(w, added)
+		}
+	}
+	fmt.Fprintln(w)
+}
+
+// formatFileDelete formats a deleted file.
+func formatFileDelete(w io.Writer, r MergeResult, color bool) {
+	header := fmt.Sprintf("--- a/%s\n+++ /dev/null", r.Path)
+	if color {
+		fmt.Fprintln(w, chalk.Cyan(header))
+	} else {
+		fmt.Fprintln(w, header)
+	}
+
+	if r.BaseContent != nil {
+		for line := range strings.SplitSeq(string(r.BaseContent), "\n") {
+			removed := "-" + line
+			if color {
+				fmt.Fprintln(w, chalk.Red(removed))
+			} else {
+				fmt.Fprintln(w, removed)
+			}
+		}
+	}
+	fmt.Fprintln(w)
+}
+
+// formatFileUpdate formats a modified file showing additions and deletions.
+func formatFileUpdate(w io.Writer, r MergeResult, color bool) {
+	header := fmt.Sprintf("--- a/%s\n+++ b/%s", r.Path, r.Path)
+	if color {
+		fmt.Fprintln(w, chalk.Cyan(header))
+	} else {
+		fmt.Fprintln(w, header)
+	}
+
+	// Simple line diff between ours and merged content.
+	oursLines := splitLines(r.OursContent)
+	mergedLines := splitLines(r.Content)
+	writeSimpleDiff(w, oursLines, mergedLines, color)
+	fmt.Fprintln(w)
+}
+
+// formatFileConflict formats a conflicted file with a warning.
+func formatFileConflict(w io.Writer, r MergeResult, color bool) {
+	warning := fmt.Sprintf("⚠ %s (conflict)", r.Path)
+	if color {
+		fmt.Fprintln(w, chalk.Yellow(warning))
+	} else {
+		fmt.Fprintln(w, warning)
+	}
+}
+
+// formatDiffstat writes a compact summary of changes.
+func formatDiffstat(w io.Writer, results []MergeResult, color bool) {
+	var added, modified, deleted, conflicted int
+
+	for _, r := range results {
+		switch r.Op {
+		case MergeAdd:
+			added++
+			symbol := "+"
+			if color {
+				fmt.Fprintf(w, " %s %s\n", chalk.Green(symbol), r.Path)
+			} else {
+				fmt.Fprintf(w, " %s %s\n", symbol, r.Path)
+			}
+		case MergeUpdate:
+			modified++
+			symbol := "~"
+			if color {
+				fmt.Fprintf(w, " %s %s\n", chalk.Cyan(symbol), r.Path)
+			} else {
+				fmt.Fprintf(w, " %s %s\n", symbol, r.Path)
+			}
+		case MergeDelete:
+			deleted++
+			symbol := "-"
+			if color {
+				fmt.Fprintf(w, " %s %s\n", chalk.Red(symbol), r.Path)
+			} else {
+				fmt.Fprintf(w, " %s %s\n", symbol, r.Path)
+			}
+		case MergeConflict:
+			conflicted++
+			symbol := "!"
+			if color {
+				fmt.Fprintf(w, " %s %s\n", chalk.Yellow(symbol), r.Path)
+			} else {
+				fmt.Fprintf(w, " %s %s\n", symbol, r.Path)
+			}
+		case MergeKeep, MergeUserAdded:
+			// Skip unchanged files in stat view.
+		}
+	}
+
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "%d file(s) added, %d modified, %d deleted", added, modified, deleted)
+	if conflicted > 0 {
+		fmt.Fprintf(w, ", %d conflicted", conflicted)
+	}
+	fmt.Fprintln(w)
+}
+
+// writeSimpleDiff writes a basic line diff (additions and removals).
+func writeSimpleDiff(w io.Writer, old, updated []string, color bool) {
+	// Simple approach: show removed then added lines.
+	// A production diff would use a proper LCS algorithm.
+	oldSet := make(map[string]int)
+	for _, l := range old {
+		oldSet[l]++
+	}
+	newSet := make(map[string]int)
+	for _, l := range updated {
+		newSet[l]++
+	}
+
+	for _, l := range old {
+		if newSet[l] <= 0 {
+			line := "-" + l
+			if color {
+				fmt.Fprintln(w, chalk.Red(line))
+			} else {
+				fmt.Fprintln(w, line)
+			}
+		} else {
+			newSet[l]--
+		}
+	}
+	for _, l := range updated {
+		if oldSet[l] <= 0 {
+			line := "+" + l
+			if color {
+				fmt.Fprintln(w, chalk.Green(line))
+			} else {
+				fmt.Fprintln(w, line)
+			}
+		} else {
+			oldSet[l]--
+		}
+	}
+}
+
+// splitLines splits content into lines, handling nil gracefully.
+func splitLines(content []byte) []string {
+	if content == nil {
+		return nil
+	}
+	return strings.Split(string(content), "\n")
+}

--- a/internal/templateupdate/format_test.go
+++ b/internal/templateupdate/format_test.go
@@ -1,0 +1,120 @@
+package templateupdate
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUT_FormatDiff_EmptyResults(t *testing.T) {
+	var buf bytes.Buffer
+	FormatDiff(nil, "gh:acme/tmpl", "abc1234", "def5678", FormatOptions{
+		Writer: &buf,
+	})
+	assert.Contains(t, buf.String(), "abc1234")
+	assert.Contains(t, buf.String(), "def5678")
+}
+
+func TestUT_FormatDiff_Stat(t *testing.T) {
+	results := []MergeResult{
+		{Path: "new.txt", Op: MergeAdd, Content: []byte("hello")},
+		{Path: "changed.txt", Op: MergeUpdate, Content: []byte("new"), OursContent: []byte("old")},
+		{Path: "gone.txt", Op: MergeDelete},
+	}
+
+	var buf bytes.Buffer
+	FormatDiff(results, "gh:acme/tmpl", "aaa", "bbb", FormatOptions{
+		Writer: &buf,
+		Stat:   true,
+	})
+
+	output := buf.String()
+	assert.Contains(t, output, "new.txt")
+	assert.Contains(t, output, "changed.txt")
+	assert.Contains(t, output, "gone.txt")
+	assert.Contains(t, output, "1 file(s) added")
+	assert.Contains(t, output, "1 modified")
+	assert.Contains(t, output, "1 deleted")
+}
+
+func TestUT_FormatDiff_Unified_AddedFile(t *testing.T) {
+	results := []MergeResult{
+		{Path: "new.txt", Op: MergeAdd, Content: []byte("line1\nline2")},
+	}
+
+	var buf bytes.Buffer
+	FormatDiff(results, "src", "aaa", "bbb", FormatOptions{
+		Writer: &buf,
+	})
+
+	output := buf.String()
+	assert.Contains(t, output, "+++ b/new.txt")
+	assert.Contains(t, output, "+line1")
+}
+
+func TestUT_FormatDiff_Unified_DeletedFile(t *testing.T) {
+	results := []MergeResult{
+		{Path: "old.txt", Op: MergeDelete, BaseContent: []byte("removed")},
+	}
+
+	var buf bytes.Buffer
+	FormatDiff(results, "src", "aaa", "bbb", FormatOptions{
+		Writer: &buf,
+	})
+
+	output := buf.String()
+	assert.Contains(t, output, "--- a/old.txt")
+	assert.Contains(t, output, "-removed")
+}
+
+func TestUT_FormatDiff_Conflict(t *testing.T) {
+	results := []MergeResult{
+		{Path: "conflict.txt", Op: MergeConflict},
+	}
+
+	var buf bytes.Buffer
+	FormatDiff(results, "src", "aaa", "bbb", FormatOptions{
+		Writer: &buf,
+	})
+
+	assert.Contains(t, buf.String(), "conflict.txt")
+	assert.Contains(t, buf.String(), "conflict")
+}
+
+func TestUT_FormatDiff_NoColor(t *testing.T) {
+	results := []MergeResult{
+		{Path: "new.txt", Op: MergeAdd, Content: []byte("data")},
+	}
+
+	var buf bytes.Buffer
+	FormatDiff(results, "src", "aaa", "bbb", FormatOptions{
+		Writer: &buf,
+		Color:  false,
+	})
+
+	output := buf.String()
+	// Should not contain ANSI escape codes.
+	assert.NotContains(t, output, "\033[")
+}
+
+func TestUT_FormatDiff_SkipsUnchanged(t *testing.T) {
+	results := []MergeResult{
+		{Path: "keep.txt", Op: MergeKeep},
+		{Path: "user.txt", Op: MergeUserAdded},
+	}
+
+	var buf bytes.Buffer
+	FormatDiff(results, "src", "aaa", "bbb", FormatOptions{
+		Writer: &buf,
+		Stat:   true,
+	})
+
+	output := buf.String()
+	assert.Contains(t, output, "0 file(s) added, 0 modified, 0 deleted")
+}
+
+func TestUT_FormatDiff_NilWriter(t *testing.T) {
+	// Should not panic.
+	FormatDiff(nil, "src", "aaa", "bbb", FormatOptions{Writer: nil})
+}

--- a/internal/templateupdate/renderpair.go
+++ b/internal/templateupdate/renderpair.go
@@ -1,0 +1,37 @@
+package templateupdate
+
+import (
+	"context"
+	"fmt"
+)
+
+// RenderPair renders the template at two commits (old and new) and returns
+// pointer maps suitable for MergeTrees. This provides a clean API for future
+// single-clone optimization while currently calling RenderAt twice.
+func (r *HistoricalRenderer) RenderPair(
+	ctx context.Context,
+	templateURL string,
+	oldSHA string,
+	newSHA string,
+	vars map[string]any,
+) (base, theirs map[string]*RenderedFile, err error) {
+	baseValues, err := r.RenderAt(ctx, templateURL, oldSHA, vars)
+	if err != nil {
+		return nil, nil, fmt.Errorf("render base (commit %s): %w", shortSHA(oldSHA), err)
+	}
+
+	theirsValues, err := r.RenderAt(ctx, templateURL, newSHA, vars)
+	if err != nil {
+		return nil, nil, fmt.Errorf("render theirs (commit %s): %w", shortSHA(newSHA), err)
+	}
+
+	return ToPointerMap(baseValues), ToPointerMap(theirsValues), nil
+}
+
+// shortSHA returns the first 7 characters of a SHA for display.
+func shortSHA(sha string) string {
+	if len(sha) > 7 {
+		return sha[:7]
+	}
+	return sha
+}

--- a/internal/templateupdate/renderpair_test.go
+++ b/internal/templateupdate/renderpair_test.go
@@ -1,0 +1,38 @@
+package templateupdate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUT_ShortSHA(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"abc123def456789012345678901234567890abcd", "abc123d"},
+		{"short", "short"},
+		{"abc1234", "abc1234"},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.expected, shortSHA(tt.input))
+	}
+}
+
+func TestUT_ToPointerMap_EmptyInput(t *testing.T) {
+	result := ToPointerMap(nil)
+	assert.Empty(t, result)
+}
+
+func TestUT_ToPointerMap_PreservesContent(t *testing.T) {
+	input := map[string]RenderedFile{
+		"file.txt": {Content: []byte("content"), Mode: 0o644, IsBinary: false},
+	}
+
+	result := ToPointerMap(input)
+	assert.Equal(t, []byte("content"), result["file.txt"].Content)
+	assert.Equal(t, input["file.txt"].Mode, result["file.txt"].Mode)
+}

--- a/internal/templateupdate/snapshot.go
+++ b/internal/templateupdate/snapshot.go
@@ -1,0 +1,107 @@
+package templateupdate
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/kaikenlabs/tag/internal/fileutil"
+	"github.com/kaikenlabs/tag/internal/types"
+)
+
+// ReadProjectFiles walks the project directory and returns an in-memory snapshot
+// of all files as a map of forward-slash paths to RenderedFile pointers.
+//
+// It skips the .tag/ directory, .git/, and the .tagconfig.json file itself.
+// Binary detection uses the same heuristic as template rendering.
+func ReadProjectFiles(projectDir string) (map[string]*RenderedFile, error) {
+	files := make(map[string]*RenderedFile)
+
+	err := filepath.WalkDir(projectDir, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+
+		relPath, relErr := filepath.Rel(projectDir, path)
+		if relErr != nil {
+			return fmt.Errorf("get relative path: %w", relErr)
+		}
+
+		if relPath == "." {
+			return nil
+		}
+
+		// Normalize to forward slashes for consistent keys.
+		normalizedPath := filepath.ToSlash(relPath)
+
+		// Skip internal directories.
+		if d.IsDir() && shouldSkipDir(normalizedPath) {
+			return filepath.SkipDir
+		}
+
+		// Skip symlinks and directories.
+		if d.IsDir() || d.Type()&os.ModeSymlink != 0 {
+			return nil
+		}
+
+		// Skip TAG metadata files at root.
+		if isProjectMetaFile(normalizedPath) {
+			return nil
+		}
+
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", normalizedPath, err)
+		}
+
+		info, err := d.Info()
+		if err != nil {
+			return fmt.Errorf("stat %s: %w", normalizedPath, err)
+		}
+
+		files[normalizedPath] = &RenderedFile{
+			Content:  content,
+			Mode:     sanitizeFileMode(info.Mode()),
+			IsBinary: !fileutil.IsTextContent(content),
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("walk project directory: %w", err)
+	}
+
+	return files, nil
+}
+
+// shouldSkipDir returns true for directories that should be excluded from the
+// project snapshot.
+func shouldSkipDir(normalizedPath string) bool {
+	switch normalizedPath {
+	case ".git", types.TemplatesDir:
+		return true
+	default:
+		return false
+	}
+}
+
+// isProjectMetaFile returns true for root-level TAG metadata files.
+func isProjectMetaFile(normalizedPath string) bool {
+	dir := filepath.Dir(normalizedPath)
+	if dir != "." {
+		return false
+	}
+
+	name := filepath.Base(normalizedPath)
+	return name == types.TagConfigFile || name == ".tagignore"
+}
+
+// ToPointerMap converts a value map to a pointer map for MergeTrees compatibility.
+func ToPointerMap(m map[string]RenderedFile) map[string]*RenderedFile {
+	result := make(map[string]*RenderedFile, len(m))
+	for k, v := range m {
+		result[k] = &v
+	}
+	return result
+}

--- a/internal/templateupdate/snapshot_test.go
+++ b/internal/templateupdate/snapshot_test.go
@@ -1,0 +1,88 @@
+package templateupdate
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUT_ReadProjectFiles_Success(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "README.md"), []byte("# Hello"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "src"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "src", "main.go"), []byte("package main"), 0o644))
+
+	files, err := ReadProjectFiles(dir)
+	require.NoError(t, err)
+	assert.Len(t, files, 2)
+	assert.Contains(t, files, "README.md")
+	assert.Contains(t, files, "src/main.go")
+	assert.Equal(t, []byte("# Hello"), files["README.md"].Content)
+	assert.False(t, files["README.md"].IsBinary)
+}
+
+func TestUT_ReadProjectFiles_SkipsGitDir(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".git", "objects"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".git", "HEAD"), []byte("ref: refs/heads/main"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "file.txt"), []byte("content"), 0o644))
+
+	files, err := ReadProjectFiles(dir)
+	require.NoError(t, err)
+	assert.Len(t, files, 1)
+	assert.Contains(t, files, "file.txt")
+}
+
+func TestUT_ReadProjectFiles_SkipsTagConfigFile(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".tagconfig.json"), []byte("{}"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "app.go"), []byte("package app"), 0o644))
+
+	files, err := ReadProjectFiles(dir)
+	require.NoError(t, err)
+	assert.Len(t, files, 1)
+	assert.Contains(t, files, "app.go")
+	assert.NotContains(t, files, ".tagconfig.json")
+}
+
+func TestUT_ReadProjectFiles_EmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	files, err := ReadProjectFiles(dir)
+	require.NoError(t, err)
+	assert.Empty(t, files)
+}
+
+func TestUT_ReadProjectFiles_BinaryDetection(t *testing.T) {
+	dir := t.TempDir()
+	binary := []byte{0x89, 0x50, 0x4E, 0x47, 0x00, 0x00, 0x01}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "image.png"), binary, 0o644))
+
+	files, err := ReadProjectFiles(dir)
+	require.NoError(t, err)
+	assert.True(t, files["image.png"].IsBinary)
+}
+
+func TestUT_ReadProjectFiles_NormalizesPaths(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "a", "b"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a", "b", "c.txt"), []byte("x"), 0o644))
+
+	files, err := ReadProjectFiles(dir)
+	require.NoError(t, err)
+	assert.Contains(t, files, "a/b/c.txt")
+}
+
+func TestUT_ToPointerMap(t *testing.T) {
+	m := map[string]RenderedFile{
+		"a.txt": {Content: []byte("a"), Mode: 0o644},
+		"b.txt": {Content: []byte("b"), Mode: 0o755},
+	}
+
+	pm := ToPointerMap(m)
+	assert.Len(t, pm, 2)
+	assert.Equal(t, []byte("a"), pm["a.txt"].Content)
+	assert.Equal(t, []byte("b"), pm["b.txt"].Content)
+}

--- a/internal/templateupdate/updater.go
+++ b/internal/templateupdate/updater.go
@@ -1,0 +1,412 @@
+package templateupdate
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/kaikenlabs/tag/internal/remote"
+	"github.com/kaikenlabs/tag/internal/scaffold"
+	"github.com/kaikenlabs/tag/internal/types"
+)
+
+// UpdateMode defines the operational mode for the update command.
+type UpdateMode int
+
+const (
+	// UpdateModeApply is the default mode: compute and apply changes.
+	UpdateModeApply UpdateMode = iota
+	// UpdateModeContinue resumes after manual conflict resolution.
+	UpdateModeContinue
+	// UpdateModeAbort restores from backup and cancels in-progress update.
+	UpdateModeAbort
+)
+
+// UpdateOptions configures the update operation.
+type UpdateOptions struct {
+	ProjectDir   string
+	Ref          string
+	VarOverrides map[string]string
+	ResolveMode  ResolveMode
+	SkipPatterns []string
+	DryRun       bool
+	Backup       bool
+	Mode         UpdateMode
+}
+
+// UpdateResult contains the outcome of an update operation.
+type UpdateResult struct {
+	OldSHA       string
+	NewSHA       string
+	Applied      []MergeResult
+	Conflicts    *ConflictReport
+	NewFiles     int
+	UpdatedFiles int
+	DeletedFiles int
+}
+
+// Updater applies upstream template changes to the user's project.
+type Updater struct {
+	renderer *HistoricalRenderer
+	resolver remote.LatestCommitResolver
+}
+
+// NewUpdater creates an Updater with the given renderer and resolver.
+func NewUpdater(renderer *HistoricalRenderer, resolver remote.LatestCommitResolver) *Updater {
+	return &Updater{renderer: renderer, resolver: resolver}
+}
+
+// Update performs the template update operation.
+func (u *Updater) Update(ctx context.Context, opts UpdateOptions) (*UpdateResult, error) {
+	projectDir := opts.ProjectDir
+	if projectDir == "" {
+		projectDir = "."
+	}
+
+	switch opts.Mode {
+	case UpdateModeContinue:
+		return u.continueUpdate(projectDir)
+	case UpdateModeAbort:
+		return u.abortUpdate(projectDir)
+	default:
+		return u.applyUpdate(ctx, projectDir, opts)
+	}
+}
+
+// resolveUpdateContext holds the resolved state needed to perform a merge.
+type resolveUpdateContext struct {
+	cfg       *scaffold.TagConfig
+	ref       *remote.Reference
+	latestSHA string
+	vars      map[string]any
+}
+
+// resolveUpdate performs pre-flight checks and resolves the latest upstream commit.
+func (u *Updater) resolveUpdate(ctx context.Context, projectDir string, opts UpdateOptions) (*resolveUpdateContext, *UpdateResult, error) {
+	cfg, err := scaffold.LoadTagConfig(projectDir)
+	if err != nil {
+		return nil, nil, fmt.Errorf("load project config: %w", err)
+	}
+
+	if valErr := validateTagConfig(cfg); valErr != nil {
+		return nil, nil, valErr
+	}
+
+	// Check for pending conflicts.
+	status, statusErr := ReadConflictStatus(projectDir)
+	if statusErr != nil {
+		return nil, nil, fmt.Errorf("read conflict status: %w", statusErr)
+	}
+	if status != nil {
+		return nil, nil, errors.New("pending conflicts from a previous update — run 'tag update --continue' or 'tag update --abort'")
+	}
+
+	ref, err := remote.Parse(cfg.Template.Source)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parse template source: %w", err)
+	}
+
+	if opts.Ref != "" {
+		ref.Version = opts.Ref
+	} else if cfg.Template.Ref != "" {
+		ref.Version = cfg.Template.Ref
+	}
+
+	latestSHA, err := u.resolver.ResolveLatestCommit(ctx, ref)
+	if err != nil {
+		return nil, nil, fmt.Errorf("resolve latest commit: %w", err)
+	}
+
+	if cfg.Template.CommitSHA == latestSHA {
+		return nil, &UpdateResult{
+			OldSHA: cfg.Template.CommitSHA,
+			NewSHA: latestSHA,
+		}, nil
+	}
+
+	return &resolveUpdateContext{
+		cfg:       cfg,
+		ref:       ref,
+		latestSHA: latestSHA,
+		vars:      mergeVars(cfg.Variables, opts.VarOverrides),
+	}, nil, nil
+}
+
+// performMerge renders both template versions and performs the 3-way merge.
+func (u *Updater) performMerge(ctx context.Context, projectDir string, rctx *resolveUpdateContext, opts UpdateOptions) ([]MergeResult, *ConflictReport, error) {
+	base, theirs, err := u.renderer.RenderPair(ctx, rctx.ref.URL, rctx.cfg.Template.CommitSHA, rctx.latestSHA, rctx.vars)
+	if err != nil {
+		return nil, nil, fmt.Errorf("render templates: %w", err)
+	}
+
+	ours, err := ReadProjectFiles(projectDir)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read project files: %w", err)
+	}
+
+	allSkipPatterns := make([]string, 0, len(rctx.cfg.SkipPatterns)+len(opts.SkipPatterns))
+	allSkipPatterns = append(allSkipPatterns, rctx.cfg.SkipPatterns...)
+	allSkipPatterns = append(allSkipPatterns, opts.SkipPatterns...)
+	ignoreMatcher, err := NewIgnoreMatcher(IgnoreMatcherOptions{
+		ProjectRoot:       projectDir,
+		TagconfigPatterns: allSkipPatterns,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("build ignore matcher: %w", err)
+	}
+
+	ignoreFn := func(path string) bool {
+		return ignoreMatcher.ShouldSkip(path, false)
+	}
+	merger := NewMergeEngine(&GitMerger{}, ignoreFn)
+	results, skipped, err := merger.MergeTrees(ctx, base, ours, theirs)
+	if err != nil {
+		return nil, nil, fmt.Errorf("merge trees: %w", err)
+	}
+
+	report := NewConflictReport(results, skipped)
+
+	if opts.ResolveMode != ResolveNone && report.HasConflicts() {
+		resolved := ResolveConflicts(report, opts.ResolveMode)
+		results = replaceConflicts(results, resolved)
+		report = NewConflictReport(results, skipped)
+	}
+
+	return results, report, nil
+}
+
+// finalizeUpdate applies merge results and updates the project config.
+func finalizeUpdate(projectDir string, result *UpdateResult, report *ConflictReport, cfg *scaffold.TagConfig, latestSHA, refVersion string, vars map[string]any) error {
+	if applyErr := applyResults(projectDir, result.Applied); applyErr != nil {
+		return fmt.Errorf("apply changes: %w", applyErr)
+	}
+
+	if report.HasConflicts() {
+		conflictStatus := NewConflictStatus(report, latestSHA)
+		if writeErr := WriteConflictStatus(projectDir, conflictStatus); writeErr != nil {
+			return fmt.Errorf("write conflict status: %w", writeErr)
+		}
+		return nil
+	}
+
+	if updateErr := updateTagConfig(projectDir, cfg, latestSHA, refVersion, vars); updateErr != nil {
+		return fmt.Errorf("update tagconfig: %w", updateErr)
+	}
+	return nil
+}
+
+// applyUpdate runs the full update workflow.
+func (u *Updater) applyUpdate(ctx context.Context, projectDir string, opts UpdateOptions) (*UpdateResult, error) {
+	rctx, earlyResult, err := u.resolveUpdate(ctx, projectDir, opts)
+	if err != nil {
+		return nil, err
+	}
+	if earlyResult != nil {
+		return earlyResult, nil
+	}
+
+	results, report, err := u.performMerge(ctx, projectDir, rctx, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	// Backup affected files.
+	if opts.Backup && !opts.DryRun {
+		affectedPaths := collectAffectedPaths(results)
+		if len(affectedPaths) > 0 {
+			if _, backupErr := CreateBackup(projectDir, affectedPaths); backupErr != nil {
+				return nil, fmt.Errorf("create backup: %w", backupErr)
+			}
+		}
+	}
+
+	result := buildUpdateResult(rctx.cfg.Template.CommitSHA, rctx.latestSHA, results, report)
+
+	if opts.DryRun {
+		return result, nil
+	}
+
+	if err := finalizeUpdate(projectDir, result, report, rctx.cfg, rctx.latestSHA, rctx.ref.Version, rctx.vars); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// buildUpdateResult constructs an UpdateResult with operation counts.
+func buildUpdateResult(oldSHA, newSHA string, results []MergeResult, report *ConflictReport) *UpdateResult {
+	result := &UpdateResult{
+		OldSHA:    oldSHA,
+		NewSHA:    newSHA,
+		Applied:   results,
+		Conflicts: report,
+	}
+	for _, r := range results {
+		switch r.Op {
+		case MergeAdd:
+			result.NewFiles++
+		case MergeUpdate:
+			result.UpdatedFiles++
+		case MergeDelete:
+			result.DeletedFiles++
+		}
+	}
+	return result
+}
+
+// continueUpdate resumes after manual conflict resolution.
+func (u *Updater) continueUpdate(projectDir string) (*UpdateResult, error) {
+	status, err := ReadConflictStatus(projectDir)
+	if err != nil {
+		return nil, fmt.Errorf("read conflict status: %w", err)
+	}
+	if status == nil {
+		return nil, errors.New("no pending update to continue")
+	}
+
+	// Check all conflicted files are resolved (no more conflict markers).
+	for _, cf := range status.ConflictedFiles {
+		filePath := filepath.Join(projectDir, cf)
+		content, readErr := os.ReadFile(filePath)
+		if readErr != nil {
+			return nil, fmt.Errorf("read conflicted file %s: %w", cf, readErr)
+		}
+
+		if strings.Contains(string(content), "<<<<<<<") {
+			return nil, fmt.Errorf("unresolved conflict markers in %s — please resolve before continuing", cf)
+		}
+	}
+
+	// Clear conflict status.
+	if clearErr := ClearConflictStatus(projectDir); clearErr != nil {
+		return nil, fmt.Errorf("clear conflict status: %w", clearErr)
+	}
+
+	// Update tagconfig with the new commit.
+	cfg, loadErr := scaffold.LoadTagConfig(projectDir)
+	if loadErr != nil {
+		return nil, fmt.Errorf("load project config: %w", loadErr)
+	}
+
+	if updateErr := updateTagConfig(projectDir, cfg, status.UpdateCommit, "", cfg.Variables); updateErr != nil {
+		return nil, fmt.Errorf("update tagconfig: %w", updateErr)
+	}
+
+	return &UpdateResult{
+		OldSHA: cfg.Template.CommitSHA,
+		NewSHA: status.UpdateCommit,
+	}, nil
+}
+
+// abortUpdate restores from backup and clears conflict state.
+func (u *Updater) abortUpdate(projectDir string) (*UpdateResult, error) {
+	backupPath, err := FindLatestBackup(projectDir)
+	if err != nil {
+		return nil, fmt.Errorf("find backup: %w", err)
+	}
+	if backupPath == "" {
+		return nil, errors.New("no backup found — cannot abort")
+	}
+
+	if err := RestoreBackup(projectDir, backupPath); err != nil {
+		return nil, fmt.Errorf("restore backup: %w", err)
+	}
+
+	// Clean up.
+	_ = ClearConflictStatus(projectDir)
+	_ = RemoveBackup(backupPath)
+
+	return &UpdateResult{}, nil
+}
+
+// applyResults writes merge results to the project directory.
+func applyResults(projectDir string, results []MergeResult) error {
+	for _, r := range results {
+		filePath := filepath.Join(projectDir, r.Path)
+
+		switch r.Op {
+		case MergeAdd, MergeUpdate, MergeConflict:
+			if err := os.MkdirAll(filepath.Dir(filePath), types.DirMode); err != nil {
+				return fmt.Errorf("create dir for %s: %w", r.Path, err)
+			}
+			if err := os.WriteFile(filePath, r.Content, r.Mode); err != nil {
+				return fmt.Errorf("write %s: %w", r.Path, err)
+			}
+		case MergeDelete:
+			if err := os.Remove(filePath); err != nil && !os.IsNotExist(err) {
+				return fmt.Errorf("delete %s: %w", r.Path, err)
+			}
+		case MergeKeep, MergeUserAdded:
+			// No action needed.
+		}
+	}
+	return nil
+}
+
+// updateTagConfig updates .tagconfig.json with the new commit SHA and variables.
+func updateTagConfig(projectDir string, cfg *scaffold.TagConfig, newSHA, newRef string, vars map[string]any) error {
+	cfg.Template.CommitSHA = newSHA
+	if newRef != "" {
+		cfg.Template.Ref = newRef
+	}
+	cfg.Variables = vars
+
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal tagconfig: %w", err)
+	}
+
+	configPath := filepath.Join(projectDir, types.TagConfigFile)
+	return os.WriteFile(configPath, append(data, '\n'), types.FileMode)
+}
+
+// mergeVars merges stored variables with command-line overrides.
+func mergeVars(stored map[string]any, overrides map[string]string) map[string]any {
+	if len(overrides) == 0 {
+		return stored
+	}
+
+	merged := make(map[string]any, len(stored))
+	maps.Copy(merged, stored)
+	for k, v := range overrides {
+		merged[k] = v
+	}
+	return merged
+}
+
+// replaceConflicts replaces MergeConflict entries in results with resolved entries.
+func replaceConflicts(results, resolved []MergeResult) []MergeResult {
+	resolvedMap := make(map[string]MergeResult, len(resolved))
+	for _, r := range resolved {
+		resolvedMap[r.Path] = r
+	}
+
+	out := make([]MergeResult, 0, len(results))
+	for _, r := range results {
+		if r.Op == MergeConflict {
+			if replacement, ok := resolvedMap[r.Path]; ok {
+				out = append(out, replacement)
+				continue
+			}
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
+// collectAffectedPaths returns paths that will be modified by the merge.
+func collectAffectedPaths(results []MergeResult) []string {
+	var paths []string
+	for _, r := range results {
+		switch r.Op {
+		case MergeAdd, MergeUpdate, MergeDelete, MergeConflict:
+			paths = append(paths, r.Path)
+		}
+	}
+	return paths
+}

--- a/internal/templateupdate/updater_test.go
+++ b/internal/templateupdate/updater_test.go
@@ -1,0 +1,179 @@
+package templateupdate
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kaikenlabs/tag/internal/scaffold"
+	"github.com/kaikenlabs/tag/internal/types"
+)
+
+// mockRendererForUpdate is a test double for HistoricalRenderer.
+// We test the Update orchestration by mocking at the resolver level.
+
+func setupUpdateProject(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	writeTagConfig(t, dir, &scaffold.TagConfig{
+		SchemaVersion: 1,
+		Template: &scaffold.TagTemplate{
+			Source:    "gh:acme/template",
+			CommitSHA: "abc123def456789012345678901234567890abcd",
+		},
+		Variables: map[string]any{
+			"project_name": "myproject",
+		},
+	})
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "README.md"), []byte("# myproject"), 0o644))
+	return dir
+}
+
+func TestUT_Updater_Update_AlreadyUpToDate(t *testing.T) {
+	dir := setupUpdateProject(t)
+
+	resolver := &mockResolver{sha: "abc123def456789012345678901234567890abcd"}
+	renderer := NewHistoricalRenderer(&mockFetcher{})
+	updater := NewUpdater(renderer, resolver)
+
+	result, err := updater.Update(context.Background(), UpdateOptions{
+		ProjectDir: dir,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, result.OldSHA, result.NewSHA)
+}
+
+func TestUT_Updater_Update_ResolverError(t *testing.T) {
+	dir := setupUpdateProject(t)
+
+	resolver := &mockResolver{err: assert.AnError}
+	renderer := NewHistoricalRenderer(&mockFetcher{})
+	updater := NewUpdater(renderer, resolver)
+
+	_, err := updater.Update(context.Background(), UpdateOptions{
+		ProjectDir: dir,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "resolve latest commit")
+}
+
+func TestUT_Updater_Update_MissingConfig(t *testing.T) {
+	dir := t.TempDir()
+
+	resolver := &mockResolver{sha: "abc123"}
+	renderer := NewHistoricalRenderer(&mockFetcher{})
+	updater := NewUpdater(renderer, resolver)
+
+	_, err := updater.Update(context.Background(), UpdateOptions{
+		ProjectDir: dir,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "load project config")
+}
+
+func TestUT_Updater_Continue_NoPendingUpdate(t *testing.T) {
+	dir := setupUpdateProject(t)
+
+	resolver := &mockResolver{}
+	renderer := NewHistoricalRenderer(&mockFetcher{})
+	updater := NewUpdater(renderer, resolver)
+
+	_, err := updater.Update(context.Background(), UpdateOptions{
+		ProjectDir: dir,
+		Mode:       UpdateModeContinue,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no pending update")
+}
+
+func TestUT_Updater_Abort_NoBackup(t *testing.T) {
+	dir := setupUpdateProject(t)
+
+	resolver := &mockResolver{}
+	renderer := NewHistoricalRenderer(&mockFetcher{})
+	updater := NewUpdater(renderer, resolver)
+
+	_, err := updater.Update(context.Background(), UpdateOptions{
+		ProjectDir: dir,
+		Mode:       UpdateModeAbort,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no backup found")
+}
+
+func TestUT_Updater_PendingConflictsBlock(t *testing.T) {
+	dir := setupUpdateProject(t)
+
+	// Write fake conflict status.
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, types.TemplatesDir), 0o755))
+	status := map[string]any{
+		"schema_version":   1,
+		"update_commit":    "newcommit",
+		"conflicted_files": []string{"file.txt"},
+	}
+	data, marshalErr := json.Marshal(status)
+	require.NoError(t, marshalErr)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, types.TemplatesDir, "conflicts.json"), data, 0o644))
+
+	resolver := &mockResolver{sha: "different_sha_12345678901234567890abcd"}
+	renderer := NewHistoricalRenderer(&mockFetcher{})
+	updater := NewUpdater(renderer, resolver)
+
+	_, err := updater.Update(context.Background(), UpdateOptions{
+		ProjectDir: dir,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pending conflicts")
+}
+
+func TestUT_MergeVars(t *testing.T) {
+	stored := map[string]any{"a": "1", "b": "2"}
+	overrides := map[string]string{"b": "3", "c": "4"}
+
+	merged := mergeVars(stored, overrides)
+	assert.Equal(t, "1", merged["a"])
+	assert.Equal(t, "3", merged["b"])
+	assert.Equal(t, "4", merged["c"])
+}
+
+func TestUT_MergeVars_NoOverrides(t *testing.T) {
+	stored := map[string]any{"a": "1"}
+	merged := mergeVars(stored, nil)
+	assert.Equal(t, stored, merged)
+}
+
+func TestUT_CollectAffectedPaths(t *testing.T) {
+	results := []MergeResult{
+		{Path: "new.txt", Op: MergeAdd},
+		{Path: "keep.txt", Op: MergeKeep},
+		{Path: "mod.txt", Op: MergeUpdate},
+		{Path: "del.txt", Op: MergeDelete},
+		{Path: "user.txt", Op: MergeUserAdded},
+	}
+
+	paths := collectAffectedPaths(results)
+	assert.ElementsMatch(t, []string{"new.txt", "mod.txt", "del.txt"}, paths)
+}
+
+func TestUT_ReplaceConflicts(t *testing.T) {
+	results := []MergeResult{
+		{Path: "ok.txt", Op: MergeUpdate, Content: []byte("ok")},
+		{Path: "conflict.txt", Op: MergeConflict, Content: []byte("<<<")},
+	}
+
+	resolved := []MergeResult{
+		{Path: "conflict.txt", Op: MergeUpdate, Content: []byte("resolved")},
+	}
+
+	replaced := replaceConflicts(results, resolved)
+	assert.Len(t, replaced, 2)
+	assert.Equal(t, MergeUpdate, replaced[1].Op)
+	assert.Equal(t, []byte("resolved"), replaced[1].Content)
+}

--- a/main.go
+++ b/main.go
@@ -62,8 +62,11 @@ func main() {
 			commands.ConvertCommand(),
 			commands.ExtractCommand(),
 			commands.UndoCommand(),
+			commands.CheckCommand(),
+			commands.DiffCommand(),
+			commands.UpdateTemplateCommand(),
 			commands.VersionCommand(Version),
-			commands.UpdateCommand(Version),
+			commands.UpgradeCommand(Version),
 			commands.DoctorCommand(Version),
 			commands.SkillCommand(Version, commands.SkillDocs{
 				Skill:     skillDoc,


### PR DESCRIPTION
## Summary

- **`tag check`** (#252): CI-friendly command that compares `.tagconfig.json` commit SHA against upstream via lightweight `ls-remote`. Exit 0 = up-to-date, exit 1 = updates available. Supports `--quiet` for CI pipelines and `--ref` override.

- **`tag diff`** (#253): Read-only dry-run 3-way merge displaying unified diff (or `--stat` diffstat) of proposed template changes. No side effects — safe to run anytime. Supports `--no-color` for piping.

- **`tag update`** (#254): Full 3-way merge engine that renders templates at old and new commit SHAs with user variables, compares with local project files, and applies changes. Supports `--dry-run`, `--accept-ours`/`--accept-theirs` for automatic conflict resolution, `--continue`/`--abort` for manual conflict workflow, `--backup` (on by default), `--skip` patterns, and `--set` variable overrides.

- Renames self-update command from `tag update` to `tag upgrade` to free the name for template lifecycle use.

### New packages/files

| File | Purpose |
|------|---------|
| `internal/remote/resolve.go` | `ResolveLatestCommit` via go-git ls-remote (implements `LatestCommitResolver`) |
| `internal/templateupdate/checker.go` | `Checker.Check()` — compare local vs upstream SHA |
| `internal/templateupdate/differ.go` | `Differ.Diff()` — dry-run merge + diff output |
| `internal/templateupdate/updater.go` | `Updater.Update()` — full merge workflow with continue/abort |
| `internal/templateupdate/snapshot.go` | `ReadProjectFiles()` — read local project state for merge |
| `internal/templateupdate/backup.go` | Backup/restore for abort support |
| `internal/templateupdate/format.go` | Unified diff and diffstat formatting |
| `internal/templateupdate/renderpair.go` | `RenderPair()` — render templates at two commits |
| `internal/commands/check.go` | CLI handler for `tag check` |
| `internal/commands/diff.go` | CLI handler for `tag diff` |
| `internal/commands/update_template.go` | CLI handler for `tag update` |
| `internal/commands/upgrade.go` | Renamed from `update.go` |

### Code review fixes applied
- SSH fallback now copies `Version` field (prevents resolving wrong commit)
- Conflict status read errors are no longer silently ignored
- Removed unused `--skip-hooks` flag (YAGNI)
- Consistent error wrapping with `%w` in command handlers

Closes #252
Closes #253
Closes #254

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./internal/templateupdate/...` — all pass
- [x] `go test ./internal/commands/...` — all pass
- [x] `go test ./internal/remote/...` — all pass
- [x] `make lint` — 0 issues
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)