### PR TITLE
feat: OpenAPI input — drive codegen from a 3.x operation via vars.operation (#325)

### DIFF
--- a/.skills/SKILL.md
+++ b/.skills/SKILL.md
@@ -94,6 +94,7 @@ Execution order: Create → OpenAPI → Inject → Append (files exist before in
 
 - `{{ name }}` — the CLI argument from `tag generate <gen> <name>`
 - `{{ vars.x }}` — meta values from `--meta`/`-m` flags or `.tagconfig.json`
+- `{{ vars.operation.* }}` — an OpenAPI operation via `--openapi`/`--operation` (see reference.md → "OpenAPI input")
 - `{{ now("20060102150405") }}` — current timestamp (Go format layout). No args = RFC3339.
 - **Never bare names**: `{{ project_name }}` does NOT work. Always `{{ vars.project_name }}`.
 
@@ -280,6 +281,8 @@ my-project/
 | Flag | Commands | Description |
 |------|----------|-------------|
 | `-m key=value` | scaffold, generate | Set variable values |
+| `--openapi <path>` | generate | OpenAPI 3.x spec to expose as `vars.operation.*` (needs `--operation`) |
+| `--operation <selector>` | generate | Operation to extract: an `operationId` or `"METHOD /path"` |
 | `--values <file>` | scaffold | Load variables from JSON |
 | `--no-input` | scaffold | Skip prompts |
 | `--replay` | scaffold | Reuse saved inputs |

--- a/.skills/reference.md
+++ b/.skills/reference.md
@@ -319,6 +319,81 @@ CLAUDE.md
 
 Templates can include generators in `_generators/` — copied to scaffolded project's `.tag/`.
 
+## OpenAPI input
+
+Drive `tag generate` from an OpenAPI 3.x contract. Two flags on `tag generate`:
+
+```
+tag generate <gen> <name> --openapi ./api.yaml --operation getUserById
+tag generate <gen> <name> --openapi ./api.yaml --operation "GET /users/{id}"
+```
+
+- `--openapi <path>` and `--operation <selector>` are **both-or-neither** (setting one without
+  the other is an error).
+- **Selector** — primary key is `operationId`; fallback is `"METHOD /path"` (case-insensitive
+  method). Not-found or ambiguous selectors hard-error listing the available operations.
+- Parses 3.0 **and** 3.1 (via `libopenapi`); `$ref` is resolved. Malformed/non-3.x specs surface
+  the parser error.
+
+### `vars` shape
+
+The selected operation lands in five reserved namespaces:
+
+```
+vars.operation
+  ├── operationId, method (upper-case), path, summary, description
+  ├── tags          []string
+  ├── parameters    [] { name, in, required, description, schema }   # path-level + operation-level, operation wins
+  ├── requestBody   { required, description, content{ mediaType -> Schema } }
+  └── responses     { "200"|"default"|… -> { description, content{ mediaType -> Schema } } }
+vars.schemas   map[name]Schema   # component schemas referenced by the operation, deref'd, deduped
+vars.info      { title, version, description }
+vars.servers   [] { url, description }
+vars.security  []                # operation-level if present (even []=no auth), else spec-level
+
+Schema (recursive, raw OpenAPI):
+  { type, format, nullable, required[], enum[], default, description,
+    ref, items, properties{name->Schema}, composition{allOf|oneOf|anyOf: []} }
+```
+
+- A `$ref` **inlines its body once**; a `$ref` nested inside that body is a **leaf** — it carries
+  only `ref: "<Name>"`, and the full body lives once under `vars.schemas.<Name>`. Walk
+  `vars.schemas` to resolve nested types.
+- OpenAPI 3.1 `type: [T, "null"]` normalizes to `type: T` + `nullable: true`. A non-null union
+  (`type: [string, integer]`) collapses to the first type.
+- `allOf`/`oneOf`/`anyOf` are exposed raw under `composition` (not flattened/merged).
+- **Precedence:** the five keys are reserved — they win over `.tagconfig.json` / template vars on
+  collision (a warning is logged). An explicit `--meta` still overrides them (scalar only; `--meta`
+  cannot reach nested OpenAPI data).
+
+### Gotcha: the `in` field
+
+`in` is a Gonja keyword, so `param.in` fails to parse. Access it with subscript:
+
+```jinja
+{% for p in vars.operation.parameters %}
+// {{ p.name }} ({{ p['in'] }}): {{ p.schema.type }}
+{% endfor %}
+```
+
+### Worked example
+
+```jinja
+---
+to: {{ name | snake }}_handler.go
+---
+package handlers
+
+// {{ vars.operation.operationId }} — {{ vars.operation.method }} {{ vars.operation.path }}
+func {{ vars.operation.operationId | pascal }}(
+{%- for p in vars.operation.parameters %}
+    {{ p.name }} {{ p.schema.type | to('go') }},  // {{ p['in'] }}
+{%- endfor %}
+) {}
+```
+
+Scope is one operation per invocation; multi-operation/whole-spec generation is a follow-up.
+
 ## Hooks
 
 ### Phases

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kaikenlabs/tag
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/charmbracelet/glamour v0.10.0
@@ -11,10 +11,12 @@ require (
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/mattn/go-isatty v0.0.20
 	github.com/nikolalohinski/gonja/v2 v2.5.2
+	github.com/pb33f/libopenapi v0.38.5
 	github.com/sergi/go-diff v1.4.0
 	github.com/stretchr/testify v1.11.1
 	github.com/urfave/cli/v2 v2.27.7
 	github.com/xeipuuv/gojsonschema v1.2.0
+	go.yaml.in/yaml/v4 v4.0.0-rc.6
 	golang.org/x/term v0.39.0
 	golang.org/x/text v0.33.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -28,6 +30,8 @@ require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
+	github.com/bahlo/generic-list-go v0.2.0 // indirect
+	github.com/buger/jsonparser v1.1.2 // indirect
 	github.com/catppuccin/go v0.3.0 // indirect
 	github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7 // indirect
 	github.com/charmbracelet/bubbletea v1.3.6 // indirect
@@ -64,6 +68,8 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
+	github.com/pb33f/jsonpath v0.8.2 // indirect
+	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
 	github.com/pjbgf/sha1cd v0.3.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
@@ -81,7 +87,7 @@ require (
 	golang.org/x/crypto v0.37.0 // indirect
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/net v0.39.0 // indirect
-	golang.org/x/sync v0.19.0 // indirect
+	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.40.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,10 @@ github.com/aymanbagabas/go-udiff v0.3.1 h1:LV+qyBQ2pqe0u42ZsUEtPiCaUoqgA9gYRDs3v
 github.com/aymanbagabas/go-udiff v0.3.1/go.mod h1:G0fsKmG+P6ylD0r6N/KgQD/nWzgfnl8ZBcNLgcbrw8E=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
+github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
+github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
+github.com/buger/jsonparser v1.1.2 h1:frqHqw7otoVbk5M8LlE/L7HTnIq2v9RX6EJ48i9AxJk=
+github.com/buger/jsonparser v1.1.2/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/catppuccin/go v0.3.0 h1:d+0/YicIq+hSTo5oPuRi5kOpqkVA5tAsU6dNhvRu+aY=
 github.com/catppuccin/go v0.3.0/go.mod h1:8IHJuMGaUUjQM82qBrGNBv7LFq6JI3NnQCF6MOlZjpc=
 github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7 h1:JFgG/xnwFfbezlUnFMJy0nusZvytYysV4SCS2cYbvws=
@@ -156,6 +160,14 @@ github.com/onsi/ginkgo/v2 v2.23.4 h1:ktYTpKJAVZnDT4VjxSbiBenUjmlL/5QkBEocaWXiQus
 github.com/onsi/ginkgo/v2 v2.23.4/go.mod h1:Bt66ApGPBFzHyR+JO10Zbt0Gsp4uWxu5mIOTusL46e8=
 github.com/onsi/gomega v1.37.0 h1:CdEG8g0S133B4OswTDC/5XPSzE1OeP29QOioj2PID2Y=
 github.com/onsi/gomega v1.37.0/go.mod h1:8D9+Txp43QWKhM24yyOBEdpkzN8FvJyAwecBgsU4KU0=
+github.com/pb33f/jsonpath v0.8.2 h1:Ou4C7zjYClBm97dfZjDCjdZGusJoynv/vrtiEKNfj2Y=
+github.com/pb33f/jsonpath v0.8.2/go.mod h1:zBV5LJW4OQOPatmQE2QdKpGQJvhDTlE5IEj6ASaRNTo=
+github.com/pb33f/libopenapi v0.38.5 h1:qSJILKRAMp1jPe/auT3tXGhyBqzvZLsawQMA320HVE8=
+github.com/pb33f/libopenapi v0.38.5/go.mod h1:8yHl64vr+ICrnzSgiwJmZ54heRqCqrhI/JL1ge+CPIY=
+github.com/pb33f/ordered-map/v2 v2.3.1 h1:5319HDO0aw4DA4gzi+zv4FXU9UlSs3xGZ40wcP1nBjY=
+github.com/pb33f/ordered-map/v2 v2.3.1/go.mod h1:qxFQgd0PkVUtOMCkTapqotNgzRhMPL7VvaHKbd1HnmQ=
+github.com/pb33f/testify v0.1.0 h1:g48/HDU/jn2COspS4nM0scptxiKTJ4DnbX/4ehK6IZ8=
+github.com/pb33f/testify v0.1.0/go.mod h1:nq283P/jJ8hXMmdhAqfj7BJIz0y+6IOHj9q0044rKt4=
 github.com/pjbgf/sha1cd v0.3.2 h1:a9wb0bp1oC2TGwStyn0Umc/IGKQnEgF0vVaZ8QF8eo4=
 github.com/pjbgf/sha1cd v0.3.2/go.mod h1:zQWigSxVmsHEZow5qaLtPYxpcKMMQpa09ixqBxuCS6A=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -210,6 +222,8 @@ github.com/yuin/goldmark-emoji v1.0.5 h1:EMVWyCGPlXJfUXBXpuMu+ii3TIaxbVBnEX9uaDC
 github.com/yuin/goldmark-emoji v1.0.5/go.mod h1:tTkZEbwu5wkPmgTcitqddVxY9osFZiavD+r4AzQrh1U=
 go.uber.org/automaxprocs v1.6.0 h1:O3y2/QNTOdbF+e/dpXNNW7Rx2hZ4sTIPyybbxyNqTUs=
 go.uber.org/automaxprocs v1.6.0/go.mod h1:ifeIMSnPZuznNm6jmdzmU3/bfk01Fe2fotchwEFJ8r8=
+go.yaml.in/yaml/v4 v4.0.0-rc.6 h1:1h7H1ohdUh93/FyE4YaDa1Zh64K6VVbjF4K6WUxMtH4=
+go.yaml.in/yaml/v4 v4.0.0-rc.6/go.mod h1:aZqd9kCMsGL7AuUv/m/PvWLdg5sjJsZ4oHDEnfPPfY0=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.37.0 h1:kJNSjF/Xp7kU0iB2Z+9viTPMW4EqqsrywMXLJOOsXSE=
 golang.org/x/crypto v0.37.0/go.mod h1:vg+k43peMZ0pUMhYmVAWysMK35e6ioLh3wB8ZCAfbVc=
@@ -218,8 +232,8 @@ golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56/go.mod h1:M4RDyNAINzryxdtnbR
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.39.0 h1:ZCu7HMWDxpXpaiKdhzIfaltL9Lp31x/3fCP11bc6/fY=
 golang.org/x/net v0.39.0/go.mod h1:X7NRbYVEA+ewNkCNyJ513WmMdQ3BineSwVtN2zD/d+E=
-golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=
-golang.org/x/sync v0.19.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
+golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=
+golang.org/x/sync v0.21.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/internal/commands/generate.go
+++ b/internal/commands/generate.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kaikenlabs/tag/internal/engine"
 	"github.com/kaikenlabs/tag/internal/history"
 	"github.com/kaikenlabs/tag/internal/hooks"
+	"github.com/kaikenlabs/tag/internal/openapi"
 	"github.com/kaikenlabs/tag/internal/template"
 	"github.com/kaikenlabs/tag/internal/tmplconfig"
 	"github.com/kaikenlabs/tag/internal/types"
@@ -78,6 +79,8 @@ ARGUMENTS
 
 FLAGS
   --meta, -m key=value        Override template variables (repeatable)
+  --openapi <path>            OpenAPI 3.x spec to expose as vars.operation.* (needs --operation)
+  --operation <selector>      Operation to extract: operationId or "METHOD /path"
   --no-hooks                  Skip pre/post hooks defined in .tagconfig.json
   --on-existing=fail|skip|overwrite
                               Control behaviour when a file already exists (default: fail)
@@ -93,6 +96,8 @@ EXAMPLES
   tag generate --dry-run crud Product
   tag generate --on-existing=skip crud Product
   tag generate --on-existing=overwrite --verbose crud Product
+  tag generate --openapi api.yaml --operation getUserById handler user
+  tag generate --openapi api.yaml --operation "GET /users/{id}" handler user
   tag generate list                    # List available generators and bundles
   tag generate info model              # Show JSON metadata for a generator or bundle
   tag generate agent-file claude       # Generate AI agent reference file`,
@@ -142,6 +147,14 @@ EXAMPLES
 				Name:  flags.IgnoreLockFlag,
 				Usage: "Skip lockfile verification for this run (a warning will be printed)",
 			},
+			&cli.StringFlag{
+				Name:  flags.OpenAPIFlag,
+				Usage: "Path to an OpenAPI 3.x spec; exposes the selected operation as vars.operation.* (requires --operation)",
+			},
+			&cli.StringFlag{
+				Name:  flags.OperationFlag,
+				Usage: "Operation to extract from the OpenAPI spec: an operationId or \"METHOD /path\" (requires --openapi)",
+			},
 		},
 	}
 }
