### PR TITLE
feat: OpenAPI multi-operation input — vars.operations from a whole spec (#327)

### DIFF
--- a/.skills/SKILL.md
+++ b/.skills/SKILL.md
@@ -94,7 +94,7 @@ Execution order: Create → OpenAPI → Inject → Append (files exist before in
 
 - `{{ name }}` — the CLI argument from `tag generate <gen> <name>`
 - `{{ vars.x }}` — meta values from `--meta`/`-m` flags or `.tagconfig.json`
-- `{{ vars.operation.* }}` — an OpenAPI operation via `--openapi`/`--operation` (see reference.md → "OpenAPI input")
+- `{{ vars.operation.* }}` — one OpenAPI operation via `--openapi`/`--operation`; or `{{ vars.operations }}` (a list) via `--operations`/`--operation-tag` (see reference.md → "OpenAPI input")
 - `{{ now("20060102150405") }}` — current timestamp (Go format layout). No args = RFC3339.
 - **Never bare names**: `{{ project_name }}` does NOT work. Always `{{ vars.project_name }}`.
 
@@ -281,8 +281,10 @@ my-project/
 | Flag | Commands | Description |
 |------|----------|-------------|
 | `-m key=value` | scaffold, generate | Set variable values |
-| `--openapi <path>` | generate | OpenAPI 3.x spec to expose as `vars.operation.*` (needs `--operation`) |
-| `--operation <selector>` | generate | Operation to extract: an `operationId` or `"METHOD /path"` |
+| `--openapi <path>` | generate | OpenAPI 3.x spec to expose to templates (needs a selector below) |
+| `--operation <selector>` | generate | Single operation → `vars.operation.*`: an `operationId` or `"METHOD /path"` |
+| `--operations` | generate | All operations → `vars.operations[]` (excludes `--operation`) |
+| `--operation-tag <name>` | generate | Operations with this tag → `vars.operations[]` (excludes `--operation`) |
 | `--values <file>` | scaffold | Load variables from JSON |
 | `--no-input` | scaffold | Skip prompts |
 | `--replay` | scaffold | Reuse saved inputs |

--- a/.skills/reference.md
+++ b/.skills/reference.md
@@ -321,17 +321,30 @@ Templates can include generators in `_generators/` — copied to scaffolded proj
 
 ## OpenAPI input
 
-Drive `tag generate` from an OpenAPI 3.x contract. Two flags on `tag generate`:
+Drive `tag generate` from an OpenAPI 3.x contract. Two modes: a **single operation** →
+`vars.operation`, or **many operations** → `vars.operations` (an ordered list).
 
 ```
+# single operation
 tag generate <gen> <name> --openapi ./api.yaml --operation getUserById
 tag generate <gen> <name> --openapi ./api.yaml --operation "GET /users/{id}"
+
+# many operations
+tag generate <gen> <name> --openapi ./api.yaml --operations              # every operation
+tag generate <gen> <name> --openapi ./api.yaml --operation-tag users     # operations tagged "users"
 ```
 
-- `--openapi <path>` and `--operation <selector>` are **both-or-neither** (setting one without
-  the other is an error).
-- **Selector** — primary key is `operationId`; fallback is `"METHOD /path"` (case-insensitive
-  method). Not-found or ambiguous selectors hard-error listing the available operations.
+- `--openapi <path>` is required for any OpenAPI input, together with **exactly one selection
+  mode**: `--operation` (single), `--operations` (all), or `--operation-tag <name>` (tag filter).
+- `--operation` is **mutually exclusive** with the multi-op selectors (error if combined).
+- `--operations` and `--operation-tag` are **not** exclusive: `--operations` turns on whole-spec
+  mode and `--operation-tag` narrows it to a tag, so `--operations --operation-tag users` is
+  equivalent to `--operation-tag users` alone. (`--operation-tag` already implies multi-op mode.)
+- **Single-op selector** — primary key is `operationId`; fallback is `"METHOD /path"`
+  (case-insensitive method). Not-found or ambiguous selectors hard-error listing the available
+  operations.
+- **Tag filter** — matches the OpenAPI `tags` on each operation, **case-sensitive**. A tag that
+  matches nothing (or an empty spec) hard-errors listing the available operations **and** tags.
 - Parses 3.0 **and** 3.1 (via `libopenapi`); `$ref` is resolved. Malformed/non-3.x specs surface
   the parser error.
 
@@ -392,7 +405,38 @@ func {{ vars.operation.operationId | pascal }}(
 ) {}
 ```
 
-Scope is one operation per invocation; multi-operation/whole-spec generation is a follow-up.
+### Multi-operation (`vars.operations`)
+
+`--operations` / `--operation-tag` expose an **ordered list** instead of a single operation. The
+current engine renders one template body to one `to:` path, so the template **loops** and emits a
+single file (one `routes.go`, one client, etc.) — there is no file-per-operation emission yet.
+
+```
+vars.operations   [] {                 # sorted by path, then HTTP method (deterministic)
+  operationId, method, path, summary, description, tags[],
+  parameters[], requestBody, responses,   # same shape as vars.operation above
+  security                                # effective auth for THIS op (op-level, else spec-level)
+}
+vars.schemas   map[name]Schema   # deduped UNION of components referenced by all selected operations
+vars.info      { title, version, description }
+vars.servers   [] { url, description }
+```
+
+- There is **no top-level `vars.security`** in multi-op mode — auth differs per operation, so it
+  travels inside each `vars.operations[]` entry instead.
+- `operations` is a reserved namespace (it wins over template/config vars on collision; a warning
+  is logged). An explicit `--meta` still overrides it.
+
+```jinja
+---
+to: {{ name | snake }}_routes.go
+---
+package routes
+{% for op in vars.operations %}
+// {{ op.operationId | pascal }} — {{ op.method }} {{ op.path }}
+func {{ op.operationId | pascal }}() {}
+{% endfor %}
+```
 
 ## Hooks
 

--- a/internal/commands/generate.go
+++ b/internal/commands/generate.go
@@ -9,6 +9,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/urfave/cli/v2"
 
@@ -79,8 +80,10 @@ ARGUMENTS
 
 FLAGS
   --meta, -m key=value        Override template variables (repeatable)
-  --openapi <path>            OpenAPI 3.x spec to expose as vars.operation.* (needs --operation)
-  --operation <selector>      Operation to extract: operationId or "METHOD /path"
+  --openapi <path>            OpenAPI 3.x spec to expose to templates (needs a selector below)
+  --operation <selector>      Single operation → vars.operation.*: operationId or "METHOD /path"
+  --operations                All operations → vars.operations[] (excludes --operation)
+  --operation-tag <name>      Operations with this tag → vars.operations[] (excludes --operation)
   --no-hooks                  Skip pre/post hooks defined in .tagconfig.json
   --on-existing=fail|skip|overwrite
                               Control behaviour when a file already exists (default: fail)
@@ -98,6 +101,8 @@ EXAMPLES
   tag generate --on-existing=overwrite --verbose crud Product
   tag generate --openapi api.yaml --operation getUserById handler user
   tag generate --openapi api.yaml --operation "GET /users/{id}" handler user
+  tag generate --openapi api.yaml --operations routes all
+  tag generate --openapi api.yaml --operation-tag users handlers users
   tag generate list                    # List available generators and bundles
   tag generate info model              # Show JSON metadata for a generator or bundle
   tag generate agent-file claude       # Generate AI agent reference file`,
@@ -155,6 +160,14 @@ EXAMPLES
 				Name:  flags.OperationFlag,
 				Usage: "Operation to extract from the OpenAPI spec: an operationId or \"METHOD /path\" (requires --openapi)",
 			},
+			&cli.BoolFlag{
+				Name:  flags.OperationsFlag,
+				Usage: "Expose every OpenAPI operation as vars.operations (requires --openapi; excludes --operation; narrow with --operation-tag)",
+			},
+			&cli.StringFlag{
+				Name:  flags.OperationTagFlag,
+				Usage: "Expose only operations carrying this OpenAPI tag as vars.operations (requires --openapi; excludes --operation)",
+			},
 		},
 	}
 }
