### PR TITLE
feat: support multiple named test cases in tag test

### DIFF
--- a/.skill/recipes.md
+++ b/.skill/recipes.md
@@ -553,12 +553,24 @@ Validate that a template scaffolds correctly for every combination of boolean va
   },
   "test": {
     "project_name": "test-project",
-    "commands": ["go build ./..."]
+    "cases": [
+      {
+        "name": "Full test",
+        "filters": { "use_docker": true, "use_grpc": true },
+        "commands": ["go build ./...", "go vet ./..."]
+      },
+      {
+        "name": "Light test",
+        "commands": ["go build ./..."]
+      }
+    ]
   }
 }
 ```
 
-The `test` block defines a fixed `project_name` for scaffolding and validation commands that run inside each scaffolded directory. With 3 boolean vars, `tag test` generates 2³ = 8 combinations and scaffolds each one.
+The `test` block defines named test cases, each with optional `filters` to pin boolean variables and `commands` to validate the scaffold output. Cases without filters run across all 2^N boolean combinations. Cases with filters pin specific variables, reducing the matrix. With 3 boolean vars and no filters, `tag test` generates 2³ = 8 combinations per case.
+
+Use `--case "Full test"` to run a single case:
 
 **Basic usage**:
 ```bash

--- a/.skill/reference.md
+++ b/.skill/reference.md
@@ -611,6 +611,7 @@ Discovers boolean variables in `tag.template.json`, generates all 2^N combinatio
 | `--pin key=value` | Fix a variable to a specific value (can be repeated) |
 | `--run <command>` | Validation command, overrides template config (can be repeated) |
 | `--filter <expr>` | Filter combinations by index or key=value pairs |
+| `--case <name>` | Run only the test case with this name |
 | `--fail-fast` | Stop on first failure |
 | `--dry-run` | List combinations without running tests |
 | `--keep-failed` | Keep scaffolded directories on failure for debugging |
@@ -626,16 +627,29 @@ Discovers boolean variables in `tag.template.json`, generates all 2^N combinatio
 {
   "vars": { "...": "..." },
   "test": {
-    "commands": ["go build ./...", "go vet ./..."],
     "project_name": "test-scaffold",
-    "env": { "CGO_ENABLED": "0" }
+    "env": { "CGO_ENABLED": "0" },
+    "cases": [
+      {
+        "name": "Full test",
+        "filters": { "use_docker": true, "use_postgres": true },
+        "commands": ["go build ./...", "go vet ./...", "golangci-lint run ./..."]
+      },
+      {
+        "name": "Light test",
+        "commands": ["go build ./..."]
+      }
+    ]
   }
 }
 ```
 
-- `commands`: Validation commands run after each successful scaffold. Requires `--accept-hooks` to execute (security: prevents untrusted template commands).
-- `project_name`: Project name for scaffold output (default: `test-scaffold`).
-- `env`: Environment variables passed to validation commands.
+- `cases`: Array of named test cases, each with optional `filters` and `commands`.
+  - `name`: Identifier for the test case (used with `--case` flag).
+  - `filters`: Boolean variable pins for this case (e.g., `{"use_docker": true}` runs only combinations where `use_docker=true`).
+  - `commands`: Validation commands run after each successful scaffold. Requires `--accept-hooks` to execute.
+- `project_name`: Project name for scaffold output (default: `test-scaffold`), shared across all cases.
+- `env`: Environment variables passed to validation commands, shared across all cases.
 
 Use `--run` to provide commands directly without `--accept-hooks`:
 

--- a/internal/commands/test.go
+++ b/internal/commands/test.go
@@ -92,6 +92,10 @@ func testFlags() []cli.Flag {
 			Name:  "filter",
 			Usage: "Filter combinations by index or key=value pairs (comma-separated)",
 		},
+		&cli.StringFlag{
+			Name:  "case",
+			Usage: "Run only the test case with this name",
+		},
 		&cli.BoolFlag{
 			Name:  "fail-fast",
 			Usage: "Stop on first failure",
@@ -150,6 +154,7 @@ func testAction(c *cli.Context, w io.Writer, templateDir string) error {
 		PinVars:     pinVars,
 		RunCommands: c.StringSlice("run"),
 		Filter:      c.String("filter"),
+		CaseName:    c.String("case"),
 		Parallel:    c.Int("parallel"),
 		FailFast:    c.Bool("fail-fast"),
 		DryRun:      c.Bool("dry-run"),
@@ -166,15 +171,22 @@ func testAction(c *cli.Context, w io.Writer, templateDir string) error {
 		return app.Errorf("test plan: %w", err)
 	}
 
+	// Count total combinations across all cases.
+	totalCombos := 0
+	for _, cp := range plan.Cases {
+		totalCombos += len(cp.Combos)
+	}
+
 	// Print header (skip for JSON to keep stdout machine-parseable).
 	if cfg.Format != "json" {
 		fmt.Fprintf(w, "Template: %s\n", templateDir)
 		fmt.Fprintf(w, "Boolean variables: %v\n", plan.BoolVars)
-		fmt.Fprintf(w, "Combinations: %d | Parallel: %d\n\n", len(plan.Combos), cfg.Parallel)
+		fmt.Fprintf(w, "Test cases: %d | Combinations: %d | Parallel: %d\n\n",
+			len(plan.Cases), totalCombos, cfg.Parallel)
 	}
 
 	if cfg.DryRun {
-		testrunner.PrintDryRun(w, plan.Combos, plan.BoolVars)
+		testrunner.PrintDryRun(w, plan)
 		return nil
 	}
 

--- a/internal/testrunner/plan_test.go
+++ b/internal/testrunner/plan_test.go
@@ -36,8 +36,9 @@ func TestUT_Plan_BasicConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{"use_amqp", "use_postgres"}, plan.BoolVars)
-	assert.Len(t, plan.Combos, 4)
-	assert.Empty(t, plan.Commands)
+	require.Len(t, plan.Cases, 1)
+	assert.Len(t, plan.Cases[0].Combos, 4)
+	assert.Empty(t, plan.Cases[0].Commands)
 	assert.Equal(t, "test-scaffold", plan.ProjectName)
 }
 
@@ -50,7 +51,7 @@ func TestUT_Plan_WithTestConfig(t *testing.T) {
 			"use_x": {"type": "boolean", "default": true}
 		},
 		"test": {
-			"commands": ["go build ./..."],
+			"cases": [{"name": "build", "commands": ["go build ./..."]}],
 			"project_name": "my-project",
 			"env": {"CGO_ENABLED": "0"}
 		}
@@ -63,7 +64,9 @@ func TestUT_Plan_WithTestConfig(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	assert.Equal(t, []string{"go build ./..."}, plan.Commands)
+	require.Len(t, plan.Cases, 1)
+	assert.Equal(t, []string{"go build ./..."}, plan.Cases[0].Commands)
+	assert.Equal(t, "build", plan.Cases[0].Name)
 	assert.Equal(t, "my-project", plan.ProjectName)
 	assert.Equal(t, map[string]string{"CGO_ENABLED": "0"}, plan.Env)
 }
@@ -77,7 +80,7 @@ func TestUT_Plan_TemplateCommandsRequireAcceptHooks(t *testing.T) {
 			"use_x": {"type": "boolean", "default": true}
 		},
 		"test": {
-			"commands": ["go build ./..."]
+			"cases": [{"name": "build", "commands": ["go build ./..."]}]
 		}
 	}`)
 