@@ -175,15 +188,72 @@ func generateAction(c *cli.Context, cfg *config.Config, fac generatorFactories) 
 		return app.UsageErrorf("invalid --on-existing value %q: must be one of fail, skip, overwrite", c.String(flags.OnExistingFlag))
 	}
 
+	openapiVars, err := loadOpenAPIVars(c)
+	if err != nil {
+		return err
+	}
+
 	target, err := resolveGenerateTarget(cfg, generatorOrBundleName, c.Path(flags.BundlePathFlag))
 	if err != nil {
 		return err
 	}
 
 	if target.IsBundle {
-		return generateBundle(c, cfg, fac, generatorOrBundleName, targetName, target.BundlePath, onExisting)
+		return generateBundle(c, cfg, fac, generatorOrBundleName, targetName, target.BundlePath, onExisting, openapiVars)
 	}
-	return generateTemplate(c, cfg, fac, generatorOrBundleName, targetName, target.GenDir, target.SharedDir, onExisting)
+	return generateTemplate(c, cfg, fac, generatorOrBundleName, targetName, target.GenDir, target.SharedDir, onExisting, openapiVars)
+}
+
+// loadOpenAPIVars reads the --openapi/--operation flags and, when both are set,
+// extracts the selected operation into the reserved vars namespaces
+// (operation/schemas/info/servers/security). The flags are both-or-neither.
+// Returns an empty (non-nil) map when neither flag is set.
+func loadOpenAPIVars(c *cli.Context) (map[string]any, error) {
+	specPath := c.String(flags.OpenAPIFlag)
+	selector := c.String(flags.OperationFlag)
+
+	switch {
+	case specPath == "" && selector == "":
+		return map[string]any{}, nil // no OpenAPI input; nothing to merge
+	case specPath == "":
+		return nil, app.UsageErrorf("--operation requires --openapi")
+	case selector == "":
+		return nil, app.UsageErrorf("--openapi requires --operation")
+	}
+
+	data, err := os.ReadFile(specPath)
+	if err != nil {
+		return nil, app.Errorf("cannot read OpenAPI spec %q: %w", specPath, err)
+	}
+	vars, err := openapi.ExtractOperation(data, selector)
+	if err != nil {
+		return nil, err
+	}
+	return vars, nil
+}
+
+// mergeOpenAPIVars overlays the OpenAPI reserved namespaces onto base. These
+// keys win over base (template/config vars) on collision — a warning is logged
+// so a template author notices their variable was shadowed. An explicit --meta
+// flag still overrides them later in the engine. base is not mutated.
+func mergeOpenAPIVars(base, openapiVars map[string]any) map[string]any {
+	if len(openapiVars) == 0 {
+		return base
+	}
+	merged := make(map[string]any, len(base)+len(openapiVars))
+	maps.Copy(merged, base)
+	for _, key := range openapi.ReservedKeys {
+		v, ok := openapiVars[key]
+		if !ok {
+			continue
+		}
+		if _, collision := merged[key]; collision {
+			slog.Warn("OpenAPI reserved namespace overrides an existing variable",
+				"key", key)
+		}
+		merged[key] = v
+	}
+	return merged
 }
 
 // generateFunc is the core generation work executed between pre/post hooks.