@@ -204,32 +217,46 @@ func generateAction(c *cli.Context, cfg *config.Config, fac generatorFactories) 
 	return generateTemplate(c, cfg, fac, generatorOrBundleName, targetName, target.GenDir, target.SharedDir, onExisting, openapiVars)
 }
 
-// loadOpenAPIVars reads the --openapi/--operation flags and, when both are set,
-// extracts the selected operation into the reserved vars namespaces
-// (operation/schemas/info/servers/security). The flags are both-or-neither.
-// Returns an empty (non-nil) map when neither flag is set.
+// loadOpenAPIVars reads the OpenAPI selector flags and extracts the matching
+// operation(s) into the reserved vars namespaces. Singular --operation yields
+// vars.operation.* (plus schemas/info/servers/security); the multi-op selectors
+// --operations (all) and --operation-tag <name> (filtered) yield vars.operations
+// (an ordered list, each carrying its own security) plus the deduped schema union.
+// --operation is mutually exclusive with the multi-op selectors, and any selector
+// requires --openapi. Returns an empty (non-nil) map when no OpenAPI input is set.
 func loadOpenAPIVars(c *cli.Context) (map[string]any, error) {
 	specPath := c.String(flags.OpenAPIFlag)
 	selector := c.String(flags.OperationFlag)
+	allOps := c.Bool(flags.OperationsFlag)
+	tag := strings.TrimSpace(c.String(flags.OperationTagFlag))
+	tagSet := c.IsSet(flags.OperationTagFlag)
+
+	if tagSet && tag == "" {
+		return nil, app.UsageErrorf("--operation-tag requires a non-empty tag name")
+	}
+
+	singleMode := selector != ""
+	multiMode := allOps || tagSet
 
 	switch {
-	case specPath == "" && selector == "":
+	case singleMode && multiMode:
+		return nil, app.UsageErrorf("--operation is mutually exclusive with --operations and --operation-tag")
+	case specPath == "" && !singleMode && !multiMode:
 		return map[string]any{}, nil // no OpenAPI input; nothing to merge
 	case specPath == "":
-		return nil, app.UsageErrorf("--operation requires --openapi")
-	case selector == "":
-		return nil, app.UsageErrorf("--openapi requires --operation")
+		return nil, app.UsageErrorf("--operation, --operations, and --operation-tag all require --openapi")
+	case !singleMode && !multiMode:
+		return nil, app.UsageErrorf("--openapi requires one of --operation, --operations, or --operation-tag")
 	}
 
 	data, err := os.ReadFile(specPath)
 	if err != nil {
 		return nil, app.Errorf("cannot read OpenAPI spec %q: %w", specPath, err)
 	}
-	vars, err := openapi.ExtractOperation(data, selector)
-	if err != nil {
-		return nil, err
+	if singleMode {
+		return openapi.ExtractOperation(data, selector)
 	}
-	return vars, nil
+	return openapi.ExtractOperations(data, tag) // tag == "" selects all operations
 }
 
 // mergeOpenAPIVars overlays the OpenAPI reserved namespaces onto base. These

--- a/internal/commands/generate_openapi_test.go
+++ b/internal/commands/generate_openapi_test.go
@@ -301,6 +301,22 @@ func TestUT_LoadOpenAPIVars_OpenAPIWithoutSelector(t *testing.T) {
 	assert.Contains(t, msg, "--operation-tag")
 }
 
+func TestUT_LoadOpenAPIVars_MultiOpSuccess(t *testing.T) {
+	specPath := filepath.Join(t.TempDir(), "api.yaml")
+	require.NoError(t, os.WriteFile(specPath, []byte(openapiTestSpec), 0o644))
+
+	c := newMultiOpFlagContext(t, openapiFlags{openapi: specPath, operations: true})
+	vars, err := loadOpenAPIVars(c)
+	require.NoError(t, err)
+
+	ops, ok := vars["operations"].([]any)
+	require.True(t, ok, "expected vars.operations list, got %T", vars["operations"])
+	require.Len(t, ops, 1)
+	assert.Equal(t, "getPetById", ops[0].(map[string]any)["operationId"])
+	// Multi-op omits the top-level security namespace.
+	assert.NotContains(t, vars, "security")
+}
+
 func TestUT_LoadOpenAPIVars_BlankTag(t *testing.T) {
 	c := newMultiOpFlagContext(t, openapiFlags{openapi: "api.yaml", operationTag: "  ", tagSet: true})
 	_, err := loadOpenAPIVars(c)

--- a/internal/commands/generate_openapi_test.go
+++ b/internal/commands/generate_openapi_test.go
@@ -61,6 +61,8 @@ func newOpenAPITestApp(cfg *config.Config) *cli.App {
 					&cli.BoolFlag{Name: flags.VerboseFlag},
 					&cli.StringFlag{Name: flags.OpenAPIFlag},
 					&cli.StringFlag{Name: flags.OperationFlag},
+					&cli.BoolFlag{Name: flags.OperationsFlag},
+					&cli.StringFlag{Name: flags.OperationTagFlag},
 				},
 				Action: func(c *cli.Context) error {
 					return generateAction(c, cfg, defaultGeneratorFactories())
@@ -154,8 +156,8 @@ func TestUT_LoadOpenAPIVars_BothOrNeither(t *testing.T) {
 		wantNil   bool
 	}{
 		{name: "neither set", wantNil: true},
-		{name: "only openapi", openapi: "api.yaml", wantErr: "--openapi requires --operation"},
-		{name: "only operation", operation: "getX", wantErr: "--operation requires --openapi"},
+		{name: "only openapi", openapi: "api.yaml", wantErr: "--openapi requires one of --operation"},
+		{name: "only operation", operation: "getX", wantErr: "all require --openapi"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -212,5 +214,96 @@ func newFlagContext(t *testing.T, openapiVal, operationVal string) *cli.Context 
 	set := flag.NewFlagSet("test", flag.ContinueOnError)
 	set.String(flags.OpenAPIFlag, openapiVal, "")
 	set.String(flags.OperationFlag, operationVal, "")
+	set.Bool(flags.OperationsFlag, false, "")
+	set.String(flags.OperationTagFlag, "", "")
 	return cli.NewContext(nil, set, nil)
+}
+
+// openapiFlags names the four OpenAPI selector flags a caller may set.
+type openapiFlags struct {
+	openapi      string
+	operation    string
+	operations   bool
+	operationTag string
+	tagSet       bool // whether --operation-tag was explicitly provided
+}
+
+// newMultiOpFlagContext builds a cli.Context with all four OpenAPI flags, honoring
+// c.IsSet for --operation-tag so blank-vs-unset can be distinguished.
+func newMultiOpFlagContext(t *testing.T, f openapiFlags) *cli.Context {
+	t.Helper()
+	set := flag.NewFlagSet("test", flag.ContinueOnError)
+	set.String(flags.OpenAPIFlag, "", "")
+	set.String(flags.OperationFlag, "", "")
+	set.Bool(flags.OperationsFlag, false, "")
+	set.String(flags.OperationTagFlag, "", "")
+	var args []string
+	if f.openapi != "" {
+		args = append(args, "--"+flags.OpenAPIFlag, f.openapi)
+	}
+	if f.operation != "" {
+		args = append(args, "--"+flags.OperationFlag, f.operation)
+	}
+	if f.operations {
+		args = append(args, "--"+flags.OperationsFlag)
+	}
+	if f.tagSet {
+		args = append(args, "--"+flags.OperationTagFlag, f.operationTag)
+	}
+	require.NoError(t, set.Parse(args))
+	return cli.NewContext(nil, set, nil)
+}
+
+func TestUT_LoadOpenAPIVars_MultiOpMutualExclusion(t *testing.T) {
+	tests := []struct {
+		name string
+		f    openapiFlags
+	}{
+		{"operation + operations", openapiFlags{openapi: "api.yaml", operation: "getX", operations: true}},
+		{"operation + tag", openapiFlags{openapi: "api.yaml", operation: "getX", operationTag: "pets", tagSet: true}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newMultiOpFlagContext(t, tt.f)
+			_, err := loadOpenAPIVars(c)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "mutually exclusive")
+		})
+	}
+}
+
+func TestUT_LoadOpenAPIVars_MultiOpRequiresOpenAPI(t *testing.T) {
+	tests := []struct {
+		name string
+		f    openapiFlags
+	}{
+		{"operations without openapi", openapiFlags{operations: true}},
+		{"tag without openapi", openapiFlags{operationTag: "pets", tagSet: true}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newMultiOpFlagContext(t, tt.f)
+			_, err := loadOpenAPIVars(c)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "--openapi")
+		})
+	}
+}
+
+func TestUT_LoadOpenAPIVars_OpenAPIWithoutSelector(t *testing.T) {
+	c := newMultiOpFlagContext(t, openapiFlags{openapi: "api.yaml"})
+	_, err := loadOpenAPIVars(c)
+	require.Error(t, err)
+	// Error names all three selector flags so the user knows the options.
+	msg := err.Error()
+	assert.Contains(t, msg, "--operation")
+	assert.Contains(t, msg, "--operations")
+	assert.Contains(t, msg, "--operation-tag")
+}
+
+func TestUT_LoadOpenAPIVars_BlankTag(t *testing.T) {
+	c := newMultiOpFlagContext(t, openapiFlags{openapi: "api.yaml", operationTag: "  ", tagSet: true})
+	_, err := loadOpenAPIVars(c)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--operation-tag")
 }