@@ -99,7 +102,7 @@ func TestUT_Plan_RunCommandsOverrideTemplateCommands(t *testing.T) {
 			"use_x": {"type": "boolean", "default": true}
 		},
 		"test": {
-			"commands": ["go build ./..."]
+			"cases": [{"name": "build", "commands": ["go build ./..."]}]
 		}
 	}`)
 
@@ -110,7 +113,8 @@ func TestUT_Plan_RunCommandsOverrideTemplateCommands(t *testing.T) {
 		MaxCases:    0,
 	})
 	require.NoError(t, err)
-	assert.Equal(t, []string{"echo override"}, plan.Commands)
+	require.Len(t, plan.Cases, 1)
+	assert.Equal(t, []string{"echo override"}, plan.Cases[0].Commands)
 }
 
 func TestUT_Plan_MaxCasesZeroIsUnlimited(t *testing.T) {
@@ -135,7 +139,8 @@ func TestUT_Plan_MaxCasesZeroIsUnlimited(t *testing.T) {
 		MaxCases:    0,
 	})
 	require.NoError(t, err)
-	assert.Len(t, plan.Combos, 128)
+	require.Len(t, plan.Cases, 1)
+	assert.Len(t, plan.Cases[0].Combos, 128)
 }
 
 func TestUT_Plan_MaxCasesEnforced(t *testing.T) {
@@ -183,7 +188,8 @@ func TestUT_Plan_SkipVarsReducesCombinations(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"a", "b"}, plan.BoolVars)
-	assert.Len(t, plan.Combos, 4)
+	require.Len(t, plan.Cases, 1)
+	assert.Len(t, plan.Cases[0].Combos, 4)
 }
 
 func TestUT_Plan_PinVarsReducesCombinations(t *testing.T) {
@@ -204,10 +210,11 @@ func TestUT_Plan_PinVarsReducesCombinations(t *testing.T) {
 		MaxCases:    0,
 	})
 	require.NoError(t, err)
-	assert.Len(t, plan.Combos, 4)
+	require.Len(t, plan.Cases, 1)
+	assert.Len(t, plan.Cases[0].Combos, 4)
 
 	// All combos should have b=true.
-	for _, c := range plan.Combos {
+	for _, c := range plan.Cases[0].Combos {
 		assert.Equal(t, "true", c.Vars["b"])
 	}
 }
@@ -229,7 +236,8 @@ func TestUT_Plan_FilterApplied(t *testing.T) {
 		MaxCases:    0,
 	})
 	require.NoError(t, err)
-	assert.Len(t, plan.Combos, 2)
+	require.Len(t, plan.Cases, 1)
+	assert.Len(t, plan.Cases[0].Combos, 2)
 }
 
 func TestUT_Plan_InvalidFilter(t *testing.T) {
@@ -261,4 +269,142 @@ func TestUT_Plan_MissingConfig(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "read template config")
+}
+
+func TestUT_Plan_MultipleCases(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeTemplateConfig(t, dir, `{
+		"vars": {
+			"use_docker": {"type": "boolean", "default": true},
+			"use_postgres": {"type": "boolean", "default": true}
+		},
+		"test": {
+			"cases": [
+				{
+					"name": "Full test",
+					"filters": {"use_docker": true, "use_postgres": true},
+					"commands": ["go build ./...", "go vet ./..."]
+				},
+				{
+					"name": "Light test",
+					"commands": ["go build ./..."]
+				}
+			]
+		}
+	}`)
+
+	plan, err := testrunner.Plan(testrunner.Config{
+		TemplateDir: dir,
+		AcceptHooks: true,
+		MaxCases:    0,
+	})
+	require.NoError(t, err)
+
+	require.Len(t, plan.Cases, 2)
+
+	// Full test: both vars pinned, so only 1 combination.
+	assert.Equal(t, "Full test", plan.Cases[0].Name)
+	assert.Len(t, plan.Cases[0].Combos, 1)
+	assert.Equal(t, []string{"go build ./...", "go vet ./..."}, plan.Cases[0].Commands)
+	assert.Equal(t, "true", plan.Cases[0].Combos[0].Vars["use_docker"])
+	assert.Equal(t, "true", plan.Cases[0].Combos[0].Vars["use_postgres"])
+
+	// Light test: no filters, all 4 combinations.
+	assert.Equal(t, "Light test", plan.Cases[1].Name)
+	assert.Len(t, plan.Cases[1].Combos, 4)
+	assert.Equal(t, []string{"go build ./..."}, plan.Cases[1].Commands)
+}
+
+func TestUT_Plan_CaseNameFilter(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeTemplateConfig(t, dir, `{
+		"vars": {
+			"a": {"type": "boolean", "default": true}
+		},
+		"test": {
+			"cases": [
+				{"name": "build", "commands": ["go build ./..."]},
+				{"name": "lint", "commands": ["golangci-lint run"]}
+			]
+		}
+	}`)
+
+	plan, err := testrunner.Plan(testrunner.Config{
+		TemplateDir: dir,
+		AcceptHooks: true,
+		CaseName:    "lint",
+		MaxCases:    0,
+	})
+	require.NoError(t, err)
+
+	require.Len(t, plan.Cases, 1)
+	assert.Equal(t, "lint", plan.Cases[0].Name)
+	assert.Equal(t, []string{"golangci-lint run"}, plan.Cases[0].Commands)
+}
+
+func TestUT_Plan_CaseNameNotFound(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeTemplateConfig(t, dir, `{
+		"vars": {
+			"a": {"type": "boolean", "default": true}
+		},
+		"test": {
+			"cases": [
+				{"name": "build", "commands": ["go build ./..."]}
+			]
+		}
+	}`)
+
+	_, err := testrunner.Plan(testrunner.Config{
+		TemplateDir: dir,
+		AcceptHooks: true,
+		CaseName:    "nonexistent",
+		MaxCases:    0,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+	assert.Contains(t, err.Error(), "build")
+}
+
+func TestUT_Plan_CaseFiltersReduceCombinations(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeTemplateConfig(t, dir, `{
+		"vars": {
+			"a": {"type": "boolean", "default": true},
+			"b": {"type": "boolean", "default": true},
+			"c": {"type": "boolean", "default": true}
+		},
+		"test": {
+			"cases": [
+				{
+					"name": "pinned",
+					"filters": {"a": true, "b": false},
+					"commands": ["echo test"]
+				}
+			]
+		}
+	}`)
+
+	plan, err := testrunner.Plan(testrunner.Config{
+		TemplateDir: dir,
+		AcceptHooks: true,
+		MaxCases:    0,
+	})
+	require.NoError(t, err)
+
+	require.Len(t, plan.Cases, 1)
+	// a and b pinned, only c varies = 2 combinations.
+	assert.Len(t, plan.Cases[0].Combos, 2)
+	for _, combo := range plan.Cases[0].Combos {
+		assert.Equal(t, "true", combo.Vars["a"])
+		assert.Equal(t, "false", combo.Vars["b"])
+	}
 }

--- a/internal/testrunner/report.go
+++ b/internal/testrunner/report.go
@@ -11,35 +11,62 @@ import (
 
 // PrintTextReport writes a human-readable test report to w.
 func PrintTextReport(w io.Writer, report Report, boolVars []string, verbose bool) {
-	// Sort results by combination index for deterministic output.
-	sorted := make([]CaseResult, len(report.Cases))
-	copy(sorted, report.Cases)
-	sort.Slice(sorted, func(i, j int) bool {
-		return sorted[i].Combination.Index < sorted[j].Combination.Index
-	})
+	// Group results by case name, preserving order.
+	type caseGroup struct {
+		name    string
+		results []CaseResult
+	}
+	var groups []caseGroup
+	groupIdx := make(map[string]int)
+	for _, c := range report.Cases {
+		idx, ok := groupIdx[c.CaseName]
+		if !ok {
+			idx = len(groups)
+			groupIdx[c.CaseName] = idx
+			groups = append(groups, caseGroup{name: c.CaseName})
+		}
+		groups[idx].results = append(groups[idx].results, c)
+	}
 
-	for _, c := range sorted {
-		label := ComboLabel(c.Combination, boolVars)
-		switch c.Status {
-		case CasePassed:
-			fmt.Fprintf(w, "  ✓  [%d] %s (%s)\n", c.Combination.Index, label, c.Duration.Round(100*time.Millisecond))
-		case CaseFailed:
-			fmt.Fprintf(w, "  ✗  [%d] %s (%s)\n", c.Combination.Index, label, c.Duration.Round(100*time.Millisecond))
-			fmt.Fprintf(w, "       Phase: %s\n", c.Phase)
-			fmt.Fprintf(w, "       Error: %s\n", c.Error)
-			if c.KeptDir != "" {
-				fmt.Fprintf(w, "       Kept:  %s\n", c.KeptDir)
-			}
-			if verbose && c.Output != "" {
-				fmt.Fprintf(w, "       Output:\n")
-				for line := range strings.SplitSeq(c.Output, "\n") {
-					fmt.Fprintf(w, "         %s\n", line)
+	multiCase := len(groups) > 1
+
+	for _, g := range groups {
+		// Sort results by combination index for deterministic output.
+		sort.Slice(g.results, func(i, j int) bool {
+			return g.results[i].Combination.Index < g.results[j].Combination.Index
+		})
+
+		if multiCase {
+			fmt.Fprintf(w, "── %s ──\n", g.name)
+		}
+
+		for _, c := range g.results {
+			label := ComboLabel(c.Combination, boolVars)
+			switch c.Status {
+			case CasePassed:
+				fmt.Fprintf(w, "  ✓  [%d] %s (%s)\n", c.Combination.Index, label, c.Duration.Round(100*time.Millisecond))
+			case CaseFailed:
+				fmt.Fprintf(w, "  ✗  [%d] %s (%s)\n", c.Combination.Index, label, c.Duration.Round(100*time.Millisecond))
+				fmt.Fprintf(w, "       Phase: %s\n", c.Phase)
+				fmt.Fprintf(w, "       Error: %s\n", c.Error)
+				if c.KeptDir != "" {
+					fmt.Fprintf(w, "       Kept:  %s\n", c.KeptDir)
 				}
+				if verbose && c.Output != "" {
+					fmt.Fprintf(w, "       Output:\n")
+					for line := range strings.SplitSeq(c.Output, "\n") {
+						fmt.Fprintf(w, "         %s\n", line)
+					}
+				}
+			case CaseErrored:
+				fmt.Fprintf(w, "  !  [%d] %s (%s)\n", c.Combination.Index, label, c.Duration.Round(100*time.Millisecond))
+				fmt.Fprintf(w, "       Phase: %s\n", c.Phase)
+				fmt.Fprintf(w, "       Error: %s\n", c.Error)
 			}
-		case CaseErrored:
-			fmt.Fprintf(w, "  !  [%d] %s (%s)\n", c.Combination.Index, label, c.Duration.Round(100*time.Millisecond))
-			fmt.Fprintf(w, "       Phase: %s\n", c.Phase)
-			fmt.Fprintf(w, "       Error: %s\n", c.Error)
+		}
+
+		if multiCase {
+			fmt.Fprintln(w)
 		}
 	}
 
@@ -61,10 +88,24 @@ func PrintJSONReport(w io.Writer, report Report) error {
 }
 
 // PrintDryRun lists all combinations that would be tested.
-func PrintDryRun(w io.Writer, combos []Combination, boolVars []string) {
-	fmt.Fprintf(w, "Combinations to test (%d total):\n\n", len(combos))
-	for _, c := range combos {
-		label := ComboLabel(c, boolVars)
-		fmt.Fprintf(w, "  [%d] %s\n", c.Index, label)
+func PrintDryRun(w io.Writer, plan *TestPlan) {
+	multiCase := len(plan.Cases) > 1
+	total := 0
+	for _, cp := range plan.Cases {
+		total += len(cp.Combos)
+	}
+
+	fmt.Fprintf(w, "Combinations to test (%d total):\n\n", total)
+	for _, cp := range plan.Cases {
+		if multiCase {
+			fmt.Fprintf(w, "── %s ──\n", cp.Name)
+		}
+		for _, c := range cp.Combos {
+			label := ComboLabel(c, plan.BoolVars)
+			fmt.Fprintf(w, "  [%d] %s\n", c.Index, label)
+		}
+		if multiCase {
+			fmt.Fprintln(w)
+		}
 	}
 }

--- a/internal/testrunner/report_test.go
+++ b/internal/testrunner/report_test.go
@@ -19,11 +19,13 @@ func TestUT_PrintTextReport_AllPassed(t *testing.T) {
 	report := testrunner.Report{
 		Cases: []testrunner.CaseResult{
 			{
+				CaseName:    "default",
 				Combination: testrunner.Combination{Index: 0, Vars: map[string]string{"a": "false"}},
 				Status:      testrunner.CasePassed,
 				Duration:    150 * time.Millisecond,
 			},
 			{
+				CaseName:    "default",
 				Combination: testrunner.Combination{Index: 1, Vars: map[string]string{"a": "true"}},
 				Status:      testrunner.CasePassed,
 				Duration:    200 * time.Millisecond,
@@ -51,11 +53,13 @@ func TestUT_PrintTextReport_WithFailure(t *testing.T) {
 	report := testrunner.Report{
 		Cases: []testrunner.CaseResult{
 			{
+				CaseName:    "default",
 				Combination: testrunner.Combination{Index: 0, Vars: map[string]string{"a": "false"}},
 				Status:      testrunner.CasePassed,
 				Duration:    100 * time.Millisecond,
 			},
 			{
+				CaseName:    "default",
 				Combination: testrunner.Combination{Index: 1, Vars: map[string]string{"a": "true"}},
 				Status:      testrunner.CaseFailed,
 				Phase:       "validate: go build ./...",
@@ -88,6 +92,7 @@ func TestUT_PrintTextReport_VerboseShowsOutput(t *testing.T) {
 	report := testrunner.Report{
 		Cases: []testrunner.CaseResult{
 			{
+				CaseName:    "default",
 				Combination: testrunner.Combination{Index: 0, Vars: map[string]string{"a": "true"}},
 				Status:      testrunner.CaseFailed,
 				Phase:       "validate: test",
@@ -115,6 +120,7 @@ func TestUT_PrintTextReport_KeptDirShown(t *testing.T) {
 	report := testrunner.Report{
 		Cases: []testrunner.CaseResult{
 			{
+				CaseName:    "default",
 				Combination: testrunner.Combination{Index: 0, Vars: map[string]string{"a": "true"}},
 				Status:      testrunner.CaseFailed,
 				Phase:       "validate: test",
@@ -141,11 +147,13 @@ func TestUT_PrintTextReport_SortsByIndex(t *testing.T) {
 	report := testrunner.Report{
 		Cases: []testrunner.CaseResult{
 			{
+				CaseName:    "default",
 				Combination: testrunner.Combination{Index: 2, Vars: map[string]string{"a": "true"}},
 				Status:      testrunner.CasePassed,
 				Duration:    100 * time.Millisecond,
 			},
 			{
+				CaseName:    "default",
 				Combination: testrunner.Combination{Index: 0, Vars: map[string]string{"a": "false"}},
 				Status:      testrunner.CasePassed,
 				Duration:    100 * time.Millisecond,
@@ -172,6 +180,7 @@ func TestUT_PrintJSONReport(t *testing.T) {
 	report := testrunner.Report{
 		Cases: []testrunner.CaseResult{
 			{
+				CaseName:    "build",
 				Combination: testrunner.Combination{Index: 0, Vars: map[string]string{"a": "true"}},
 				Status:      testrunner.CasePassed,
 				Duration:    100 * time.Millisecond,
@@ -196,18 +205,27 @@ func TestUT_PrintJSONReport(t *testing.T) {
 	cases := decoded["cases"].([]any)
 	firstCase := cases[0].(map[string]any)
 	assert.Equal(t, "passed", firstCase["status"])
+	assert.Equal(t, "build", firstCase["case_name"])
 }
 
 func TestUT_PrintDryRun(t *testing.T) {
 	t.Parallel()
 
-	combos := []testrunner.Combination{
-		{Index: 0, Vars: map[string]string{"a": "false", "b": "false"}},
-		{Index: 1, Vars: map[string]string{"a": "true", "b": "false"}},
+	plan := &testrunner.TestPlan{
+		BoolVars: []string{"a", "b"},
+		Cases: []testrunner.TestCasePlan{
+			{
+				Name: "default",
+				Combos: []testrunner.Combination{
+					{Index: 0, Vars: map[string]string{"a": "false", "b": "false"}},
+					{Index: 1, Vars: map[string]string{"a": "true", "b": "false"}},
+				},
+			},
+		},
 	}
 
 	var buf bytes.Buffer
-	testrunner.PrintDryRun(&buf, combos, []string{"a", "b"})
+	testrunner.PrintDryRun(&buf, plan)
 	output := buf.String()
 
 	assert.Contains(t, output, "2 total")
@@ -215,4 +233,67 @@ func TestUT_PrintDryRun(t *testing.T) {
 	assert.Contains(t, output, "[1]")
 	assert.Contains(t, output, "a=false b=false")
 	assert.Contains(t, output, "a=true b=false")
+}
+
+func TestUT_PrintTextReport_MultipleCasesGrouped(t *testing.T) {
+	t.Parallel()
+
+	report := testrunner.Report{
+		Cases: []testrunner.CaseResult{
+			{
+				CaseName:    "build",
+				Combination: testrunner.Combination{Index: 0, Vars: map[string]string{"a": "false"}},
+				Status:      testrunner.CasePassed,
+				Duration:    100 * time.Millisecond,
+			},
+			{
+				CaseName:    "lint",
+				Combination: testrunner.Combination{Index: 0, Vars: map[string]string{"a": "false"}},
+				Status:      testrunner.CasePassed,
+				Duration:    150 * time.Millisecond,
+			},
+		},
+		Passed:     2,
+		TotalCases: 2,
+		Duration:   250 * time.Millisecond,
+	}
+
+	var buf bytes.Buffer
+	testrunner.PrintTextReport(&buf, report, []string{"a"}, false)
+	output := buf.String()
+
+	assert.Contains(t, output, "── build ──")
+	assert.Contains(t, output, "── lint ──")
+	assert.Contains(t, output, "2 passed, 0 failed, 0 errored")
+}
+
+func TestUT_PrintDryRun_MultipleCases(t *testing.T) {
+	t.Parallel()
+
+	plan := &testrunner.TestPlan{
+		BoolVars: []string{"a"},
+		Cases: []testrunner.TestCasePlan{
+			{
+				Name: "build",
+				Combos: []testrunner.Combination{
+					{Index: 0, Vars: map[string]string{"a": "false"}},
+				},
+			},
+			{
+				Name: "lint",
+				Combos: []testrunner.Combination{
+					{Index: 0, Vars: map[string]string{"a": "false"}},
+					{Index: 1, Vars: map[string]string{"a": "true"}},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	testrunner.PrintDryRun(&buf, plan)
+	output := buf.String()
+
+	assert.Contains(t, output, "3 total")
+	assert.Contains(t, output, "── build ──")
+	assert.Contains(t, output, "── lint ──")
 }

--- a/internal/testrunner/runner.go
+++ b/internal/testrunner/runner.go
@@ -7,6 +7,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"strconv"
 	"sync"
 	"time"
 
@@ -33,19 +34,8 @@ func Plan(cfg Config) (*TestPlan, error) {
 		return nil, err
 	}
 
-	// Resolve validation commands: CLI override > template config > none.
-	commands := cfg.RunCommands
-	if len(commands) == 0 && testCfg != nil {
-		commands = testCfg.Commands
-	}
-
-	// Security: require opt-in for template-defined commands.
-	if len(cfg.RunCommands) == 0 && len(commands) > 0 && !cfg.AcceptHooks {
-		return nil, fmt.Errorf(
-			"template defines test commands %v; pass --accept-hooks to allow or --run to override",
-			commands,
-		)
-	}
+	// Extract boolean vars.
+	boolVars := ExtractBooleanVars(tmplCfg, cfg.SkipVars)
 
 	// Resolve environment variables from template config.
 	env := make(map[string]string)
@@ -59,21 +49,8 @@ func Plan(cfg Config) (*TestPlan, error) {
 		projectName = testCfg.ProjectName
 	}
 
-	// Extract boolean vars.
-	boolVars := ExtractBooleanVars(tmplCfg, cfg.SkipVars)
-
-	// Check safety limit BEFORE allocating combinations to prevent OOM.
-	count := CombinationCount(boolVars, cfg.PinVars)
-	if cfg.MaxCases > 0 && count > cfg.MaxCases {
-		return nil, fmt.Errorf(
-			"combination count %d exceeds safety limit %d (use --max-cases 0 to override)",
-			count, cfg.MaxCases,
-		)
-	}
-
-	// Generate and filter combinations.
-	combos := GenerateCombinations(boolVars, cfg.PinVars)
-	combos, err = FilterCombinations(combos, cfg.Filter)
+	// Build test case plans.
+	cases, err := buildCasePlans(cfg, testCfg, boolVars)
 	if err != nil {
 		return nil, err
 	}
@@ -81,11 +58,95 @@ func Plan(cfg Config) (*TestPlan, error) {
 	return &TestPlan{
 		TemplateDir: templateDir,
 		BoolVars:    boolVars,
-		Combos:      combos,
-		Commands:    commands,
+		Cases:       cases,
 		Env:         env,
 		ProjectName: projectName,
 	}, nil
+}
+
+func buildCasePlans(cfg Config, testCfg *tmplconfig.TestConfig, boolVars []string) ([]TestCasePlan, error) {
+	// Resolve test cases: CLI --run overrides everything, otherwise use template config.
+	var templateCases []tmplconfig.TestCase
+	if len(cfg.RunCommands) > 0 {
+		// CLI override: single anonymous case with the provided commands.
+		templateCases = []tmplconfig.TestCase{
+			{Name: "default", Commands: cfg.RunCommands},
+		}
+	} else if testCfg != nil && len(testCfg.Cases) > 0 {
+		templateCases = testCfg.Cases
+
+		// Security: require opt-in for template-defined commands.
+		if !cfg.AcceptHooks {
+			return nil, fmt.Errorf(
+				"template defines %d test case(s); pass --accept-hooks to allow or --run to override",
+				len(templateCases),
+			)
+		}
+	}
+
+	if len(templateCases) == 0 {
+		// No test cases defined — create a single case with no commands
+		// so combinations are still generated (scaffold-only validation).
+		templateCases = []tmplconfig.TestCase{
+			{Name: "default"},
+		}
+	}
+
+	// Filter by --case if specified.
+	if cfg.CaseName != "" {
+		var found bool
+		for _, tc := range templateCases {
+			if tc.Name == cfg.CaseName {
+				templateCases = []tmplconfig.TestCase{tc}
+				found = true
+				break
+			}
+		}
+		if !found {
+			names := make([]string, 0, len(templateCases))
+			for _, tc := range templateCases {
+				names = append(names, tc.Name)
+			}
+			return nil, fmt.Errorf("test case %q not found; available: %v", cfg.CaseName, names)
+		}
+	}
+
+	// Build a TestCasePlan for each case.
+	var totalCombos int
+	var plans []TestCasePlan
+	for _, tc := range templateCases {
+		// Merge CLI pin vars with case-level filters.
+		mergedPins := make(map[string]string, len(cfg.PinVars)+len(tc.Filters))
+		maps.Copy(mergedPins, cfg.PinVars)
+		for k, v := range tc.Filters {
+			mergedPins[k] = strconv.FormatBool(v)
+		}
+
+		count := CombinationCount(boolVars, mergedPins)
+		totalCombos += count
+
+		combos := GenerateCombinations(boolVars, mergedPins)
+		combos, err := FilterCombinations(combos, cfg.Filter)
+		if err != nil {
+			return nil, err
+		}
+
+		plans = append(plans, TestCasePlan{
+			Name:     tc.Name,
+			Combos:   combos,
+			Commands: tc.Commands,
+		})
+	}
+
+	// Check safety limit against total combinations across all cases.
+	if cfg.MaxCases > 0 && totalCombos > cfg.MaxCases {
+		return nil, fmt.Errorf(
+			"total combination count %d exceeds safety limit %d (use --max-cases 0 to override)",
+			totalCombos, cfg.MaxCases,
+		)
+	}
+
+	return plans, nil
 }
 
 // Execute runs the test plan with the given configuration and returns the report.
@@ -94,46 +155,65 @@ func Execute(ctx context.Context, plan *TestPlan, cfg Config) (Report, error) {
 	if parallel <= 0 {
 		parallel = defaultParallel
 	}
-	if parallel > len(plan.Combos) {
-		parallel = len(plan.Combos)
-	}
 
 	start := time.Now()
 
-	results := runWorkerPool(ctx, plan, cfg, parallel)
-
-	report := Report{
-		TotalCases:  len(plan.Combos),
-		TemplateDir: plan.TemplateDir,
-		Duration:    time.Since(start),
+	// Count total combinations across all cases.
+	totalCombos := 0
+	for _, cp := range plan.Cases {
+		totalCombos += len(cp.Combos)
 	}
 
-	for _, r := range results {
-		report.Cases = append(report.Cases, r)
-		switch r.Status {
-		case CasePassed:
-			report.Passed++
-		case CaseFailed:
-			report.Failed++
-		case CaseErrored:
-			report.Errored++
+	report := Report{
+		TemplateDir: plan.TemplateDir,
+	}
+
+	// Execute each test case.
+	for _, cp := range plan.Cases {
+		if ctx.Err() != nil {
+			break
+		}
+
+		p := min(parallel, len(cp.Combos))
+		if p <= 0 {
+			continue
+		}
+
+		results := runWorkerPool(ctx, plan, cfg, cp, p)
+		for _, r := range results {
+			report.Cases = append(report.Cases, r)
+			switch r.Status {
+			case CasePassed:
+				report.Passed++
+			case CaseFailed:
+				report.Failed++
+			case CaseErrored:
+				report.Errored++
+			}
+		}
+
+		if cfg.FailFast && (report.Failed > 0 || report.Errored > 0) {
+			break
 		}
 	}
 
-	return report, nil
+	report.TotalCases = len(report.Cases)
+	report.Duration = time.Since(start)
+
+	return report, nil //nolint:nilerr // ctx.Err above is for early loop exit, not a returned error
 }
 
-func runWorkerPool(ctx context.Context, plan *TestPlan, cfg Config, parallel int) []CaseResult {
+func runWorkerPool(ctx context.Context, plan *TestPlan, cfg Config, cp TestCasePlan, parallel int) []CaseResult {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	comboCh := make(chan Combination, len(plan.Combos))
-	for _, c := range plan.Combos {
+	comboCh := make(chan Combination, len(cp.Combos))
+	for _, c := range cp.Combos {
 		comboCh <- c
 	}
 	close(comboCh)
 
-	resultCh := make(chan CaseResult, len(plan.Combos))
+	resultCh := make(chan CaseResult, len(cp.Combos))
 
 	var wg sync.WaitGroup
 	for range parallel {
@@ -142,7 +222,7 @@ func runWorkerPool(ctx context.Context, plan *TestPlan, cfg Config, parallel int
 				if ctx.Err() != nil {
 					return
 				}
-				result := runSingleTest(ctx, plan, cfg, combo)
+				result := runSingleTest(ctx, plan, cfg, cp, combo)
 				resultCh <- result
 
 				if cfg.FailFast && result.Status != CasePassed {
@@ -156,20 +236,21 @@ func runWorkerPool(ctx context.Context, plan *TestPlan, cfg Config, parallel int
 	wg.Wait()
 	close(resultCh)
 
-	results := make([]CaseResult, 0, len(plan.Combos))
+	results := make([]CaseResult, 0, len(cp.Combos))
 	for r := range resultCh {
 		results = append(results, r)
 	}
 	return results
 }
 
-func runSingleTest(ctx context.Context, plan *TestPlan, cfg Config, combo Combination) CaseResult {
+func runSingleTest(ctx context.Context, plan *TestPlan, cfg Config, cp TestCasePlan, combo Combination) CaseResult {
 	start := time.Now()
 
 	// Create isolated temp directory for this combination.
 	tmpDir, err := os.MkdirTemp("", fmt.Sprintf("tag-test-%d-*", combo.Index))
 	if err != nil {
 		return CaseResult{
+			CaseName:    cp.Name,
 			Combination: combo,
 			Status:      CaseErrored,
 			Phase:       "setup",
@@ -206,6 +287,7 @@ func runSingleTest(ctx context.Context, plan *TestPlan, cfg Config, combo Combin
 	s, err := scaffold.NewScaffold(opts, scaffold.WithOutput(io.Discard))
 	if err != nil {
 		return CaseResult{
+			CaseName:    cp.Name,
 			Combination: combo,
 			Status:      CaseErrored,
 			Phase:       "scaffold-init",
@@ -217,6 +299,7 @@ func runSingleTest(ctx context.Context, plan *TestPlan, cfg Config, combo Combin
 	result, err := s.Run(opts)
 	if err != nil {
 		return CaseResult{
+			CaseName:    cp.Name,
 			Combination: combo,
 			Status:      CaseFailed,
 			Phase:       "scaffold",
@@ -233,30 +316,33 @@ func runSingleTest(ctx context.Context, plan *TestPlan, cfg Config, combo Combin
 		projectDir = result.OutputDir
 	}
 
-	return runValidation(ctx, plan, cfg, combo, projectDir, tmpDir, &shouldClean, start)
+	return runValidation(ctx, plan, cfg, cp, combo, projectDir, tmpDir, &shouldClean, start)
 }
 
 func runValidation(
 	ctx context.Context,
 	plan *TestPlan,
 	cfg Config,
+	cp TestCasePlan,
 	combo Combination,
 	outputDir string,
 	tmpDir string,
 	shouldClean *bool,
 	start time.Time,
 ) CaseResult {
-	if len(plan.Commands) == 0 {
+	if len(cp.Commands) == 0 {
 		return CaseResult{
+			CaseName:    cp.Name,
 			Combination: combo,
 			Status:      CasePassed,
 			Duration:    time.Since(start),
 		}
 	}
 
-	vResult := RunValidationCommands(ctx, outputDir, plan.Commands, plan.Env, cfg.Timeout)
+	vResult := RunValidationCommands(ctx, outputDir, cp.Commands, plan.Env, cfg.Timeout)
 	if vResult == nil {
 		return CaseResult{
+			CaseName:    cp.Name,
 			Combination: combo,
 			Status:      CasePassed,
 			Duration:    time.Since(start),
@@ -280,6 +366,7 @@ func runValidation(
 	}
 
 	return CaseResult{
+		CaseName:    cp.Name,
 		Combination: combo,
 		Status:      CaseFailed,
 		Phase:       "validate: " + vResult.Command,

--- a/internal/testrunner/types.go
+++ b/internal/testrunner/types.go
@@ -22,6 +22,7 @@ type Config struct {
 	PinVars     map[string]string // Vars to fix at a specific value (not permuted)
 	RunCommands []string          // Validation commands (overrides template config)
 	Filter      string            // Filter expression (index or key=value pairs)
+	CaseName    string            // Run only the test case with this name
 	Parallel    int               // Max concurrent test runs
 	FailFast    bool              // Stop on first failure
 	DryRun      bool              // List combinations without running
@@ -37,10 +38,16 @@ type Config struct {
 type TestPlan struct {
 	TemplateDir string
 	BoolVars    []string
-	Combos      []Combination
-	Commands    []string
+	Cases       []TestCasePlan
 	Env         map[string]string
 	ProjectName string
+}
+
+// TestCasePlan represents a single named test case with its filtered combinations and commands.
+type TestCasePlan struct {
+	Name     string
+	Combos   []Combination
+	Commands []string
 }
 
 // Combination represents a single set of boolean variable assignments.
@@ -90,6 +97,7 @@ func (s *CaseStatus) UnmarshalJSON(data []byte) error {
 
 // CaseResult holds the outcome of testing a single combination.
 type CaseResult struct {
+	CaseName    string        `json:"case_name"`
 	Combination Combination   `json:"combination"`
 	Status      CaseStatus    `json:"status"`
 	Phase       string        `json:"phase,omitempty"`    // "scaffold", "validate:<cmd>", etc.

--- a/internal/tmplconfig/parse.go
+++ b/internal/tmplconfig/parse.go
@@ -28,9 +28,16 @@ func ParseTemplateConfig(data []byte) (*TemplateConfig, error) {
 
 // TestConfig represents the optional "test" section in tag.template.json.
 type TestConfig struct {
-	Commands    []string          `json:"commands,omitempty"`
+	Cases       []TestCase        `json:"cases,omitempty"`
 	ProjectName string            `json:"project_name,omitempty"`
 	Env         map[string]string `json:"env,omitempty"`
+}
+
+// TestCase defines a named test case with optional filters and validation commands.
+type TestCase struct {
+	Name     string          `json:"name"`
+	Filters  map[string]bool `json:"filters,omitempty"`
+	Commands []string        `json:"commands"`
 }
 
 // ParseTestConfig extracts the optional "test" section from raw template config JSON.


### PR DESCRIPTION
## Summary
- Replace single `commands` array in `test` config with named `cases` array, each with optional `filters` and its own `commands`
- Add `--case` flag to run a single test case by name
- Case-level `filters` pin boolean variables for that case, reducing the combination matrix
- `project_name` and `env` remain shared across all cases
- Report output groups results by case name when multiple cases exist

## Config format

```json
{
  "test": {
    "project_name": "my-project",
    "env": {"CGO_ENABLED": "0"},
    "cases": [
      {"name": "Full test", "filters": {"use_docker": true}, "commands": ["go build ./...", "go vet ./..."]},
      {"name": "Light test", "commands": ["go build ./..."]}
    ]
  }
}
```

## Test plan
- [x] All existing tests updated and passing
- [x] New tests for multiple cases, case filtering, case-level filters, case not found
- [x] `make lint` clean
- [x] `make test` passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)