@@ -244,7 +314,7 @@ func mergeVars(base, overlay map[string]any) map[string]any {
 	return merged
 }
 
-func generateBundle(c *cli.Context, cfg *config.Config, fac generatorFactories, generatorName, targetName, bundlePath string, onExisting engine.OnExistingPolicy) error {
+func generateBundle(c *cli.Context, cfg *config.Config, fac generatorFactories, generatorName, targetName, bundlePath string, onExisting engine.OnExistingPolicy, openapiVars map[string]any) error {
 	data, err := os.ReadFile(bundlePath)
 	if err != nil {
 		return app.Errorf("cannot open bundle file: %w", err)
@@ -264,9 +334,11 @@ func generateBundle(c *cli.Context, cfg *config.Config, fac generatorFactories, 
 		return reqErr
 	}
 
-	// Merge variable layers: ScaffoldVars (base) <- BundleVars (override).
+	// Merge variable layers: ScaffoldVars (base) <- BundleVars (override) <-
+	// OpenAPI reserved namespaces (win on collision).
 	// CLI --meta flags are handled later by the engine (highest precedence).
 	mergedVars := mergeVars(cfg.Variables, bundle.Vars)
+	mergedVars = mergeOpenAPIVars(mergedVars, openapiVars)
 
 	// Load dialects (built-in + user-global only) for bundle's shared engine.
 	reg, dialectErr := loadDialectRegistryGlobal()
@@ -335,7 +407,7 @@ func generateBundle(c *cli.Context, cfg *config.Config, fac generatorFactories, 
 	})
 }
 
-func generateTemplate(c *cli.Context, cfg *config.Config, fac generatorFactories, generatorName, targetName, dirPath, sharedPath string, onExisting engine.OnExistingPolicy) error {
+func generateTemplate(c *cli.Context, cfg *config.Config, fac generatorFactories, generatorName, targetName, dirPath, sharedPath string, onExisting engine.OnExistingPolicy, openapiVars map[string]any) error {
 	// Check generator prerequisites from tag.template.json if present.
 	vars := make(map[string]any)
 	if cfg.Variables != nil {
@@ -357,12 +429,10 @@ func generateTemplate(c *cli.Context, cfg *config.Config, fac generatorFactories
 			return engine.GenerateResult{}, app.Errorf("error creating engine: %w", err)
 		}
 		data := engine.Data{
-			Name:       targetName,
-			RawMeta:    c.StringSlice(flags.MetaFlag),
-			OnExisting: onExisting,
-		}
-		if cfg.Variables != nil {
-			data.ScaffoldVars = cfg.Variables
+			Name:         targetName,
+			RawMeta:      c.StringSlice(flags.MetaFlag),
+			OnExisting:   onExisting,
+			ScaffoldVars: mergeOpenAPIVars(cfg.Variables, openapiVars),
 		}
 		return runGenerate(gen, data)
 	})

--- a/internal/commands/generate_openapi_test.go
+++ b/internal/commands/generate_openapi_test.go
@@ -1,0 +1,216 @@
+package commands
+
+import (
+	"flag"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+
+	"github.com/kaikenlabs/tag/internal/config"
+	"github.com/kaikenlabs/tag/internal/types/flags"
+)
+
+const openapiTestSpec = `openapi: 3.0.3
+info:
+  title: Pet Store
+  version: 1.0.0
+paths:
+  /pets/{id}:
+    get:
+      operationId: getPetById
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: A pet
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        name:
+          type: string
+`
+
+// newOpenAPITestApp builds a cli.App exposing the generate flags used by the
+// OpenAPI wiring, so tests exercise real urfave/cli flag parsing.
+func newOpenAPITestApp(cfg *config.Config) *cli.App {
+	return &cli.App{
+		Writer: io.Discard,
+		Commands: []*cli.Command{
+			{
+				Name: "generate",
+				Flags: []cli.Flag{
+					&cli.StringSliceFlag{Name: flags.MetaFlag, Aliases: []string{"m"}},
+					&cli.BoolFlag{Name: flags.DryRunFlag},
+					&cli.BoolFlag{Name: flags.NoHooksFlag},
+					&cli.StringFlag{Name: flags.OnExistingFlag, Value: ""},
+					&cli.BoolFlag{Name: flags.VerboseFlag},
+					&cli.StringFlag{Name: flags.OpenAPIFlag},
+					&cli.StringFlag{Name: flags.OperationFlag},
+				},
+				Action: func(c *cli.Context) error {
+					return generateAction(c, cfg, defaultGeneratorFactories())
+				},
+			},
+		},
+	}
+}
+
+func TestUT_GenerateAction_OpenAPIViaAppRun(t *testing.T) {
+	tmpDir := setupTempDir(t)
+
+	template := "---\nto: {{ name }}.txt\n---\n" +
+		"method: {{ vars.operation.method }}\n" +
+		"path: {{ vars.operation.path }}\n" +
+		"op: {{ vars.operation.operationId }}\n" +
+		"param: {{ vars.operation.parameters[0].name }}\n" +
+		"petType: {{ vars.schemas.Pet.type }}\n" +
+		"title: {{ vars.info.title }}\n"
+	createGenerator(t, tmpDir, "handler", template)
+	createSharedDir(t, tmpDir)
+
+	specPath := filepath.Join(tmpDir, "api.yaml")
+	require.NoError(t, os.WriteFile(specPath, []byte(openapiTestSpec), 0o644))
+
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tmpDir))
+	t.Cleanup(func() { os.Chdir(origDir) })
+
+	cfg := createTestConfig(t, tmpDir)
+
+	app := newOpenAPITestApp(cfg)
+	err = app.Run([]string{
+		"tag", "generate",
+		"--openapi", specPath,
+		"--operation", "getPetById",
+		"--no-hooks",
+		"handler", "widget",
+	})
+	require.NoError(t, err)
+
+	out, err := os.ReadFile(filepath.Join(tmpDir, "widget.txt"))
+	require.NoError(t, err)
+	content := string(out)
+	assert.Contains(t, content, "method: GET")
+	assert.Contains(t, content, "path: /pets/{id}")
+	assert.Contains(t, content, "op: getPetById")
+	assert.Contains(t, content, "param: id")
+	assert.Contains(t, content, "petType: object")
+	assert.Contains(t, content, "title: Pet Store")
+}
+
+func TestUT_GenerateAction_OpenAPIMethodPathSelector(t *testing.T) {
+	tmpDir := setupTempDir(t)
+
+	createGenerator(t, tmpDir, "handler",
+		"---\nto: {{ name }}.txt\n---\nop: {{ vars.operation.operationId }}\n")
+	createSharedDir(t, tmpDir)
+
+	specPath := filepath.Join(tmpDir, "api.yaml")
+	require.NoError(t, os.WriteFile(specPath, []byte(openapiTestSpec), 0o644))
+
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tmpDir))
+	t.Cleanup(func() { os.Chdir(origDir) })
+
+	cfg := createTestConfig(t, tmpDir)
+	app := newOpenAPITestApp(cfg)
+	err = app.Run([]string{
+		"tag", "generate",
+		"--openapi", specPath,
+		"--operation", "GET /pets/{id}",
+		"--no-hooks",
+		"handler", "widget",
+	})
+	require.NoError(t, err)
+
+	out, err := os.ReadFile(filepath.Join(tmpDir, "widget.txt"))
+	require.NoError(t, err)
+	assert.Contains(t, string(out), "op: getPetById")
+}
+
+func TestUT_LoadOpenAPIVars_BothOrNeither(t *testing.T) {
+	tests := []struct {
+		name      string
+		openapi   string
+		operation string
+		wantErr   string
+		wantNil   bool
+	}{
+		{name: "neither set", wantNil: true},
+		{name: "only openapi", openapi: "api.yaml", wantErr: "--openapi requires --operation"},
+		{name: "only operation", operation: "getX", wantErr: "--operation requires --openapi"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newFlagContext(t, tt.openapi, tt.operation)
+			vars, err := loadOpenAPIVars(c)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			if tt.wantNil {
+				assert.Empty(t, vars)
+			}
+		})
+	}
+}
+
+func TestUT_LoadOpenAPIVars_MissingFile(t *testing.T) {
+	c := newFlagContext(t, "/no/such/spec.yaml", "getX")
+	_, err := loadOpenAPIVars(c)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot read OpenAPI spec")
+}
+
+func TestUT_MergeOpenAPIVars_ReservedWins(t *testing.T) {
+	base := map[string]any{
+		"operation": "user-defined", // collides -> OpenAPI wins
+		"keep":      "untouched",    // unrelated -> survives
+	}
+	openapiVars := map[string]any{
+		"operation": map[string]any{"method": "GET"},
+		"schemas":   map[string]any{"Pet": map[string]any{}},
+	}
+
+	merged := mergeOpenAPIVars(base, openapiVars)
+
+	assert.Equal(t, "untouched", merged["keep"])
+	assert.Equal(t, map[string]any{"method": "GET"}, merged["operation"])
+	assert.Contains(t, merged, "schemas")
+	// base is not mutated.
+	assert.Equal(t, "user-defined", base["operation"])
+}
+
+func TestUT_MergeOpenAPIVars_NoOpenAPI(t *testing.T) {
+	base := map[string]any{"a": 1}
+	assert.Equal(t, base, mergeOpenAPIVars(base, nil))
+}
+
+// newFlagContext builds a cli.Context carrying only the --openapi/--operation
+// flags, for direct unit testing of loadOpenAPIVars.
+func newFlagContext(t *testing.T, openapiVal, operationVal string) *cli.Context {
+	t.Helper()
+	set := flag.NewFlagSet("test", flag.ContinueOnError)
+	set.String(flags.OpenAPIFlag, openapiVal, "")
+	set.String(flags.OperationFlag, operationVal, "")
+	return cli.NewContext(nil, set, nil)
+}