--- a/internal/integration/openapi_test.go
+++ b/internal/integration/openapi_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -46,4 +47,69 @@ func TestIT_GenerateFromOpenAPI(t *testing.T) {
 	assert.Contains(t, content, "Response 200 schema ref: Pet")
 	assert.Contains(t, content, "Pet.name type: string")
 	assert.Contains(t, content, "API: Pet Store v1.0.0")
+}
+
+// TestIT_GenerateFromOpenAPIAllOperations drives the multi-op read-side path:
+// extract every operation and render a single-file loop over vars.operations,
+// asserting all operations appear in the documented path-then-method order.
+func TestIT_GenerateFromOpenAPIAllOperations(t *testing.T) {
+	testdataDir := getTestdataDir()
+	generatorDir := filepath.Join(testdataDir, "generators", "openapi-routes")
+	specPath := filepath.Join(testdataDir, "openapi", "petstore_multi.yaml")
+
+	spec, err := os.ReadFile(specPath)
+	require.NoError(t, err)
+
+	vars, err := openapi.ExtractOperations(spec, "")
+	require.NoError(t, err)
+
+	workDir := setupWorkDir(t, "")
+
+	gen, err := engine.NewGenerator(false, generatorDir, "", io.Discard)
+	require.NoError(t, err)
+
+	_, err = gen.Generate(engine.Data{Name: "api", ScaffoldVars: vars})
+	require.NoError(t, err)
+
+	out, err := os.ReadFile(filepath.Join(workDir, "api_routes.go"))
+	require.NoError(t, err)
+	content := string(out)
+
+	assert.Contains(t, content, "operations: 3")
+	assert.Contains(t, content, "listPets: GET /pets")
+	assert.Contains(t, content, "createPet: POST /pets")
+	assert.Contains(t, content, "getPetById: GET /pets/{id}")
+	// Sorted by path then method: listPets, createPet, getPetById.
+	assert.Less(t, strings.Index(content, "listPets"), strings.Index(content, "createPet"))
+	assert.Less(t, strings.Index(content, "createPet"), strings.Index(content, "getPetById"))
+}
+
+// TestIT_GenerateFromOpenAPIByTag renders only operations carrying a given tag.
+func TestIT_GenerateFromOpenAPIByTag(t *testing.T) {
+	testdataDir := getTestdataDir()
+	generatorDir := filepath.Join(testdataDir, "generators", "openapi-routes")
+	specPath := filepath.Join(testdataDir, "openapi", "petstore_multi.yaml")
+
+	spec, err := os.ReadFile(specPath)
+	require.NoError(t, err)
+
+	vars, err := openapi.ExtractOperations(spec, "pets")
+	require.NoError(t, err)
+
+	workDir := setupWorkDir(t, "")
+
+	gen, err := engine.NewGenerator(false, generatorDir, "", io.Discard)
+	require.NoError(t, err)
+
+	_, err = gen.Generate(engine.Data{Name: "api", ScaffoldVars: vars})
+	require.NoError(t, err)
+
+	out, err := os.ReadFile(filepath.Join(workDir, "api_routes.go"))
+	require.NoError(t, err)
+	content := string(out)
+
+	assert.Contains(t, content, "operations: 2")
+	assert.Contains(t, content, "listPets: GET /pets")
+	assert.Contains(t, content, "getPetById: GET /pets/{id}")
+	assert.NotContains(t, content, "createPet")
 }

