### PR TITLE
fix: run tag test validation commands in project root, not parent temp dir

### DIFF
--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -361,6 +361,7 @@ func (s *Scaffold) executeScaffold(ctx *runContext) (ScaffoldResult, error) {
 	success = true
 	return ScaffoldResult{
 		OutputDir:   ctx.outputDir,
+		ProjectRoot: ctx.projectRoot,
 		TemplateDir: ctx.templateDirAbs,
 		Vars:        ctx.vars,
 		Opts:        ctx.opts,

--- a/internal/scaffold/types.go
+++ b/internal/scaffold/types.go
@@ -49,7 +49,8 @@ type Options struct {
 // It carries the information needed by the commands layer to render
 // a post-scaffold summary (output location, resolved variables, etc.).
 type ScaffoldResult struct {
-	OutputDir   string         // Absolute path to the generated project
+	OutputDir   string         // Absolute path to the top-level output directory
+	ProjectRoot string         // Absolute path to the project root (may differ from OutputDir with wrapper dirs)
 	TemplateDir string         // Absolute path to the template directory (for README)
 	Vars        map[string]any // Resolved template variables
 	Opts        Options        // Options used for this scaffold run

--- a/internal/testrunner/runner.go
+++ b/internal/testrunner/runner.go
@@ -225,7 +225,15 @@ func runSingleTest(ctx context.Context, plan *TestPlan, cfg Config, combo Combin
 		}
 	}
 
-	return runValidation(ctx, plan, cfg, combo, result.OutputDir, tmpDir, &shouldClean, start)
+	// Use ProjectRoot (not OutputDir) so validation commands run inside the
+	// actual project directory, not the parent temp dir. With wrapper-style
+	// templates the scaffold creates a subdirectory (e.g. tmpDir/project-name/).
+	projectDir := result.ProjectRoot
+	if projectDir == "" {
+		projectDir = result.OutputDir
+	}
+
+	return runValidation(ctx, plan, cfg, combo, projectDir, tmpDir, &shouldClean, start)
 }
 
 func runValidation(


### PR DESCRIPTION
## Summary

- Wrapper-style templates scaffold into a subdirectory of the temp dir (e.g. `tmpDir/project-name/`), but `tag test` validation commands were executing in the parent temp dir
- Adds `ProjectRoot` field to `ScaffoldResult` exposing the actual project directory
- Test runner now uses `ProjectRoot` as the working directory for validation commands

## Root cause

`ScaffoldResult.OutputDir` returns the top-level output directory, but with wrapper-style templates the project files live in a subdirectory (`ctx.projectRoot`). The test runner passed `OutputDir` to `RunValidationCommands`, so commands like `go build ./...` ran one level too high.

## Test plan

- [x] `make lint` passes
- [x] `make test` passes
- [x] `go build ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)