--- a/internal/integration/openapi_test.go
+++ b/internal/integration/openapi_test.go
@@ -1,0 +1,49 @@
+package integration
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kaikenlabs/tag/internal/engine"
+	"github.com/kaikenlabs/tag/internal/openapi"
+)
+
+// TestIT_GenerateFromOpenAPI drives the full read-side path: extract an
+// operation from an OpenAPI spec and render it through the real engine,
+// asserting the vars.operation/schemas/info namespaces reached the template.
+func TestIT_GenerateFromOpenAPI(t *testing.T) {
+	testdataDir := getTestdataDir()
+	generatorDir := filepath.Join(testdataDir, "generators", "openapi-handler")
+	specPath := filepath.Join(testdataDir, "openapi", "petstore.yaml")
+
+	spec, err := os.ReadFile(specPath)
+	require.NoError(t, err)
+
+	vars, err := openapi.ExtractOperation(spec, "getPetById")
+	require.NoError(t, err)
+
+	workDir := setupWorkDir(t, "")
+
+	gen, err := engine.NewGenerator(false, generatorDir, "", io.Discard)
+	require.NoError(t, err)
+
+	_, err = gen.Generate(engine.Data{Name: "pet", ScaffoldVars: vars})
+	require.NoError(t, err)
+
+	out, err := os.ReadFile(filepath.Join(workDir, "pet_handler.go"))
+	require.NoError(t, err)
+	content := string(out)
+
+	assert.Contains(t, content, "getPetById handles GET /pets/{id}")
+	assert.Contains(t, content, "Parameters: 2")
+	assert.Contains(t, content, "- id (path): string")
+	assert.Contains(t, content, "- expand (query): boolean")
+	assert.Contains(t, content, "Response 200 schema ref: Pet")
+	assert.Contains(t, content, "Pet.name type: string")
+	assert.Contains(t, content, "API: Pet Store v1.0.0")
+}

--- a/internal/integration/testdata/generators/openapi-handler/handler.tmpl
+++ b/internal/integration/testdata/generators/openapi-handler/handler.tmpl
@@ -1,0 +1,13 @@
+---
+to: {{ name | snake }}_handler.go
+---
+package handlers
+
+// {{ vars.operation.operationId }} handles {{ vars.operation.method }} {{ vars.operation.path }}
+// Parameters: {{ vars.operation.parameters | length }}
+{% for p in vars.operation.parameters -%}
+// - {{ p.name }} ({{ p['in'] }}): {{ p.schema.type }}
+{% endfor -%}
+// Response 200 schema ref: {{ vars.operation.responses['200'].content['application/json'].ref }}
+// Pet.name type: {{ vars.schemas.Pet.properties.name.type }}
+// API: {{ vars.info.title }} v{{ vars.info.version }}

--- a/internal/integration/testdata/openapi/petstore.yaml
+++ b/internal/integration/testdata/openapi/petstore.yaml
@@ -1,0 +1,36 @@
+openapi: 3.0.3
+info:
+  title: Pet Store
+  version: 1.0.0
+paths:
+  /pets/{id}:
+    get:
+      operationId: getPetById
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: expand
+          in: query
+          required: false
+          schema:
+            type: boolean
+      responses:
+        '200':
+          description: A pet
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Pet:
+      type: object
+      required: [id, name]
+      properties:
+        id:
+          type: string
+        name:
+          type: string