--- a/internal/integration/testdata/generators/openapi-routes/routes.tmpl
+++ b/internal/integration/testdata/generators/openapi-routes/routes.tmpl
@@ -1,0 +1,10 @@
+---
+to: {{ name | snake }}_routes.go
+---
+package routes
+
+// {{ vars.info.title }} v{{ vars.info.version }}
+// operations: {{ vars.operations | length }}
+{% for op in vars.operations -%}
+// {{ op.operationId }}: {{ op.method }} {{ op.path }}
+{% endfor -%}

--- a/internal/integration/testdata/openapi/petstore_multi.yaml
+++ b/internal/integration/testdata/openapi/petstore_multi.yaml
@@ -1,0 +1,24 @@
+openapi: 3.0.3
+info:
+  title: Pet Store
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      tags: [pets]
+      responses:
+        '200':
+          description: A list of pets
+    post:
+      operationId: createPet
+      responses:
+        '201':
+          description: Created
+  /pets/{id}:
+    get:
+      operationId: getPetById
+      tags: [pets]
+      responses:
+        '200':
+          description: A pet

--- a/internal/openapi/extract.go
+++ b/internal/openapi/extract.go
@@ -2,6 +2,7 @@ package openapi
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
@@ -23,7 +24,7 @@ const maxSchemaDepth = 20
 // with template- or config-declared vars these win (they are reserved for
 // OpenAPI input); an explicit --meta flag still overrides them, as --meta is
 // applied later at the highest precedence by the engine.
