### PR TITLE
feat: add --add-to-lib flag for local template library installation

### DIFF
--- a/internal/commands/flags.go
+++ b/internal/commands/flags.go
@@ -155,6 +155,10 @@ func commonScaffoldFlags() []cli.Flag {
 			Aliases: []string{"d"},
 			Usage:   "Preview what would be written without creating any files",
 		},
+		&cli.BoolFlag{
+			Name:  flags.AddToLibFlag,
+			Usage: "Add the template to the library after scaffolding (enables generator resolution from library)",
+		},
 	}
 }
 

--- a/internal/commands/scaffold.go
+++ b/internal/commands/scaffold.go
@@ -21,6 +21,7 @@ import (
 	"github.com/kaikenlabs/tag/internal/remote"
 	"github.com/kaikenlabs/tag/internal/scaffold"
 	"github.com/kaikenlabs/tag/internal/types"
+	"github.com/kaikenlabs/tag/internal/types/flags"
 	"github.com/kaikenlabs/tag/pkg/app"
 )
 
@@ -150,6 +151,7 @@ func scaffoldFromLibrary(c *cli.Context, lib *library.Library, entry *library.En
 	opts.TemplateRef = entry.Source
 	opts.TemplateName = entry.Name
 	opts.IsRemote = false
+	opts.SkipGeneratorCopy = true // generators resolve from library
 
 	return runScaffold(c, opts, func(*scaffold.CookiecutterDetectedError) error {
 		return app.Errorf("template %q is a Cookiecutter template; run 'tag lib update %s' to convert it", entry.Name, entry.Name)
@@ -206,6 +208,17 @@ func scaffoldFromRef(c *cli.Context, positional []string) error {
 		opts.TemplateName = remote.DeriveName(templateRef)
 	}
 
+	// Decide whether to add the template to the library.
+	// Remote templates are always added; local templates are added when
+	// --add-to-lib is set or the user confirms interactively.
+	addToLib := isRemote
+	if !isRemote {
+		addToLib = resolveAddToLib(c, templateDir)
+	}
+	if addToLib {
+		opts.SkipGeneratorCopy = true
+	}
+
 	// Verify template lockfile for remote templates.
 	if isRemote {
 		if lockErr := verifyTemplateLock(templateRef, templateDir, opts.UpdateLock, opts.IgnoreLock); lockErr != nil {
@@ -220,12 +233,39 @@ func scaffoldFromRef(c *cli.Context, positional []string) error {
 		return err
 	}
 
-	// Auto-add remote templates to the library for future use
-	if isRemote {
+	// Add the template to the library for generator resolution.
+	if addToLib {
 		addToLibrary(c, templateRef, templateDir)
 	}
 
 	return nil
+}
+
+// resolveAddToLib determines whether a local template should be added to the
+// library after scaffolding. Returns true if --add-to-lib is set, or if the
+// template has generators and the user confirms interactively.
+func resolveAddToLib(c *cli.Context, templateDir string) bool {
+	if c.Bool(flags.AddToLibFlag) {
+		return true
+	}
+
+	// Only prompt if the template has generators/bundles worth installing.
+	hasGenerators := hasSubdirScaffold(templateDir, types.TemplatesDir) || hasSubdirScaffold(templateDir, types.GeneratorsDir)
+	if !hasGenerators {
+		return false
+	}
+
+	// Non-interactive mode: don't add (safe default, generators copied to .tag/).
+	if c.Bool("no-input") || !scaffold.IsTTY() {
+		return false
+	}
+
+	prompter := scaffold.NewInteractivePrompter()
+	add, err := prompter.Confirm("Add template to library? (enables generator resolution without copying .tag/)", false)
+	if err != nil {
+		return false
+	}
+	return add
 }
 
 // looksLikeBareName returns true if ref is a simple name (no path separators,
@@ -481,11 +521,8 @@ func displayScaffoldSummary(w io.Writer, result scaffold.ScaffoldResult) {
 	// Check if the template has generators
 	hasGenerators := hasSubdirScaffold(templateDir, types.TemplatesDir) || hasSubdirScaffold(templateDir, types.GeneratorsDir)
 
-	if hasGenerators && opts.TemplateName != "" {
+	if hasGenerators {
 		fmt.Fprintln(w, "  tag generate list    # see available generators")
-	} else if hasGenerators && opts.TemplateName == "" {
-		fmt.Fprintln(w)
-		fmt.Fprintf(w, "  Add to library for generators: tag lib add %s\n", opts.TemplateRef)
 	}
 	fmt.Fprintln(w)
 

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -320,9 +320,12 @@ func (s *Scaffold) executeScaffold(ctx *runContext) (ScaffoldResult, error) {
 	}
 
 	// Copy generators, bundles, and shared templates into the output .tag/ dir
-	// so they are available locally without requiring "tag lib add".
-	if err := copyGeneratorsToOutput(ctx.templateDirAbs, ctx.projectRoot); err != nil {
-		return ScaffoldResult{}, fmt.Errorf("failed to copy generators: %w", err)
+	// when the template is not being added to the library (where generators
+	// are resolved from instead).
+	if !ctx.opts.SkipGeneratorCopy {
+		if err := copyGeneratorsToOutput(ctx.templateDirAbs, ctx.projectRoot); err != nil {
+			return ScaffoldResult{}, fmt.Errorf("failed to copy generators: %w", err)
+		}
 	}
 
 	// Run post-scaffold hooks

--- a/internal/scaffold/types.go
+++ b/internal/scaffold/types.go
@@ -42,6 +42,7 @@ type Options struct {
 	UpdateLock           bool              // Refresh lockfile entry for this template (--update-lock flag)
 	IgnoreLock           bool              // Skip lockfile verification (--ignore-lock flag)
 	DryRun               bool              // Preview changes without writing files (--dry-run flag)
+	SkipGeneratorCopy    bool              // Skip copying generators/bundles to output .tag/ directory
 }
 
 // ScaffoldResult contains the output of a successful scaffold run.

--- a/internal/types/flags/flags.go
+++ b/internal/types/flags/flags.go
@@ -18,4 +18,5 @@ const (
 	AllFlag           = "all"
 	AsFlag            = "as"
 	InteractiveFlag   = "interactive"
+	AddToLibFlag      = "add-to-lib"
 )


### PR DESCRIPTION
## Summary

- Add `--add-to-lib` flag to scaffold command for local templates
- When scaffolding from a local path with generators, prompt interactively to add template to library (skipped with `--no-input`)
- Skip redundant `.tag/` copy for library and remote scaffolds (generators already resolve from library)
- Simplify post-scaffold summary — always show "tag generate list" when generators exist

## Context

Previously, `copyGeneratorsToOutput` (added in #267) copied `.tag/` contents into every scaffolded project. However:
- **Library scaffolds**: generators already resolve from the library cache — copy is redundant
- **Remote scaffolds**: template is auto-added to library after scaffold — copy is redundant
- **Local scaffolds**: only case where copy is needed, unless the template is added to the library

This PR makes the `.tag/` copy conditional and gives users control over library installation for local templates.

## Test plan

- [ ] `tag scaffold <library-template>` — no `.tag/` copy, generators resolve from library
- [ ] `tag scaffold gh:user/template` — no `.tag/` copy, auto-added to library
- [ ] `tag scaffold ./local-template` — prompts to add to library when generators exist
- [ ] `tag scaffold ./local-template --add-to-lib` — adds to library, skips `.tag/` copy
- [ ] `tag scaffold ./local-template --no-input` — copies `.tag/` (safe default, no prompt)
- [ ] `tag scaffold ./local-template` (no generators) — no prompt, no copy needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)