--- a/internal/openapi/extract.go
+++ b/internal/openapi/extract.go
@@ -1,0 +1,478 @@
+package openapi
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/pb33f/libopenapi"
+	base "github.com/pb33f/libopenapi/datamodel/high/base"
+	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
+	"github.com/pb33f/libopenapi/orderedmap"
+	yaml "go.yaml.in/yaml/v4"
+
+	"github.com/kaikenlabs/tag/pkg/app"
+)
+
+// maxSchemaDepth bounds recursion into deeply nested inline schemas (a $ref
+// graph can't recurse — nested refs are leaves, see schemaToMap).
+// ponytail: cap depth ~20; deepen only if a real spec needs it.
+const maxSchemaDepth = 20
+
+// ReservedKeys are the vars namespaces ExtractOperation produces. On collision
+// with template- or config-declared vars these win (they are reserved for
+// OpenAPI input); an explicit --meta flag still overrides them, as --meta is
+// applied later at the highest precedence by the engine.
+var ReservedKeys = []string{"operation", "schemas", "info", "servers", "security"}
+
+// ExtractOperation parses an OpenAPI 3.x spec and extracts a single operation
+// (selected by operationId or "METHOD /path") into a map[string]any suitable
+// for the template `vars` namespace. See claudedocs/openapi-input-plan.md.
+func ExtractOperation(spec []byte, selector string) (map[string]any, error) {
+	if strings.TrimSpace(selector) == "" {
+		return nil, app.Errorf("empty operation selector")
+	}
+
+	doc, err := libopenapi.NewDocument(spec)
+	if err != nil {
+		return nil, app.Errorf("cannot parse OpenAPI spec: %w", err)
+	}
+	model, buildErr := doc.BuildV3Model()
+	if buildErr != nil {
+		return nil, app.Errorf("cannot build OpenAPI 3.x model: %w", buildErr)
+	}
+
+	method, path, pathItem, op, err := resolveOperation(&model.Model, selector)
+	if err != nil {
+		return nil, err
+	}
+
+	ex := &extractor{collected: map[string]bool{}}
+	result := map[string]any{
+		"operation": ex.operationToMap(method, path, pathItem, op),
+		"info":      infoToMap(model.Model.Info),
+		"servers":   serversToList(model.Model.Servers),
+		"security":  securityToList(op, &model.Model),
+	}
+	result["schemas"] = ex.collectComponentSchemas(&model.Model)
+	return result, nil
+}
+
+// extractor carries walk state: `collected` is the transitive set of referenced
+// component names (for vars.schemas); it is never cleared so refs dedupe.
+type extractor struct {
+	collected map[string]bool
+}
+
+// --- selector resolution ---
+
+// resolveOperation finds the operation matching selector by operationId, then
+// by "METHOD /path". Not-found and ambiguous both hard-error listing candidates.
+func resolveOperation(model *v3.Document, selector string) (string, string, *v3.PathItem, *v3.Operation, error) {
+	if model.Paths == nil || model.Paths.PathItems == nil {
+		return "", "", nil, nil, app.Errorf("spec has no paths")
+	}
+
+	wantMethod, wantPath, isMethodPath := parseMethodPathSelector(selector)
+	var matches []opMatch
+
+	forEachOperation(model, func(method, path string, item *v3.PathItem, op *v3.Operation) {
+		if isMethodPath {
+			if method == wantMethod && path == wantPath {
+				matches = append(matches, opMatch{method, path, item, op})
+			}
+			return
+		}
+		if op.OperationId == selector {
+			matches = append(matches, opMatch{method, path, item, op})
+		}
+	})
+
+	switch len(matches) {
+	case 1:
+		m := matches[0]
+		return m.method, m.path, m.item, m.op, nil
+	case 0:
+		return "", "", nil, nil, app.Errorf(
+			"no operation matches %q; available operations:\n%s", selector, listCandidates(model))
+	default:
+		return "", "", nil, nil, app.Errorf(
+			"selector %q is ambiguous (%d matches); use the \"METHOD /path\" form. available operations:\n%s",
+			selector, len(matches), listCandidates(model))
+	}
+}
+
+type opMatch struct {
+	method string
+	path   string
+	item   *v3.PathItem
+	op     *v3.Operation
+}
+
+// parseMethodPathSelector recognizes the "GET /users/{id}" fallback form.
+func parseMethodPathSelector(selector string) (method, path string, ok bool) {
+	fields := strings.Fields(selector)
+	if len(fields) != 2 || !strings.HasPrefix(fields[1], "/") {
+		return "", "", false
+	}
+	return strings.ToUpper(fields[0]), fields[1], true
+}
+
+// forEachOperation visits every (METHOD, path) operation in the spec, method
+// upper-cased. Shared by selector resolution and candidate listing so the two
+// stay in sync.
+func forEachOperation(model *v3.Document, fn func(method, path string, item *v3.PathItem, op *v3.Operation)) {
+	if model.Paths == nil || model.Paths.PathItems == nil {
+		return
+	}
+	for pair := model.Paths.PathItems.Oldest(); pair != nil; pair = pair.Next() {
+		path, item := pair.Key, pair.Value
+		for mp := item.GetOperations().Oldest(); mp != nil; mp = mp.Next() {
+			fn(strings.ToUpper(mp.Key), path, item, mp.Value)
+		}
+	}
+}
+
+// listCandidates renders "METHOD /path (operationId)" lines for error messages.
+func listCandidates(model *v3.Document) string {
+	var lines []string
+	forEachOperation(model, func(method, path string, _ *v3.PathItem, op *v3.Operation) {
+		line := fmt.Sprintf("  %s %s", method, path)
+		if op.OperationId != "" {
+			line += " (" + op.OperationId + ")"
+		}
+		lines = append(lines, line)
+	})
+	sort.Strings(lines)
+	return strings.Join(lines, "\n")
+}
+
+// --- operation walk ---
+
+func (e *extractor) operationToMap(method, path string, item *v3.PathItem, op *v3.Operation) map[string]any {
+	out := map[string]any{
+		"operationId": op.OperationId,
+		"method":      method,
+		"path":        path,
+		"summary":     op.Summary,
+		"description": op.Description,
+		"tags":        toAnySlice(op.Tags),
+		"parameters":  e.paramsToList(effectiveParams(item, op)),
+	}
+	if op.RequestBody != nil {
+		out["requestBody"] = e.requestBodyToMap(op.RequestBody)
+	}
+	if op.Responses != nil {
+		out["responses"] = e.responsesToMap(op.Responses)
+	}
+	return out
+}
+
+// effectiveParams merges path-item-level and operation-level parameters.
+// Operation-level parameters override path-level ones with the same (name, in).
+func effectiveParams(item *v3.PathItem, op *v3.Operation) []*v3.Parameter {
+	index := map[string]int{}
+	var merged []*v3.Parameter
+	add := func(p *v3.Parameter) {
+		key := p.In + "\x00" + p.Name
+		if i, ok := index[key]; ok {
+			merged[i] = p
+			return
+		}
+		index[key] = len(merged)
+		merged = append(merged, p)
+	}
+	for _, p := range item.Parameters {
+		add(p)
+	}
+	for _, p := range op.Parameters {
+		add(p)
+	}
+	return merged
+}
+
+func (e *extractor) paramsToList(params []*v3.Parameter) []any {
+	out := make([]any, 0, len(params))
+	for _, p := range params {
+		m := map[string]any{
+			"name":        p.Name,
+			"in":          p.In,
+			"required":    p.Required != nil && *p.Required,
+			"description": p.Description,
+		}
+		if p.Schema != nil {
+			m["schema"] = e.schemaToMap(p.Schema, false, 0)
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+func (e *extractor) requestBodyToMap(rb *v3.RequestBody) map[string]any {
+	m := map[string]any{
+		"required":    rb.Required != nil && *rb.Required,
+		"description": rb.Description,
+		"content":     e.contentToMap(rb.Content),
+	}
+	return m
+}
+
+func (e *extractor) responsesToMap(resp *v3.Responses) map[string]any {
+	out := map[string]any{}
+	if resp.Codes != nil {
+		for pair := resp.Codes.Oldest(); pair != nil; pair = pair.Next() {
+			out[pair.Key] = e.responseToMap(pair.Value)
+		}
+	}
+	if resp.Default != nil {
+		out["default"] = e.responseToMap(resp.Default)
+	}
+	return out
+}
+
+func (e *extractor) responseToMap(r *v3.Response) map[string]any {
+	return map[string]any{
+		"description": r.Description,
+		"content":     e.contentToMap(r.Content),
+	}
+}
+
+// contentToMap keys each media type to its schema. No "pick JSON" magic.
+func (e *extractor) contentToMap(content *orderedmap.Map[string, *v3.MediaType]) map[string]any {
+	out := map[string]any{}
+	if content == nil {
+		return out
+	}
+	for pair := content.Oldest(); pair != nil; pair = pair.Next() {
+		if pair.Value.Schema != nil {
+			out[pair.Key] = e.schemaToMap(pair.Value.Schema, false, 0)
+		}
+	}
+	return out
+}
+
+// --- schema walk ---
+
+// schemaToMap converts a schema proxy into the recursive raw-OpenAPI map shape.
+// A $ref inlines its body once; nested refs beyond it become leaves (name only,
+// no body) so a wide or cyclic $ref graph can neither blow up nor loop — the
+// deref'd bodies live once in vars.schemas, keyed by name. refsAsLeaves carries
+// that "we are already inside an inlined ref" state; depth is a backstop cap for
+// deeply nested inline schemas. Every referenced component name is recorded in
+// e.collected for vars.schemas.
+func (e *extractor) schemaToMap(proxy *base.SchemaProxy, refsAsLeaves bool, depth int) map[string]any {
+	if proxy == nil {
+		return nil
+	}
+
+	out := map[string]any{}
+	if proxy.IsReference() {
+		ref := refName(proxy.GetReference())
+		out["ref"] = ref
+		e.collected[ref] = true
+		if refsAsLeaves {
+			return out // nested ref: name only; body is in vars.schemas[ref]
+		}
+		refsAsLeaves = true // inline this ref's body once; deeper refs are leaves
+	}
+
+	if depth > maxSchemaDepth {
+		return out
+	}
+	sch := proxy.Schema()
+	if sch == nil {
+		return out
+	}
+	e.fillSchema(out, sch, refsAsLeaves, depth)
+	return out
+}
+
+func (e *extractor) fillSchema(out map[string]any, s *base.Schema, refsAsLeaves bool, depth int) {
+	typ, nullable := normalizeType(s.Type)
+	if typ != "" {
+		out["type"] = typ
+	}
+	if nullable || (s.Nullable != nil && *s.Nullable) {
+		out["nullable"] = true
+	}
+	if s.Format != "" {
+		out["format"] = s.Format
+	}
+	if s.Description != "" {
+		out["description"] = s.Description
+	}
+	if len(s.Required) > 0 {
+		out["required"] = toAnySlice(s.Required)
+	}
+	if len(s.Enum) > 0 {
+		out["enum"] = nodesToValues(s.Enum)
+	}
+	if s.Default != nil {
+		out["default"] = nodeToValue(s.Default)
+	}
+	if s.Items != nil && s.Items.IsA() {
+		out["items"] = e.schemaToMap(s.Items.A, refsAsLeaves, depth+1)
+	}
+	if s.Properties != nil && s.Properties.Len() > 0 {
+		props := map[string]any{}
+		for pair := s.Properties.Oldest(); pair != nil; pair = pair.Next() {
+			props[pair.Key] = e.schemaToMap(pair.Value, refsAsLeaves, depth+1)
+		}
+		out["properties"] = props
+	}
+	if comp := e.composition(s, refsAsLeaves, depth); len(comp) > 0 {
+		out["composition"] = comp
+	}
+}
+
+// composition exposes allOf/oneOf/anyOf raw (no flatten/merge).
+// ponytail: no allOf merge; add a flattened view only if a template needs it.
+func (e *extractor) composition(s *base.Schema, refsAsLeaves bool, depth int) map[string]any {
+	out := map[string]any{}
+	add := func(key string, proxies []*base.SchemaProxy) {
+		if len(proxies) == 0 {
+			return
+		}
+		list := make([]any, 0, len(proxies))
+		for _, p := range proxies {
+			list = append(list, e.schemaToMap(p, refsAsLeaves, depth+1))
+		}
+		out[key] = list
+	}
+	add("allOf", s.AllOf)
+	add("oneOf", s.OneOf)
+	add("anyOf", s.AnyOf)
+	return out
+}
+
+// collectComponentSchemas resolves every transitively-referenced component name
+// into vars.schemas, deduped. New refs discovered while walking a component are
+// picked up because e.collected grows during the walk.
+func (e *extractor) collectComponentSchemas(model *v3.Document) map[string]any {
+	out := map[string]any{}
+	if model.Components == nil || model.Components.Schemas == nil {
+		return out
+	}
+	// Iterate until no new component names surface (transitive closure).
+	for {
+		pending := make([]string, 0)
+		for name := range e.collected {
+			if _, done := out[name]; !done {
+				pending = append(pending, name)
+			}
+		}
+		if len(pending) == 0 {
+			return out
+		}
+		for _, name := range pending {
+			proxy, ok := model.Components.Schemas.Get(name)
+			if !ok {
+				out[name] = map[string]any{} // dangling ref: record the name, empty body
+				continue
+			}
+			// refsAsLeaves=true: a component body inlines its own fields, but any
+			// nested $ref stays a leaf — each component is expanded exactly once.
+			out[name] = e.schemaToMap(proxy, true, 0)
+		}
+	}
+}
+
+// --- top-level sections ---
+
+func infoToMap(info *base.Info) map[string]any {
+	if info == nil {
+		return map[string]any{}
+	}
+	return map[string]any{
+		"title":       info.Title,
+		"version":     info.Version,
+		"description": info.Description,
+	}
+}
+
+func serversToList(servers []*v3.Server) []any {
+	out := make([]any, 0, len(servers))
+	for _, s := range servers {
+		out = append(out, map[string]any{"url": s.URL, "description": s.Description})
+	}
+	return out
+}
+
+// securityToList returns operation-level security if present (even an explicit
+// empty list meaning "no auth"), else the spec-level requirements.
+func securityToList(op *v3.Operation, model *v3.Document) []any {
+	reqs := op.Security
+	if reqs == nil {
+		reqs = model.Security
+	}
+	out := make([]any, 0, len(reqs))
+	for _, r := range reqs {
+		schemes := map[string]any{}
+		if r.Requirements != nil {
+			for pair := r.Requirements.Oldest(); pair != nil; pair = pair.Next() {
+				schemes[pair.Key] = toAnySlice(pair.Value)
+			}
+		}
+		out = append(out, schemes)
+	}
+	return out
+}
+
+// --- helpers ---
+
+// normalizeType folds the OpenAPI 3.1 `type: [T, "null"]` array into a single
+// type plus a nullable flag. Multi non-null types collapse to the first
+// (per plan); "null" anywhere sets nullable.
+func normalizeType(types []string) (typ string, nullable bool) {
+	for _, t := range types {
+		if t == "null" {
+			nullable = true
+			continue
+		}
+		if typ == "" {
+			typ = t
+		}
+	}
+	return typ, nullable
+}
+
+// refName decodes the final JSON-pointer token of a "$ref" into a component name.
+// "#/components/schemas/Foo~1Bar" -> "Foo/Bar".
+func refName(ref string) string {
+	seg := ref
+	if i := strings.LastIndex(ref, "/"); i >= 0 {
+		seg = ref[i+1:]
+	}
+	seg = strings.ReplaceAll(seg, "~1", "/")
+	seg = strings.ReplaceAll(seg, "~0", "~")
+	return seg
+}
+
+func toAnySlice(in []string) []any {
+	out := make([]any, len(in))
+	for i, s := range in {
+		out[i] = s
+	}
+	return out
+}
+
+func nodesToValues(nodes []*yaml.Node) []any {
+	out := make([]any, 0, len(nodes))
+	for _, n := range nodes {
+		out = append(out, nodeToValue(n))
+	}
+	return out
+}
+
+// nodeToValue decodes a YAML scalar node into its native Go value, falling back
+// to the raw string on decode failure.
+func nodeToValue(n *yaml.Node) any {
+	if n == nil {
+		return nil
+	}
+	var v any
+	if err := n.Decode(&v); err != nil {
+		return n.Value
+	}
+	return v
+}

--- a/internal/openapi/extract_test.go
+++ b/internal/openapi/extract_test.go
@@ -1,0 +1,487 @@
+package openapi
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func loadFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("testdata", name))
+	require.NoError(t, err)
+	return data
+}
+
+// asMap / asList narrow the map[string]any tree without repetitive casts.
+func asMap(t *testing.T, v any) map[string]any {
+	t.Helper()
+	m, ok := v.(map[string]any)
+	require.True(t, ok, "expected map[string]any, got %T", v)
+	return m
+}
+
+func asList(t *testing.T, v any) []any {
+	t.Helper()
+	l, ok := v.([]any)
+	require.True(t, ok, "expected []any, got %T", v)
+	return l
+}
+
+func TestUT_ExtractOperation_ByOperationID(t *testing.T) {
+	spec := loadFixture(t, "petstore_30.yaml")
+
+	res, err := ExtractOperation(spec, "getPetById")
+	require.NoError(t, err)
+
+	op := asMap(t, res["operation"])
+	assert.Equal(t, "getPetById", op["operationId"])
+	assert.Equal(t, "GET", op["method"])
+	assert.Equal(t, "/pets/{id}", op["path"])
+	assert.Equal(t, "Get a pet by id", op["summary"])
+
+	params := asList(t, op["parameters"])
+	require.Len(t, params, 1)
+	p := asMap(t, params[0])
+	assert.Equal(t, "id", p["name"])
+	assert.Equal(t, "path", p["in"])
+	assert.Equal(t, true, p["required"])
+	sch := asMap(t, p["schema"])
+	assert.Equal(t, "string", sch["type"])
+	assert.Equal(t, "uuid", sch["format"])
+}
+
+func TestUT_ExtractOperation_ByMethodPath(t *testing.T) {
+	spec := loadFixture(t, "petstore_30.yaml")
+
+	res, err := ExtractOperation(spec, "GET /pets/{id}")
+	require.NoError(t, err)
+	op := asMap(t, res["operation"])
+	assert.Equal(t, "getPetById", op["operationId"])
+	assert.Equal(t, "GET", op["method"])
+}
+
+func TestUT_ExtractOperation_MethodPathCaseInsensitive(t *testing.T) {
+	spec := loadFixture(t, "petstore_30.yaml")
+
+	res, err := ExtractOperation(spec, "get /pets/{id}")
+	require.NoError(t, err)
+	op := asMap(t, res["operation"])
+	assert.Equal(t, "getPetById", op["operationId"])
+}
+
+func TestUT_ExtractOperation_NotFound(t *testing.T) {
+	spec := loadFixture(t, "petstore_30.yaml")
+
+	_, err := ExtractOperation(spec, "nope")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no operation matches")
+	// Error lists candidates so the user can pick one.
+	assert.Contains(t, err.Error(), "getPetById")
+	assert.Contains(t, err.Error(), "GET /pets")
+}
+
+func TestUT_ExtractOperation_EmptySelector(t *testing.T) {
+	spec := loadFixture(t, "petstore_30.yaml")
+
+	_, err := ExtractOperation(spec, "   ")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty operation selector")
+}
+
+func TestUT_ExtractOperation_Ambiguous(t *testing.T) {
+	spec := []byte(`openapi: 3.0.0
+info: {title: t, version: v}
+paths:
+  /a:
+    get:
+      operationId: dup
+      responses: {'200': {description: ok}}
+  /b:
+    get:
+      operationId: dup
+      responses: {'200': {description: ok}}
+`)
+	_, err := ExtractOperation(spec, "dup")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ambiguous")
+	assert.Contains(t, err.Error(), "GET /a")
+	assert.Contains(t, err.Error(), "GET /b")
+}
+
+func TestUT_ExtractOperation_RefResolutionAndSchemas(t *testing.T) {
+	spec := loadFixture(t, "petstore_30.yaml")
+
+	res, err := ExtractOperation(spec, "getPetById")
+	require.NoError(t, err)
+
+	// 200 response schema is a $ref to Pet; ref name preserved and deref'd.
+	op := asMap(t, res["operation"])
+	responses := asMap(t, op["responses"])
+	r200 := asMap(t, responses["200"])
+	content := asMap(t, r200["content"])
+	petSchema := asMap(t, content["application/json"])
+	assert.Equal(t, "Pet", petSchema["ref"])
+	assert.Equal(t, "object", petSchema["type"])
+
+	// vars.schemas collects referenced components transitively (Pet -> Owner ->
+	// Address) plus Error (default response), deduped.
+	schemas := asMap(t, res["schemas"])
+	assert.Contains(t, schemas, "Pet")
+	assert.Contains(t, schemas, "Owner")
+	assert.Contains(t, schemas, "Address")
+	assert.Contains(t, schemas, "Error")
+
+	// Pet.status enum + Pet.photoUrls array items.
+	pet := asMap(t, schemas["Pet"])
+	props := asMap(t, pet["properties"])
+	status := asMap(t, props["status"])
+	assert.Equal(t, []any{"available", "pending", "sold"}, status["enum"])
+	photoUrls := asMap(t, props["photoUrls"])
+	assert.Equal(t, "array", photoUrls["type"])
+	items := asMap(t, photoUrls["items"])
+	assert.Equal(t, "string", items["type"])
+	assert.Equal(t, []any{"id", "name"}, pet["required"])
+}
+
+func TestUT_ExtractOperation_RequestBody(t *testing.T) {
+	spec := loadFixture(t, "petstore_30.yaml")
+
+	res, err := ExtractOperation(spec, "createPet")
+	require.NoError(t, err)
+	op := asMap(t, res["operation"])
+	rb := asMap(t, op["requestBody"])
+	assert.Equal(t, true, rb["required"])
+	assert.Equal(t, "Pet to add", rb["description"])
+	content := asMap(t, rb["content"])
+	schema := asMap(t, content["application/json"])
+	assert.Equal(t, "Pet", schema["ref"])
+}
+
+func TestUT_ExtractOperation_TopLevelSections(t *testing.T) {
+	spec := loadFixture(t, "petstore_30.yaml")
+
+	res, err := ExtractOperation(spec, "listPets")
+	require.NoError(t, err)
+
+	info := asMap(t, res["info"])
+	assert.Equal(t, "Pet Store", info["title"])
+	assert.Equal(t, "1.0.0", info["version"])
+
+	servers := asList(t, res["servers"])
+	require.Len(t, servers, 1)
+	assert.Equal(t, "https://api.example.com/v1", asMap(t, servers[0])["url"])
+
+	// listPets has no operation-level security -> spec-level applies.
+	security := asList(t, res["security"])
+	require.Len(t, security, 1)
+	assert.Contains(t, asMap(t, security[0]), "apiKey")
+}
+
+func TestUT_ExtractOperation_NullableNormalization_31(t *testing.T) {
+	spec := loadFixture(t, "petstore_31.yaml")
+
+	res, err := ExtractOperation(spec, "getPet")
+	require.NoError(t, err)
+
+	schemas := asMap(t, res["schemas"])
+	pet := asMap(t, schemas["Pet"])
+	props := asMap(t, pet["properties"])
+
+	// type: [string, "null"] -> type: string, nullable: true
+	nickname := asMap(t, props["nickname"])
+	assert.Equal(t, "string", nickname["type"])
+	assert.Equal(t, true, nickname["nullable"])
+
+	age := asMap(t, props["age"])
+	assert.Equal(t, "integer", age["type"])
+	assert.Equal(t, true, age["nullable"])
+	assert.Equal(t, "int32", age["format"])
+
+	// Non-nullable field stays plain.
+	id := asMap(t, props["id"])
+	assert.Equal(t, "string", id["type"])
+	assert.NotContains(t, id, "nullable")
+}
+
+func TestUT_ExtractOperation_CircularRef(t *testing.T) {
+	spec := []byte(`openapi: 3.0.0
+info: {title: t, version: v}
+paths:
+  /nodes:
+    get:
+      operationId: getNodes
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Node'
+components:
+  schemas:
+    Node:
+      type: object
+      properties:
+        value:
+          type: string
+        next:
+          $ref: '#/components/schemas/Node'
+`)
+	res, err := ExtractOperation(spec, "getNodes")
+	require.NoError(t, err) // terminates, no stack overflow
+
+	schemas := asMap(t, res["schemas"])
+	node := asMap(t, schemas["Node"])
+	props := asMap(t, node["properties"])
+	next := asMap(t, props["next"])
+	// The self-ref emits the ref name and stops descending.
+	assert.Equal(t, "Node", next["ref"])
+}
+
+func TestUT_ExtractOperation_NestedRefIsLeaf(t *testing.T) {
+	// A $ref inlines its body once; a $ref nested inside that body is a leaf
+	// (name only, no inline body) so a wide $ref graph cannot blow up. The
+	// deref'd body lives once in vars.schemas.
+	spec := loadFixture(t, "petstore_30.yaml")
+
+	res, err := ExtractOperation(spec, "getPetById")
+	require.NoError(t, err)
+
+	// vars.schemas.Pet.owner is a nested ref -> leaf (ref name, no body).
+	pet := asMap(t, asMap(t, res["schemas"])["Pet"])
+	owner := asMap(t, asMap(t, pet["properties"])["owner"])
+	assert.Equal(t, "Owner", owner["ref"])
+	assert.NotContains(t, owner, "properties", "nested ref must not inline its body")
+	assert.NotContains(t, owner, "type")
+
+	// The body is available once under vars.schemas.Owner.
+	ownerSchema := asMap(t, asMap(t, res["schemas"])["Owner"])
+	assert.Equal(t, "object", ownerSchema["type"])
+	assert.Contains(t, asMap(t, ownerSchema["properties"]), "address")
+}
+
+func TestUT_ExtractOperation_RefParameter(t *testing.T) {
+	// A parameter that is itself a component $ref must be deref'd with name/in
+	// populated, else effectiveParams' (name,in) key would collide.
+	spec := []byte(`openapi: 3.0.0
+info: {title: t, version: v}
+paths:
+  /x:
+    get:
+      operationId: getX
+      parameters:
+        - $ref: '#/components/parameters/PageParam'
+        - $ref: '#/components/parameters/SizeParam'
+      responses:
+        '200': {description: ok}
+components:
+  parameters:
+    PageParam:
+      name: page
+      in: query
+      required: false
+      schema: {type: integer}
+    SizeParam:
+      name: size
+      in: query
+      required: true
+      schema: {type: integer}
+`)
+	res, err := ExtractOperation(spec, "getX")
+	require.NoError(t, err)
+	params := asList(t, asMap(t, res["operation"])["parameters"])
+	require.Len(t, params, 2, "ref parameters must not collide")
+	names := map[string]bool{}
+	for _, p := range params {
+		names[asMap(t, p)["name"].(string)] = true
+	}
+	assert.True(t, names["page"])
+	assert.True(t, names["size"])
+}
+
+func TestUT_ExtractOperation_MutualCycle(t *testing.T) {
+	// Indirect cycle A -> B -> A terminates and both are collected once.
+	spec := []byte(`openapi: 3.0.0
+info: {title: t, version: v}
+paths:
+  /x:
+    get:
+      operationId: getX
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/A'
+components:
+  schemas:
+    A:
+      type: object
+      properties:
+        b: {$ref: '#/components/schemas/B'}
+    B:
+      type: object
+      properties:
+        a: {$ref: '#/components/schemas/A'}
+`)
+	res, err := ExtractOperation(spec, "getX")
+	require.NoError(t, err)
+	schemas := asMap(t, res["schemas"])
+	assert.Contains(t, schemas, "A")
+	assert.Contains(t, schemas, "B")
+	// Each component's nested ref is a leaf, so no infinite structure.
+	a := asMap(t, schemas["A"])
+	assert.Equal(t, "B", asMap(t, asMap(t, a["properties"])["b"])["ref"])
+}
+
+func TestUT_ExtractOperation_Composition(t *testing.T) {
+	spec := []byte(`openapi: 3.0.0
+info: {title: t, version: v}
+paths:
+  /x:
+    get:
+      operationId: getX
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/A'
+                  - type: object
+                    properties:
+                      extra: {type: string}
+components:
+  schemas:
+    A:
+      type: object
+      properties:
+        a: {type: string}
+`)
+	res, err := ExtractOperation(spec, "getX")
+	require.NoError(t, err)
+	op := asMap(t, res["operation"])
+	content := asMap(t, asMap(t, asMap(t, op["responses"])["200"])["content"])
+	schema := asMap(t, content["application/json"])
+	comp := asMap(t, schema["composition"])
+	allOf := asList(t, comp["allOf"])
+	require.Len(t, allOf, 2)
+	assert.Equal(t, "A", asMap(t, allOf[0])["ref"])
+}
+
+func TestUT_ExtractOperation_PathLevelParams(t *testing.T) {
+	// Path-item params merge with operation params; operation overrides same (name,in).
+	spec := []byte(`openapi: 3.0.0
+info: {title: t, version: v}
+paths:
+  /items/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        description: from path level
+        schema: {type: string}
+      - name: trace
+        in: header
+        required: false
+        schema: {type: string}
+    get:
+      operationId: getItem
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: overridden by operation
+          schema: {type: integer}
+      responses:
+        '200': {description: ok}
+`)
+	res, err := ExtractOperation(spec, "getItem")
+	require.NoError(t, err)
+	op := asMap(t, res["operation"])
+	params := asList(t, op["parameters"])
+	require.Len(t, params, 2) // id (merged/overridden) + trace (inherited)
+
+	byName := map[string]map[string]any{}
+	for _, p := range params {
+		pm := asMap(t, p)
+		byName[pm["name"].(string)] = pm
+	}
+	require.Contains(t, byName, "id")
+	require.Contains(t, byName, "trace")
+	// Operation-level id wins.
+	assert.Equal(t, "overridden by operation", byName["id"]["description"])
+	assert.Equal(t, "integer", asMap(t, byName["id"]["schema"])["type"])
+}
+
+func TestUT_ExtractOperation_OperationSecurityOverridesSpec(t *testing.T) {
+	spec := []byte(`openapi: 3.0.0
+info: {title: t, version: v}
+security:
+  - global: []
+paths:
+  /x:
+    get:
+      operationId: getX
+      security: []
+      responses:
+        '200': {description: ok}
+`)
+	res, err := ExtractOperation(spec, "getX")
+	require.NoError(t, err)
+	// Explicit empty operation security means "no auth" -> empty list, not spec-level.
+	security := asList(t, res["security"])
+	assert.Empty(t, security)
+}
+
+func TestUT_ExtractOperation_MalformedSpec(t *testing.T) {
+	_, err := ExtractOperation([]byte("this is not: [valid: openapi"), "x")
+	require.Error(t, err)
+}
+
+func TestUT_ExtractOperation_NonOpenAPISpec(t *testing.T) {
+	_, err := ExtractOperation([]byte("foo: bar\n"), "x")
+	require.Error(t, err)
+}
+
+func TestUT_RefName(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"#/components/schemas/User", "User"},
+		{"#/components/schemas/Foo~1Bar", "Foo/Bar"},
+		{"#/components/schemas/Tilde~0Name", "Tilde~Name"},
+		{"User", "User"},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, refName(tt.in), tt.in)
+	}
+}
+
+func TestUT_NormalizeType(t *testing.T) {
+	tests := []struct {
+		name     string
+		in       []string
+		wantType string
+		wantNull bool
+	}{
+		{"single", []string{"string"}, "string", false},
+		{"nullable", []string{"string", "null"}, "string", true},
+		{"null first", []string{"null", "integer"}, "integer", true},
+		{"multi collapses to first", []string{"string", "integer", "null"}, "string", true},
+		{"empty", nil, "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			typ, null := normalizeType(tt.in)
+			assert.Equal(t, tt.wantType, typ)
+			assert.Equal(t, tt.wantNull, null)
+		})
+	}
+}