-var ReservedKeys = []string{"operation", "schemas", "info", "servers", "security"}
+var ReservedKeys = []string{"operation", "operations", "schemas", "info", "servers", "security"}
 
 // ExtractOperation parses an OpenAPI 3.x spec and extracts a single operation
 // (selected by operationId or "METHOD /path") into a map[string]any suitable
@@ -56,6 +57,94 @@ func ExtractOperation(spec []byte, selector string) (map[string]any, error) {
 	}
 	result["schemas"] = ex.collectComponentSchemas(&model.Model)
 	return result, nil
+}
+
+// ExtractOperations parses an OpenAPI 3.x spec and extracts many operations into
+// a map[string]any for the template `vars` namespace. An empty tag selects every
+// operation; otherwise only operations carrying that OpenAPI tag. Operations are
+// ordered by path then method for deterministic output, and each entry carries
+// its own effective security (op-level, else spec-level) — there is no top-level
+// `security` key in multi-op mode, since it differs per operation. vars.schemas
+// is the deduped union of components referenced by all selected operations.
+// See #327.
+func ExtractOperations(spec []byte, tag string) (map[string]any, error) {
+	doc, err := libopenapi.NewDocument(spec)
+	if err != nil {
+		return nil, app.Errorf("cannot parse OpenAPI spec: %w", err)
+	}
+	model, buildErr := doc.BuildV3Model()
+	if buildErr != nil {
+		return nil, app.Errorf("cannot build OpenAPI 3.x model: %w", buildErr)
+	}
+
+	var selected []opMatch
+	forEachOperation(&model.Model, func(method, path string, item *v3.PathItem, op *v3.Operation) {
+		if tag != "" && !slices.Contains(op.Tags, tag) {
+			return
+		}
+		selected = append(selected, opMatch{method, path, item, op})
+	})
+
+	if len(selected) == 0 {
+		return nil, app.Errorf(
+			"no operations selected%s; available operations:\n%s\navailable tags:\n%s",
+			tagSuffix(tag), listCandidates(&model.Model), listTags(&model.Model))
+	}
+
+	// Stable, deterministic order: path then method. Beats document order because
+	// this output drives generated code — a re-serialized spec must not churn diffs.
+	sort.Slice(selected, func(i, j int) bool {
+		if selected[i].path != selected[j].path {
+			return selected[i].path < selected[j].path
+		}
+		return selected[i].method < selected[j].method
+	})
+
+	// One shared extractor so e.collected accumulates across every operation:
+	// collectComponentSchemas then yields the deduped union in a single pass.
+	ex := &extractor{collected: map[string]bool{}}
+	operations := make([]any, 0, len(selected))
+	for _, m := range selected {
+		opMap := ex.operationToMap(m.method, m.path, m.item, m.op)
+		opMap["security"] = securityToList(m.op, &model.Model)
+		operations = append(operations, opMap)
+	}
+
+	result := map[string]any{
+		"operations": operations,
+		"info":       infoToMap(model.Model.Info),
+		"servers":    serversToList(model.Model.Servers),
+	}
+	result["schemas"] = ex.collectComponentSchemas(&model.Model)
+	return result, nil
+}
+
+// listTags renders the distinct OpenAPI tags in the spec, sorted, for error
+// messages. Operations with no tags contribute nothing.
+func listTags(model *v3.Document) string {
+	seen := map[string]bool{}
+	forEachOperation(model, func(_, _ string, _ *v3.PathItem, op *v3.Operation) {
+		for _, t := range op.Tags {
+			seen[t] = true
+		}
+	})
+	if len(seen) == 0 {
+		return "  (none)"
+	}
+	tags := make([]string, 0, len(seen))
+	for t := range seen {
+		tags = append(tags, "  "+t)
+	}
+	sort.Strings(tags)
+	return strings.Join(tags, "\n")
+}
+
+// tagSuffix annotates the no-match error with the filter that produced it.
+func tagSuffix(tag string) string {
+	if tag == "" {
+		return ""
+	}
+	return fmt.Sprintf(" for tag %q", tag)
 }
 
 // extractor carries walk state: `collected` is the transitive set of referenced

