### PR TITLE
fix: try SSH before HTTPS when no token is configured

### DIFF
--- a/internal/remote/git.go
+++ b/internal/remote/git.go
@@ -144,9 +144,26 @@ func (f *GitFetcher) FetchAtCommit(ctx context.Context, url, commitSHA, destDir 
 }
 
 // clone performs the Git clone operation.
-// If HTTPS auth fails and the ref has a known provider with SSH support,
-// it falls back to cloning via SSH (git@host:owner/repo.git).
+// When the URL is HTTPS and no token is configured, it tries SSH first
+// (leveraging the user's SSH agent/keys), then falls back to unauthenticated HTTPS.
+// When a token is available, it clones via HTTPS and falls back to SSH on auth errors.
 func (f *GitFetcher) clone(ctx context.Context, ref *Reference, destDir string) (*git.Repository, error) {
+	// If the URL is HTTPS with no token available, try SSH first —
+	// this transparently supports users who rely on SSH keys for private repos.
+	if !isSSHURL(ref.URL) && canFallbackToSSH(ref) {
+		if _, hasToken := f.auth.TokenFor(ref.Provider); !hasToken {
+			repo, err := f.cloneViaSSH(ctx, ref, destDir)
+			if err == nil {
+				return repo, nil
+			}
+			// SSH failed — fall through to HTTPS (may be a public repo)
+			os.RemoveAll(destDir)
+			if mkErr := os.MkdirAll(destDir, types.DirMode); mkErr != nil {
+				return nil, &FetchError{Ref: ref, Message: "cannot recreate temp directory", Err: mkErr}
+			}
+		}
+	}
+
 	// Get auth if available
 	auth, err := f.auth.GitAuth(ref)
 	if err != nil {
@@ -156,26 +173,36 @@ func (f *GitFetcher) clone(ctx context.Context, ref *Reference, destDir string) 
 	repo, err := f.doClone(ctx, ref.URL, ref, destDir, auth)
 	if err != nil && isAuthError(err) && canFallbackToSSH(ref) {
 		// HTTPS auth failed — retry with SSH
-		sshURL := fmt.Sprintf("git@%s:%s/%s.git", ref.Host, ref.Owner, ref.Repo)
-		fallbackRef := &Reference{URL: sshURL, Provider: ref.Provider}
-		sshAuth, sshErr := f.auth.GitAuth(fallbackRef)
-		if sshErr == nil {
-			// Clean destDir for retry (clone requires empty directory)
-			os.RemoveAll(destDir)
-			if mkErr := os.MkdirAll(destDir, types.DirMode); mkErr != nil {
-				return nil, &FetchError{Ref: ref, Message: "cannot recreate temp directory", Err: mkErr}
-			}
-
-			// Build full ref for clone with version/subpath info
-			cloneRef := *ref
-			cloneRef.URL = sshURL
-			repo, err = f.doClone(ctx, sshURL, &cloneRef, destDir, sshAuth)
+		if sshRepo, sshErr := f.cloneViaSSH(ctx, ref, destDir); sshErr == nil {
+			return sshRepo, nil
 		}
 	}
 	if err != nil {
 		return nil, f.wrapCloneError(ref, err)
 	}
 	return repo, nil
+}
+
+// cloneViaSSH attempts to clone using SSH (git@host:owner/repo.git).
+func (f *GitFetcher) cloneViaSSH(ctx context.Context, ref *Reference, destDir string) (*git.Repository, error) {
+	sshURL := fmt.Sprintf("git@%s:%s/%s.git", ref.Host, ref.Owner, ref.Repo)
+	fallbackRef := &Reference{URL: sshURL, Provider: ref.Provider}
+
+	sshAuth, err := f.auth.GitAuth(fallbackRef)
+	if err != nil {
+		return nil, err
+	}
+
+	// Clean destDir for retry (clone requires empty directory)
+	os.RemoveAll(destDir)
+	if mkErr := os.MkdirAll(destDir, types.DirMode); mkErr != nil {
+		return nil, &FetchError{Ref: ref, Message: "cannot recreate temp directory", Err: mkErr}
+	}
+
+	cloneRef := *ref
+	cloneRef.URL = sshURL
+
+	return f.doClone(ctx, sshURL, &cloneRef, destDir, sshAuth)
 }
 
 // doClone performs the actual git clone with the given URL and auth.

--- a/internal/remote/git_test.go
+++ b/internal/remote/git_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/go-git/go-git/v5/plumbing/transport"
+	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -216,6 +218,123 @@ func TestIT_GitFetcher_PublicGitHubRepo(t *testing.T) {
 }
 
 // --- Unit Tests for sanitizeErrorMessage ---
+
+func TestUT_Clone_SSHFirstWhenNoToken(t *testing.T) {
+	// When no token is available and the ref has enough info for SSH,
+	// clone should attempt SSH before HTTPS.
+	var cloneAttempts []string
+
+	mockAuth := &recordingAuthProvider{
+		tokens: map[Provider]string{}, // no tokens
+		recordCloneURL: func(url string) {
+			cloneAttempts = append(cloneAttempts, url)
+		},
+	}
+
+	fetcher := &GitFetcher{auth: mockAuth, out: nil}
+	ref := &Reference{
+		Original: "bb:whalar/go-service-template",
+		Type:     ReferenceTypeGit,
+		Provider: ProviderBitbucket,
+		Host:     "bitbucket.org",
+		Owner:    "whalar",
+		Repo:     "go-service-template",
+		URL:      "https://bitbucket.org/whalar/go-service-template.git",
+	}
+
+	destDir := t.TempDir()
+	// clone will fail (no real server), but we can verify the attempt order
+	_, _ = fetcher.clone(context.Background(), ref, destDir)
+
+	require.GreaterOrEqual(t, len(cloneAttempts), 1, "should have attempted at least one clone")
+	assert.Equal(t, "git@bitbucket.org:whalar/go-service-template.git", cloneAttempts[0],
+		"first attempt should be SSH when no token is available")
+}
+
+func TestUT_Clone_HTTPSFirstWhenTokenAvailable(t *testing.T) {
+	// When a token IS available, clone should try HTTPS first (not SSH).
+	var cloneAttempts []string
+
+	mockAuth := &recordingAuthProvider{
+		tokens: map[Provider]string{
+			ProviderBitbucket: "some-token",
+		},
+		recordCloneURL: func(url string) {
+			cloneAttempts = append(cloneAttempts, url)
+		},
+	}
+
+	fetcher := &GitFetcher{auth: mockAuth, out: nil}
+	ref := &Reference{
+		Original: "bb:whalar/go-service-template",
+		Type:     ReferenceTypeGit,
+		Provider: ProviderBitbucket,
+		Host:     "bitbucket.org",
+		Owner:    "whalar",
+		Repo:     "go-service-template",
+		URL:      "https://bitbucket.org/whalar/go-service-template.git",
+	}
+
+	destDir := t.TempDir()
+	_, _ = fetcher.clone(context.Background(), ref, destDir)
+
+	require.GreaterOrEqual(t, len(cloneAttempts), 1, "should have attempted at least one clone")
+	assert.Equal(t, "https://bitbucket.org/whalar/go-service-template.git", cloneAttempts[0],
+		"first attempt should be HTTPS when token is available")
+}
+
+func TestUT_Clone_SSHFirstAlsoForGitHub(t *testing.T) {
+	// SSH-first should work for all providers, not just Bitbucket.
+	var cloneAttempts []string
+
+	mockAuth := &recordingAuthProvider{
+		tokens:         map[Provider]string{},
+		recordCloneURL: func(url string) { cloneAttempts = append(cloneAttempts, url) },
+	}
+
+	fetcher := &GitFetcher{auth: mockAuth, out: nil}
+	ref := &Reference{
+		Original: "gh:user/repo",
+		Type:     ReferenceTypeGit,
+		Provider: ProviderGitHub,
+		Host:     "github.com",
+		Owner:    "user",
+		Repo:     "repo",
+		URL:      "https://github.com/user/repo.git",
+	}
+
+	destDir := t.TempDir()
+	_, _ = fetcher.clone(context.Background(), ref, destDir)
+
+	require.GreaterOrEqual(t, len(cloneAttempts), 1)
+	assert.Equal(t, "git@github.com:user/repo.git", cloneAttempts[0],
+		"SSH-first should apply to GitHub as well")
+}
+
+// recordingAuthProvider tracks which URLs are cloned, for verifying attempt order.
+type recordingAuthProvider struct {
+	tokens         map[Provider]string
+	recordCloneURL func(string)
+}
+
+func (r *recordingAuthProvider) TokenFor(provider Provider) (string, bool) {
+	token, ok := r.tokens[provider]
+	return token, ok
+}
+
+func (r *recordingAuthProvider) GitAuth(ref *Reference) (transport.AuthMethod, error) {
+	if r.recordCloneURL != nil {
+		r.recordCloneURL(ref.URL)
+	}
+	token, ok := r.tokens[ref.Provider]
+	if !ok || token == "" {
+		return nil, nil //nolint:nilnil // nil means no auth
+	}
+	return &githttp.BasicAuth{
+		Username: "x-access-token",
+		Password: token,
+	}, nil
+}
 
 func TestUT_SanitizeErrorMessage_RedactsGitHubToken(t *testing.T) {
 	msg := `authentication failed: https://ghp_abc123XYZ789@github.com/owner/repo.git`


### PR DESCRIPTION
## Summary
- When no provider token (e.g. `BITBUCKET_TOKEN`) is set, `clone()` now tries SSH first (`git@host:owner/repo.git`) before falling back to unauthenticated HTTPS
- Fixes private repo access for users who rely on SSH keys instead of tokens, since `go-git` does not honor `~/.gitconfig` URL rewrites (`insteadOf`)
- When a token IS available, behavior is unchanged: HTTPS first, SSH fallback on auth errors

## Test plan
- [x] `TestUT_Clone_SSHFirstWhenNoToken` — SSH attempted first for Bitbucket with no token
- [x] `TestUT_Clone_HTTPSFirstWhenTokenAvailable` — HTTPS still preferred when token exists
- [x] `TestUT_Clone_SSHFirstAlsoForGitHub` — applies to all providers
- [x] All existing tests pass
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)