--- a/internal/openapi/testdata/petstore_30.yaml
+++ b/internal/openapi/testdata/petstore_30.yaml
@@ -1,0 +1,120 @@
+openapi: 3.0.3
+info:
+  title: Pet Store
+  version: 1.0.0
+  description: A sample pet store API
+servers:
+  - url: https://api.example.com/v1
+    description: Production
+security:
+  - apiKey: []
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      summary: List pets
+      description: Returns all pets
+      tags: [pets]
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          description: Max items to return
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: A list of pets
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+    post:
+      operationId: createPet
+      summary: Create a pet
+      requestBody:
+        required: true
+        description: Pet to add
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+      responses:
+        '201':
+          description: Created
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /pets/{id}:
+    get:
+      operationId: getPetById
+      summary: Get a pet by id
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Pet id
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: A pet
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        default:
+          description: error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+components:
+  schemas:
+    Pet:
+      type: object
+      required: [id, name]
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        tag:
+          type: string
+        status:
+          type: string
+          enum: [available, pending, sold]
+        photoUrls:
+          type: array
+          items:
+            type: string
+        owner:
+          $ref: '#/components/schemas/Owner'
+    Owner:
+      type: object
+      properties:
+        name:
+          type: string
+        address:
+          $ref: '#/components/schemas/Address'
+    Address:
+      type: object
+      properties:
+        city:
+          type: string
+    Error:
+      type: object
+      required: [code, message]
+      properties:
+        code:
+          type: integer
+        message:
+          type: string