--- a/internal/openapi/extract_test.go
+++ b/internal/openapi/extract_test.go
@@ -485,3 +485,94 @@ func TestUT_NormalizeType(t *testing.T) {
 		})
 	}
 }
+
+// --- multi-operation extraction (#327) ---
+
+// opIDs pulls the operationId from each entry of a vars.operations list.
+func opIDs(t *testing.T, ops []any) []string {
+	t.Helper()
+	ids := make([]string, 0, len(ops))
+	for _, o := range ops {
+		ids = append(ids, asMap(t, o)["operationId"].(string))
+	}
+	return ids
+}
+
+func TestUT_ExtractOperations_All(t *testing.T) {
+	spec := loadFixture(t, "petstore_30.yaml")
+
+	res, err := ExtractOperations(spec, "")
+	require.NoError(t, err)
+
+	ops := asList(t, res["operations"])
+	// Sorted by path then method: /pets GET, /pets POST, /pets/{id} GET.
+	assert.Equal(t, []string{"listPets", "createPet", "getPetById"}, opIDs(t, ops))
+
+	// Multi-op drops the top-level security key (it lives per-op instead).
+	assert.NotContains(t, res, "security")
+	// info/servers remain top-level.
+	assert.Contains(t, res, "info")
+	assert.Contains(t, res, "servers")
+}
+
+func TestUT_ExtractOperations_ByTag(t *testing.T) {
+	spec := loadFixture(t, "petstore_30.yaml")
+
+	res, err := ExtractOperations(spec, "pets")
+	require.NoError(t, err)
+
+	ops := asList(t, res["operations"])
+	// Only listPets and getPetById carry tag "pets"; createPet is excluded.
+	assert.Equal(t, []string{"listPets", "getPetById"}, opIDs(t, ops))
+}
+
+func TestUT_ExtractOperations_SchemaUnion(t *testing.T) {
+	spec := loadFixture(t, "petstore_30.yaml")
+
+	res, err := ExtractOperations(spec, "")
+	require.NoError(t, err)
+
+	// Union of components referenced by all operations, deduped: Pet (+Owner
+	// +Address transitively) and Error (from default responses).
+	schemas := asMap(t, res["schemas"])
+	assert.Contains(t, schemas, "Pet")
+	assert.Contains(t, schemas, "Owner")
+	assert.Contains(t, schemas, "Address")
+	assert.Contains(t, schemas, "Error")
+}
+
+func TestUT_ExtractOperations_PerOpSecurity(t *testing.T) {
+	spec := loadFixture(t, "petstore_30.yaml")
+
+	res, err := ExtractOperations(spec, "pets")
+	require.NoError(t, err)
+	ops := asList(t, res["operations"])
+	require.Len(t, ops, 2)
+
+	// listPets has no op-level security -> spec-level apiKey applies.
+	listPets := asMap(t, ops[0])
+	sec := asList(t, listPets["security"])
+	require.Len(t, sec, 1)
+	assert.Contains(t, asMap(t, sec[0]), "apiKey")
+
+	// getPetById overrides with op-level bearerAuth.
+	getByID := asMap(t, ops[1])
+	sec = asList(t, getByID["security"])
+	require.Len(t, sec, 1)
+	assert.Contains(t, asMap(t, sec[0]), "bearerAuth")
+}
+
+func TestUT_ExtractOperations_NoMatch(t *testing.T) {
+	spec := loadFixture(t, "petstore_30.yaml")
+
+	_, err := ExtractOperations(spec, "nonexistent")
+	require.Error(t, err)
+	// Error lists available operations and tags so the user can pick.
+	assert.Contains(t, err.Error(), "getPetById")
+	assert.Contains(t, err.Error(), "pets")
+}
+
+func TestUT_ReservedKeys_IncludesOperations(t *testing.T) {
+	assert.Contains(t, ReservedKeys, "operations")
+	assert.Contains(t, ReservedKeys, "operation")
+}

--- a/internal/openapi/extract_test.go
+++ b/internal/openapi/extract_test.go
@@ -576,3 +576,27 @@ func TestUT_ReservedKeys_IncludesOperations(t *testing.T) {
 	assert.Contains(t, ReservedKeys, "operations")
 	assert.Contains(t, ReservedKeys, "operation")
 }
+
+func TestUT_ExtractOperations_ParseError(t *testing.T) {
+	_, err := ExtractOperations([]byte("just a string"), "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot parse OpenAPI spec")
+}
+
+func TestUT_ExtractOperations_BuildError(t *testing.T) {
+	// A Swagger 2.0 document parses as YAML but fails the v3 model build.
+	spec := []byte("swagger: \"2.0\"\ninfo: {title: t, version: v}\npaths: {}\n")
+	_, err := ExtractOperations(spec, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot build OpenAPI 3.x model")
+}
+
+func TestUT_ExtractOperations_NoOperations(t *testing.T) {
+	// Valid 3.x spec with zero operations: the empty-result error reports no tag
+	// suffix (tag == "") and "(none)" available tags.
+	spec := []byte("openapi: 3.0.3\ninfo: {title: t, version: v}\npaths: {}\n")
+	_, err := ExtractOperations(spec, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no operations selected")
+	assert.Contains(t, err.Error(), "(none)")
+}

--- a/internal/openapi/testdata/petstore_30.yaml
+++ b/internal/openapi/testdata/petstore_30.yaml
@@ -55,6 +55,9 @@ paths:
     get:
       operationId: getPetById
       summary: Get a pet by id
+      tags: [pets]
+      security:
+        - bearerAuth: []
       parameters:
         - name: id
           in: path

--- a/internal/types/flags/flags.go
+++ b/internal/types/flags/flags.go
@@ -21,4 +21,6 @@ const (
 	AddToLibFlag      = "add-to-lib"
 	OpenAPIFlag       = "openapi"
 	OperationFlag     = "operation"
+	OperationsFlag    = "operations"
+	OperationTagFlag  = "operation-tag"
 )


### PR DESCRIPTION
## Intent

Follow-up to #325 (single-operation OpenAPI input). Let a single `tag generate` run drive codegen from **many** operations of one OpenAPI 3.x spec — the "generate a handler/client/DTO for the whole API surface in one run" case.

The core design question was the generation model. Decided (with the operator): **Shape #1 — single-file loop**. The template loops over `vars.operations` and emits one file. No engine change; the file-per-operation emission primitive stays a future ticket.

## What changed

- **`openapi.ExtractOperations(spec, tag)`** — selects all operations (`tag == ""`) or those carrying a given OpenAPI tag; orders them **by path then method** (deterministic across spec re-serialization); each entry carries its **own effective security** (op-level, else spec-level); **`vars.schemas`** is the **deduped union** of components referenced by all selected operations (one shared extractor). Empty result hard-errors listing available operations **and** tags.
- **CLI** — `--operations` (all) and `--operation-tag <name>` (tag filter), both requiring `--openapi` and **mutually exclusive** with singular `--operation`. `--operations` is the whole-spec mode switch; `--operation-tag` narrows it (given together, the tag filters).
- **`operations`** added as the sixth reserved `vars` namespace.
- **Docs** — `.skills/SKILL.md` + `.skills/reference.md` extend the existing "OpenAPI input" section with the new flags, the `vars.operations` shape, and a worked loop example.
- **No top-level `vars.security` in multi-op mode** — auth differs per operation, so it travels inside each `vars.operations[]` entry.

## Design & review

Design and adversarial review ran in orchestration with **Codex** and **Antigravity**. Consensus: sort path-then-method, per-op security, reject blank `--operation-tag`. One Minor (the `--operations`+`--operation-tag` combo) was resolved as intended behavior + explicit docs. Merge verdict: approve.

## Tests

Unit: multi-op extraction, tag filter, schema union/dedup, per-op security, no-match error, flag mutual-exclusion. Integration: renders of all-operations and by-tag through the real engine. `make lint` → 0 issues; `go test ./...` → pass (36 packages).

## Untouched (per ticket)

Write-side `parser.go`/`Spec` and Action switch, and `internal/schema/*.json`.

Closes #327

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MAd6EJyGUVRLXGeZDTjquB