--- a/internal/openapi/testdata/petstore_31.yaml
+++ b/internal/openapi/testdata/petstore_31.yaml
@@ -1,0 +1,37 @@
+openapi: 3.1.0
+info:
+  title: Pet Store 3.1
+  version: 2.0.0
+  description: A 3.1 pet store API
+paths:
+  /pets/{id}:
+    get:
+      operationId: getPet
+      summary: Get a pet
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Pet id
+          schema:
+            type: string
+      responses:
+        '200':
+          description: A pet
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Pet:
+      type: object
+      required: [id]
+      properties:
+        id:
+          type: string
+        nickname:
+          type: [string, "null"]
+        age:
+          type: [integer, "null"]
+          format: int32

--- a/internal/types/flags/flags.go
+++ b/internal/types/flags/flags.go
@@ -19,4 +19,6 @@ const (
 	AsFlag            = "as"
 	InteractiveFlag   = "interactive"
 	AddToLibFlag      = "add-to-lib"
+	OpenAPIFlag       = "openapi"
+	OperationFlag     = "operation"
 )


### PR DESCRIPTION
## Intent

Add a **read-side** OpenAPI source to `tag generate` (ticket #325). Point it at an OpenAPI 3.x spec and one operation, and TAG hands the whole operation — parameters, request body, responses, referenced component schemas — to your template as `vars.operation.*`. The API contract can now drive codegen (handler, client, DTO, …) straight from the spec.

```
tag generate my-template --openapi ./api.yaml --operation getUserById
tag generate my-template --openapi ./api.yaml --operation "GET /users/{id}"   # fallback selector
```

This is symmetric to, but separate from, the existing write-side `internal/openapi/` (the `to("openapi")` filter / OpenAPI Action) — it never touches the Action dispatch.

## What changed

- **`internal/openapi/extract.go`** — `ExtractOperation(spec, selector) (map[string]any, error)`. Parses 3.0 **and** 3.1 via `github.com/pb33f/libopenapi`, resolves the selector, and walks the operation into plain `map[string]any`/`[]any` so Gonja and existing filters (`to("go")`, `length`, …) apply unchanged.
  - A `$ref` **inlines its body once**; a nested `$ref` is a **leaf** (`ref: "<Name>"` only), with bodies deduped into `vars.schemas` — no exponential expansion, no cycles.
  - OpenAPI 3.1 `type: [T, "null"]` normalizes to `type: T` + `nullable: true`.
  - Path-level + operation-level parameters merged (operation wins on `name`+`in`).
  - `allOf`/`oneOf`/`anyOf` exposed raw under `composition`.
- **`internal/commands/generate.go`** — `--openapi` / `--operation` flags (both-or-neither), merged into `ScaffoldVars` as reserved namespaces (`operation`/`schemas`/`info`/`servers`/`security`) that win over template/config vars on collision (warned). `--meta` still overrides scalars.
- **Tests** — unit (3.0 + 3.1 fixtures, selector by id / `METHOD /path`, not-found, ambiguous, circular + mutual-cycle guard, `$ref` params, nested-ref-leaf, nullable normalization, malformed spec), command-level `app.Run` wiring, and an integration render test.
- **Docs** — `.skills/SKILL.md` + `.skills/reference.md` (flags, `vars` shape, selector syntax, the `p['in']` gotcha, worked example).

No change to `internal/schema/*.json`; write-side `parser.go`/`Spec` and the Action switch untouched.

## Review

Reviewed by `quality-engineer` + `refactoring-expert` agents + Codex. Two Majors surfaced and fixed in-branch (recursive ref re-expansion → inline-once/leaf design; `$ref` parameter coverage). Report: `claudedocs/code-reviews/325-openapi-input-pr-review.md`.

`make lint` 0 issues · `make test` green.

Closes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ju6wehzfPF1QGFo2ZajjCq
