### PR TITLE
feat: tag template rename-var — atomic variable refactoring (#240)

### DIFF
--- a/.skills/SKILL.md
+++ b/.skills/SKILL.md
@@ -42,6 +42,10 @@ Generate code in existing project?
 Validate template before publishing?
   → tag template lint [path]
 
+Rename a template variable everywhere?
+  → tag template rename-var --dry-run <old> <new>   (preview first)
+  → tag template rename-var <old> <new>
+
 Test all boolean combinations?
   → tag test [template-dir]
 
@@ -257,6 +261,7 @@ my-project/
 | `tag template info <template>` | Show template details |
 | `tag template lint [path]` | Validate template (schema, syntax, vars) |
 | `tag template variables [path]` | Audit variable declarations vs usage (`--format json`, `--strict`) |
+| `tag template rename-var <old> <new> [path]` | Rename a variable across config and templates (`--dry-run`) |
 | `tag convert cookiecutter <src> -o <dst>` | Convert Cookiecutter template |
 | `tag dialect list` | List available type-mapping dialects |
 | `tag dialect show <name>` | Show type mappings for a dialect |

--- a/.skills/reference.md
+++ b/.skills/reference.md
@@ -547,6 +547,26 @@ Cross-references declared variables in `tag.template.json` with usage in templat
 
 Exit codes: `0` = no issues (or non-strict), `1` = issues found (`--strict`), `2` = usage error.
 
+### Variable Renaming
+
+```bash
+tag template rename-var --dry-run old_name new_name   # Preview every change
+tag template rename-var old_name new_name             # Apply in current directory
+tag template rename-var old_name new_name ./template  # Apply to a specific template
+```
+
+Flags must precede the positional arguments.
+
+Rewrites the declaration in `tag.template.json`, derived defaults, hook commands, bundle and generator `requires` entries, all `{{ vars.* }}` / `{% ... vars.* ... %}` expressions, and file/directory name placeholders (renamed on disk).
+
+Left untouched: plain text, comments (`{# ... #}`), `{% raw %}` blocks, string literals inside expressions, `.tagignore`d files, `_dialects/`, symlinks, and binary files. `_generators/` and `.tag/` are included.
+
+Planning is read-only, so `--dry-run` cannot write. A failed apply rolls back every file and path already changed.
+
+Only dot access is rewritten — `vars["old_name"]` is not recognised.
+
+Exit codes: `0` = applied or previewed, `1` = rename error (undeclared, name taken, path collision), `2` = usage error.
+
 ### Cache Management
 
 ```bash

--- a/docs/commands/template.md
+++ b/docs/commands/template.md
@@ -22,6 +22,7 @@ The `tag template` command group provides tools for managing templates, generato
 | `tag template info <template>` | Show template metadata and details |
 | `tag template lint [path]` | Validate template syntax, schema, and variable references |
 | `tag template variables [path]` | Audit variable declarations and usage across template files |
+| `tag template rename-var <old> <new> [path]` | Rename a variable across the config and all template files |
 | `tag template list` | List available generators and bundles |
 
 ---
@@ -276,6 +277,103 @@ Summary: 5 declared, 0 undeclared, 0 unused
 - Generator-level `tag.template.json` configs
 - Template comments (`{# ... #}`) are stripped before scanning
 - Binary files and `.tagignore` patterns are honored
+
+---
+
+### `tag template rename-var`
+
+Rename a template variable everywhere the template refers to it — the declaration, every expression, and file or directory name placeholders (which are renamed on disk).
+
+```bash
+tag template rename-var [flags] <old-name> <new-name> [path]
+```
+
+If `[path]` is omitted, the current directory is used. Flags must precede the positional arguments.
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--dry-run` | `false` | Preview every change without modifying anything |
+
+**What is rewritten:**
+
+| Location | Example |
+|----------|---------|
+| `tag.template.json` declaration | `"old_name": { ... }` → `"new_name": { ... }` |
+| Derived variable defaults | `"default": "{{ vars.old_name \| kebab }}"` |
+| Hook commands | `"post_scaffold": ["echo {{ vars.old_name }}"]` |
+| Bundle and generator `requires` | `"requires": ["old_name"]` |
+| Template bodies | `{{ vars.old_name }}`, `{{ vars.old_name \| f1 \| f2 }}` |
+| Frontmatter `to:` paths | `to: {{ vars.old_name \| snake }}/main.go` |
+| Conditionals and loops | `{% if vars.old_name %}`, `{% for x in vars.old_name %}` |
+| File and directory placeholders | `{{ vars.old_name \| snake }}/main.go` (renamed on disk) |
+
+**What is left alone:**
+
+- Plain text that merely mentions the name — only Gonja expressions are rewritten
+- Comments (`{# ... #}`)
+- `{% raw %}` blocks, whose contents are emitted literally
+- String literals inside an expression, such as `{{ "vars.old_name" }}`
+- Files excluded by `.tagignore`, the `_dialects/` tree, symlinks, and binary files
+
+`_generators/` and `.tag/` **are** included, because generators inherit root-level variables and bundle manifests reference them by name.
+
+**Exit codes:**
+
+| Code | Meaning |
+|------|---------|
+| `0` | Rename applied (or previewed with `--dry-run`) |
+| `1` | Rename failed — the variable is not declared, the new name is taken or invalid, or a renamed path would collide |
+| `2` | Usage error (wrong number of arguments) |
+
+**Examples:**
+
+```bash
+# Preview first — always a good idea
+tag template rename-var --dry-run project_name service_name
+
+# Apply
+tag template rename-var project_name service_name
+
+# Rename in a specific template
+tag template rename-var old_flag new_flag ./my-template
+```
+
+**Example dry-run output:**
+
+```
+Renaming "project_name" → "service_name"
+
+Changes:
+
+  README.md:1
+    - # {{ vars.project_name }}
+    + # {{ vars.service_name }}
+
+  go.mod:1
+    - module {{ vars.project_name | kebab }}
+    + module {{ vars.service_name | kebab }}
+
+  tag.template.json:4
+    -     "project_name": { "type": "string", "prompt": "Project name" },
+    +     "service_name": { "type": "string", "prompt": "Project name" },
+
+  {{ vars.project_name | snake }}/main.go (path placeholder):
+    - {{ vars.project_name | snake }}/main.go
+    + {{ vars.service_name | snake }}/main.go
+
+  4 files, 5 replacements total
+```
+
+**Safety:**
+
+- Planning is read-only, so `--dry-run` cannot modify the template.
+- An apply that fails partway restores every file and path it had already changed, so a half-renamed template never survives the command.
+- Run `tag template lint` afterwards to confirm nothing was missed.
+
+**Limitations:**
+
+- Only dot access (`vars.old_name`) is rewritten. Subscript access (`vars["old_name"]`) is not recognised — the same limitation `tag template lint` and `tag template variables` have.
+- A `{% raw %}` block containing a literal `{{ vars.old_name }}` is correctly left alone, but `tag template lint` does not model raw blocks and will report it as an undefined variable afterwards.
 
 ---
 

--- a/docs/templates/authoring.md
+++ b/docs/templates/authoring.md
@@ -464,6 +464,22 @@ This checks `tag.template.json` against the JSON Schema, parses all template fil
 
 See [tag template lint](../commands/template.md#tag-template-lint) for full details.
 
+## Renaming a Variable
+
+Renaming a variable by hand means touching the declaration, every expression, and any path placeholder — missing one leaves a silently empty value at render time. Let TAG do it:
+
+```bash
+# Preview every change first
+tag template rename-var --dry-run project_name service_name
+
+# Apply
+tag template rename-var project_name service_name
+```
+
+This rewrites the declaration, derived defaults, hook commands, `requires` entries, all expressions, and file or directory name placeholders. Prose, comments and `{% raw %}` blocks are left alone.
+
+See [tag template rename-var](../commands/template.md#tag-template-rename-var) for full details.
+
 ## Testing Your Template
 
 ```bash

--- a/internal/commands/template.go
+++ b/internal/commands/template.go
@@ -13,7 +13,7 @@ import (
 func TemplateCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
 		Name:  "template",
-		Usage: "Template authoring commands (init, new, info, list, lint, test, variables, graph)",
+		Usage: "Template authoring commands (init, new, info, list, lint, test, variables, rename-var, graph)",
 		Subcommands: []*cli.Command{
 			templateInitCommand(),
 			templateNewCommand(cfg),
@@ -22,6 +22,7 @@ func TemplateCommand(cfg *config.Config) *cli.Command {
 			templateLintCommand(),
 			templateTestCommand(),
 			templateVariablesCommand(),
+			templateRenameVarCommand(),
 			templateGraphCommand(),
 		},
 	}

--- a/internal/commands/template_cmd_test.go
+++ b/internal/commands/template_cmd_test.go
@@ -17,7 +17,7 @@ func TestUT_TemplateCommand_SubcommandCount(t *testing.T) {
 
 	require.NotNil(t, cmd)
 	assert.Equal(t, "template", cmd.Name)
-	assert.Len(t, cmd.Subcommands, 8)
+	assert.Len(t, cmd.Subcommands, 9)
 }
 
 func TestUT_TemplateCommand_NewHasSubcommands(t *testing.T) {

--- a/internal/commands/template_renamevar.go
+++ b/internal/commands/template_renamevar.go
@@ -1,0 +1,79 @@
+package commands
+
+import (
+	"io"
+	"os"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/kaikenlabs/tag/internal/types/flags"
+	"github.com/kaikenlabs/tag/internal/vars"
+	"github.com/kaikenlabs/tag/pkg/app"
+)
+
+func templateRenameVarCommand() *cli.Command {
+	return &cli.Command{
+		Name:      "rename-var",
+		Usage:     "Rename a template variable across the config and all template files",
+		ArgsUsage: "[--dry-run] <old-name> <new-name> [path]",
+		Description: `Renames a variable everywhere a TAG template refers to it:
+the declaration in tag.template.json, derived variable defaults, hook commands,
+bundle "requires" entries, template bodies, conditionals and loops, and file or
+directory name placeholders (which are renamed on disk).
+
+Only Gonja expressions are rewritten. Prose that merely mentions the variable
+name is left alone, as are comments, {% raw %} blocks and string literals.
+
+Files excluded by .tagignore, the _dialects/ tree and binary files are skipped.
+Generator and bundle definitions under _generators/ and .tag/ are included,
+because they reference root-level variables.
+
+If [path] is omitted, the current directory is used.
+
+Flags must precede the positional arguments.
+
+Examples:
+  tag template rename-var --dry-run project_name service_name
+  tag template rename-var project_name service_name
+  tag template rename-var old_flag new_flag ./my-template`,
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:  flags.DryRunFlag,
+				Usage: "Preview all changes without modifying anything",
+			},
+		},
+		Action: func(c *cli.Context) error {
+			return renameVarAction(c, os.Stdout)
+		},
+	}
+}
+
+func renameVarAction(c *cli.Context, out io.Writer) error {
+	if c.NArg() < 2 || c.NArg() > 3 {
+		return app.UsageErrorf(
+			"expected <old-name> <new-name> [path], got %d argument(s)", c.NArg())
+	}
+
+	oldName := c.Args().Get(0)
+	newName := c.Args().Get(1)
+	root := "."
+	if c.NArg() == 3 {
+		root = c.Args().Get(2)
+	}
+
+	plan, err := vars.PlanRename(root, oldName, newName)
+	if err != nil {
+		return app.Errorf("cannot rename variable: %w", err)
+	}
+
+	dryRun := c.Bool(flags.DryRunFlag)
+	if !dryRun {
+		if applyErr := plan.Apply(); applyErr != nil {
+			return app.Errorf("rename failed (template left unchanged): %w", applyErr)
+		}
+	}
+
+	vars.WriteRenamePlan(out, plan, dryRun)
+
+	return nil
+}

--- a/internal/commands/template_renamevar_test.go
+++ b/internal/commands/template_renamevar_test.go
@@ -1,0 +1,131 @@
+package commands
+
+import (
+	"flag"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+
+	"github.com/kaikenlabs/tag/pkg/app"
+)
+
+func newRenameVarCLIContext(t *testing.T, args []string, dryRun bool) *cli.Context {
+	t.Helper()
+	cliApp := &cli.App{
+		Writer: io.Discard,
+		Flags: []cli.Flag{
+			&cli.BoolFlag{Name: "dry-run"},
+		},
+	}
+
+	set := flag.NewFlagSet("test", flag.ContinueOnError)
+	for _, f := range cliApp.Flags {
+		require.NoError(t, f.Apply(set))
+	}
+	if dryRun {
+		require.NoError(t, set.Set("dry-run", "true"))
+	}
+	require.NoError(t, set.Parse(args))
+
+	return cli.NewContext(cliApp, set, nil)
+}
+
+// renameVarTemplate writes a minimal template and returns its root.
+func renameVarTemplate(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "tag.template.json"),
+		[]byte(`{"vars": {"old": {"type": "string"}}}`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "README.md"),
+		[]byte("# {{ vars.old }}\n"), 0o644))
+	return root
+}
+
+func TestUT_TemplateRenameVar_RegisteredAsSubcommand(t *testing.T) {
+	t.Parallel()
+
+	var names []string
+	for _, sub := range TemplateCommand(nil).Subcommands {
+		names = append(names, sub.Name)
+	}
+	assert.Contains(t, names, "rename-var")
+}
+
+func TestUT_TemplateRenameVar_RenamesTemplate(t *testing.T) {
+	t.Parallel()
+
+	root := renameVarTemplate(t)
+	cmd := templateRenameVarCommand()
+	ctx := newRenameVarCLIContext(t, []string{"old", "renamed", root}, false)
+
+	require.NoError(t, cmd.Action(ctx))
+
+	readme, err := os.ReadFile(filepath.Join(root, "README.md"))
+	require.NoError(t, err)
+	assert.Equal(t, "# {{ vars.renamed }}\n", string(readme))
+
+	config, err := os.ReadFile(filepath.Join(root, "tag.template.json"))
+	require.NoError(t, err)
+	assert.Contains(t, string(config), `"renamed"`)
+}
+
+func TestUT_TemplateRenameVar_DryRunDoesNotWrite(t *testing.T) {
+	t.Parallel()
+
+	root := renameVarTemplate(t)
+	cmd := templateRenameVarCommand()
+	ctx := newRenameVarCLIContext(t, []string{"old", "renamed", root}, true)
+
+	require.NoError(t, cmd.Action(ctx))
+
+	readme, err := os.ReadFile(filepath.Join(root, "README.md"))
+	require.NoError(t, err)
+	assert.Equal(t, "# {{ vars.old }}\n", string(readme))
+}
+
+func TestUT_TemplateRenameVar_ArgumentErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{name: "no arguments", args: nil, wantErr: "expected"},
+		{name: "one argument", args: []string{"old"}, wantErr: "expected"},
+		{name: "too many arguments", args: []string{"a", "b", "c", "d"}, wantErr: "expected"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cmd := templateRenameVarCommand()
+			ctx := newRenameVarCLIContext(t, tt.args, false)
+
+			err := cmd.Action(ctx)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+
+			var cmdErr *app.CommandError
+			require.ErrorAs(t, err, &cmdErr)
+			assert.Equal(t, app.ExitUsage, cmdErr.ExitCode())
+		})
+	}
+}
+
+func TestUT_TemplateRenameVar_PlanningFailureIsReported(t *testing.T) {
+	t.Parallel()
+
+	root := renameVarTemplate(t)
+	cmd := templateRenameVarCommand()
+	ctx := newRenameVarCLIContext(t, []string{"missing", "renamed", root}, false)
+
+	err := cmd.Action(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not declared")
+}

--- a/internal/integration/renamevar_test.go
+++ b/internal/integration/renamevar_test.go
@@ -1,0 +1,187 @@
+package integration
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kaikenlabs/tag/internal/lint"
+	"github.com/kaikenlabs/tag/internal/vars"
+)
+
+// renameVarFixture is a template that exercises every location the ticket lists:
+// declaration, derived default, hook command, bundle requires, body references,
+// frontmatter, conditionals, loops and path placeholders.
+var renameVarFixture = map[string]string{
+	"tag.template.json": `{
+  "name": "demo",
+  "vars": {
+    "project_name": { "type": "string", "prompt": "Project name" },
+    "features": { "type": "string", "default": "" },
+    "module": { "default": "github.com/acme/{{ vars.project_name | kebab }}" }
+  },
+  "hooks": {
+    "post_scaffold": ["echo built {{ vars.project_name }}"]
+  }
+}`,
+	"README.md": `# {{ vars.project_name }}
+
+The project_name below is prose and must survive untouched.
+
+{% if vars.project_name %}Configured.{% endif %}
+{% for f in vars.features %}- {{ f }}
+{% endfor %}
+`,
+	"go.mod": "module {{ vars.module }}\n",
+	"{{ vars.project_name | snake }}/main.go": `---
+to: {{ vars.project_name | snake }}/main.go
+---
+package main
+
+// {{ vars.project_name }}
+func main() {}
+`,
+	"_generators/api/tag.template.json": `{
+  "vars": { "name": { "type": "string" } },
+  "requires": ["project_name"]
+}`,
+	"_generators/api/templates/handler.go.t": "// {{ vars.name }} for {{ vars.project_name }}\n",
+	".tagignore":                             "vendor/\n",
+	"vendor/third_party.go":                  "// {{ vars.project_name }} must not be touched\n",
+}
+
+func writeFixture(t *testing.T, root string, files map[string]string) {
+	t.Helper()
+	for rel, content := range files {
+		full := filepath.Join(root, filepath.FromSlash(rel))
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+		require.NoError(t, os.WriteFile(full, []byte(content), 0o644))
+	}
+}
+
+func readFile(t *testing.T, parts ...string) string {
+	t.Helper()
+	content, err := os.ReadFile(filepath.Join(parts...))
+	require.NoError(t, err)
+	return string(content)
+}
+
+func TestIT_TemplateRenameVar_LeavesTemplateLintClean(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeFixture(t, root, renameVarFixture)
+
+	// The fixture must start clean, otherwise the post-rename assertion is vacuous.
+	before, err := vars.Analyze(root)
+	require.NoError(t, err)
+	require.False(t, before.HasIssues(), "fixture should start with no variable issues")
+
+	plan, err := vars.PlanRename(root, "project_name", "service_name")
+	require.NoError(t, err)
+	require.NoError(t, plan.Apply())
+
+	// An unchanged tree also lints clean, so prove the rename actually happened
+	// before drawing any conclusion from the linters below.
+	require.Contains(t, readFile(t, root, "README.md"), "{{ vars.service_name }}")
+	require.NotContains(t, readFile(t, root, "tag.template.json"), "project_name")
+
+	// Every reference moved: nothing undeclared, nothing unused.
+	after, err := vars.Analyze(root)
+	require.NoError(t, err)
+	assert.False(t, after.HasIssues(),
+		"a complete rename must leave no undeclared or unused variables")
+
+	linter, err := lint.NewLinter(root)
+	require.NoError(t, err)
+	result, err := linter.Run()
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.ErrorCount(), "issues: %+v", result.Issues)
+}
+
+func TestIT_TemplateRenameVar_RewritesEveryLocation(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeFixture(t, root, renameVarFixture)
+
+	plan, err := vars.PlanRename(root, "project_name", "service_name")
+	require.NoError(t, err)
+	require.NoError(t, plan.Apply())
+
+	config := readFile(t, root, "tag.template.json")
+	assert.Contains(t, config, `"service_name": { "type": "string", "prompt": "Project name" }`)
+	assert.Contains(t, config, `github.com/acme/{{ vars.service_name | kebab }}`)
+	assert.Contains(t, config, `echo built {{ vars.service_name }}`)
+	assert.NotContains(t, config, "vars.project_name")
+
+	readme := readFile(t, root, "README.md")
+	assert.Contains(t, readme, "# {{ vars.service_name }}")
+	assert.Contains(t, readme, "{% if vars.service_name %}")
+	assert.Contains(t, readme, "The project_name below is prose and must survive untouched.",
+		"prose must not be rewritten")
+
+	generator := readFile(t, root, "_generators", "api", "tag.template.json")
+	assert.Contains(t, generator, `"requires": ["service_name"]`)
+	assert.Contains(t, readFile(t, root, "_generators", "api", "templates", "handler.go.t"),
+		"// {{ vars.name }} for {{ vars.service_name }}")
+
+	assert.Equal(t, "// {{ vars.project_name }} must not be touched\n",
+		readFile(t, root, "vendor", "third_party.go"), ".tagignore must be honoured")
+
+	renamedDir := filepath.Join(root, "{{ vars.service_name | snake }}")
+	assert.DirExists(t, renamedDir)
+	assert.NoDirExists(t, filepath.Join(root, "{{ vars.project_name | snake }}"))
+	main := readFile(t, renamedDir, "main.go")
+	assert.Contains(t, main, "to: {{ vars.service_name | snake }}/main.go")
+	assert.Contains(t, main, "// {{ vars.service_name }}")
+}
+
+// Raw blocks and comments live in their own fixture because `tag template lint`
+// does not model either construct: its variable scan treats their contents as
+// real references, so a template that keeps a literal {{ vars.old }} inside
+// {% raw %} lints as an undefined variable after a rename. Leaving the literal
+// alone is still correct — rewriting it would change the generated output.
+func TestIT_TemplateRenameVar_LeavesRawBlocksAndCommentsLiteral(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeFixture(t, root, map[string]string{
+		"tag.template.json": `{"vars": {"project_name": {"type": "string"}}}`,
+		"doc.md": `# {{ vars.project_name }}
+{% raw %}Literal {{ vars.project_name }} stays literal.{% endraw %}
+{# {{ vars.project_name }} in a comment #}
+`,
+	})
+
+	plan, err := vars.PlanRename(root, "project_name", "service_name")
+	require.NoError(t, err)
+	require.NoError(t, plan.Apply())
+
+	doc := readFile(t, root, "doc.md")
+	assert.Contains(t, doc, "# {{ vars.service_name }}")
+	assert.Contains(t, doc, "{% raw %}Literal {{ vars.project_name }} stays literal.{% endraw %}")
+	assert.Contains(t, doc, "{# {{ vars.project_name }} in a comment #}")
+}
+
+func TestIT_TemplateRenameVar_DryRunIsAPreview(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeFixture(t, root, renameVarFixture)
+
+	plan, err := vars.PlanRename(root, "project_name", "service_name")
+	require.NoError(t, err)
+
+	assert.Positive(t, plan.FileCount())
+	assert.Positive(t, plan.ReplacementCount())
+
+	// Planning alone must be inert: the tree is byte-identical to the fixture.
+	for rel, want := range renameVarFixture {
+		assert.Equal(t, want, readFile(t, root, filepath.FromSlash(rel)),
+			"planning must not modify %s", rel)
+	}
+}

--- a/internal/vars/jsonedit.go
+++ b/internal/vars/jsonedit.go
@@ -1,0 +1,155 @@
+package vars
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"slices"
+)
+
+// JSON member names that carry variable names as data rather than as template
+// expressions, and so need renaming alongside the {{ vars.x }} references.
+const (
+	varsMember     = "vars"
+	requiresMember = "requires"
+)
+
+// span is a byte range within the original document.
+type span struct {
+	start, end int
+}
+
+// renameJSONDeclarations renames a variable where a TAG config file records it
+// as data rather than as a template expression: the `vars` object key, and any
+// entry of the top-level `requires` array. It returns the rewritten document and
+// the number of replacements.
+//
+// The edit is a byte-level splice on the original document, which preserves key
+// order, indentation and comments-by-formatting that a decode/encode round trip
+// through map[string]any would destroy. Spans are applied back-to-front so
+// earlier offsets stay valid.
+func renameJSONDeclarations(data []byte, oldName, newName string) ([]byte, int, error) {
+	spans, err := findDeclarationSpans(data, oldName)
+	if err != nil {
+		return nil, 0, err
+	}
+	if len(spans) == 0 {
+		return data, 0, nil
+	}
+
+	quoted, err := json.Marshal(newName)
+	if err != nil {
+		return nil, 0, fmt.Errorf("encode variable name: %w", err)
+	}
+
+	// Apply back-to-front so each splice leaves earlier offsets valid.
+	slices.SortFunc(spans, func(a, b span) int { return b.start - a.start })
+
+	out := slices.Clone(data)
+	for _, s := range spans {
+		out = append(out[:s.start], append(slices.Clone(quoted), out[s.end:]...)...)
+	}
+
+	return out, len(spans), nil
+}
+
+// findDeclarationSpans locates the byte ranges of every JSON string token that
+// declares oldName: the key `vars.<oldName>` and elements of the top-level
+// `requires` array equal to oldName.
+func findDeclarationSpans(data []byte, oldName string) ([]span, error) {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	var spans []span
+
+	err := walkJSONStrings(dec, nil, func(path []string, value string, isKey bool, end int) {
+		if value != oldName {
+			return
+		}
+		match := (isKey && len(path) == 1 && path[0] == varsMember) ||
+			(!isKey && len(path) == 1 && path[0] == requiresMember)
+		if !match {
+			return
+		}
+		if start, ok := stringTokenStart(data, end); ok {
+			spans = append(spans, span{start: start, end: end})
+		}
+	})
+	if err != nil {
+		return nil, fmt.Errorf("parse json: %w", err)
+	}
+
+	return spans, nil
+}
+
+// walkJSONStrings performs a recursive descent over the decoder's token stream,
+// invoking fn for every string token with the path of enclosing object keys.
+// Array elements inherit their array's path, so an element of the top-level
+// "requires" array is reported with path ["requires"]. end is the input offset
+// just past the token's closing quote.
+func walkJSONStrings(
+	dec *json.Decoder,
+	path []string,
+	fn func(path []string, value string, isKey bool, end int),
+) error {
+	tok, err := dec.Token()
+	if err != nil {
+		return err
+	}
+
+	delim, ok := tok.(json.Delim)
+	if !ok {
+		if s, isString := tok.(string); isString {
+			fn(path, s, false, int(dec.InputOffset()))
+		}
+		return nil
+	}
+
+	switch delim {
+	case '{':
+		for dec.More() {
+			keyTok, keyErr := dec.Token()
+			if keyErr != nil {
+				return keyErr
+			}
+			key, _ := keyTok.(string)
+			fn(path, key, true, int(dec.InputOffset()))
+
+			if valErr := walkJSONStrings(dec, append(slices.Clone(path), key), fn); valErr != nil {
+				return valErr
+			}
+		}
+	case '[':
+		for dec.More() {
+			if elemErr := walkJSONStrings(dec, path, fn); elemErr != nil {
+				return elemErr
+			}
+		}
+	}
+
+	// Consume the matching closing delimiter.
+	_, err = dec.Token()
+	return err
+}
+
+// stringTokenStart walks backwards from the offset just past a JSON string
+// token to the offset of its opening quote. Scanning for the quote rather than
+// subtracting the decoded length is what makes escaped names splice correctly:
+// a key written with a \u escape is longer on the wire than its decoded value,
+// so offset arithmetic would cut into the middle of it.
+func stringTokenStart(data []byte, end int) (int, bool) {
+	if end <= 0 || end > len(data) || data[end-1] != '"' {
+		return 0, false
+	}
+	for i := end - 2; i >= 0; i-- {
+		if data[i] != '"' {
+			continue
+		}
+		backslashes := 0
+		for j := i - 1; j >= 0 && data[j] == '\\'; j-- {
+			backslashes++
+		}
+		if backslashes%2 == 0 {
+			return i, true
+		}
+	}
+	return 0, false
+}

--- a/internal/vars/jsonedit_test.go
+++ b/internal/vars/jsonedit_test.go
@@ -1,0 +1,123 @@
+package vars
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUT_RenameJSONDeclarations_VarsKey(t *testing.T) {
+	t.Parallel()
+
+	src := `{
+  "name": "demo",
+  "vars": {
+    "old": { "type": "string" },
+    "keep": 1
+  }
+}`
+	want := `{
+  "name": "demo",
+  "vars": {
+    "new": { "type": "string" },
+    "keep": 1
+  }
+}`
+
+	got, n, err := renameJSONDeclarations([]byte(src), "old", "new")
+	require.NoError(t, err)
+	assert.Equal(t, 1, n)
+	assert.Equal(t, want, string(got), "key order and formatting must be preserved")
+}
+
+func TestUT_RenameJSONDeclarations_RequiresEntries(t *testing.T) {
+	t.Parallel()
+
+	src := `{"requires": ["old", "other"], "vars": {"old": 1}}`
+	want := `{"requires": ["new", "other"], "vars": {"new": 1}}`
+
+	got, n, err := renameJSONDeclarations([]byte(src), "old", "new")
+	require.NoError(t, err)
+	assert.Equal(t, 2, n)
+	assert.Equal(t, want, string(got))
+}
+
+func TestUT_RenameJSONDeclarations_EscapedKeySurvives(t *testing.T) {
+	t.Parallel()
+
+	// A \uXXXX-escaped key decodes to "old" and must be replaced as a whole
+	// token — naive offset arithmetic would splice into the middle of it.
+	src := "{\"vars\": {\"\\u006fld\": {\"type\": \"string\"}}}"
+	want := `{"vars": {"new": {"type": "string"}}}`
+
+	got, n, err := renameJSONDeclarations([]byte(src), "old", "new")
+	require.NoError(t, err)
+	assert.Equal(t, 1, n)
+	assert.Equal(t, want, string(got))
+}
+
+func TestUT_RenameJSONDeclarations_LeavesUnrelatedStringsAlone(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{
+			name: "value that happens to equal the name",
+			src:  `{"vars": {"other": "old"}}`,
+		},
+		{
+			name: "prompt text containing the name",
+			src:  `{"vars": {"other": {"prompt": "old"}}}`,
+		},
+		{
+			name: "key of the same name nested deeper than vars",
+			src:  `{"vars": {"other": {"options": {"old": 1}}}}`,
+		},
+		{
+			name: "key of the same name outside vars",
+			src:  `{"hooks": {"old": 1}}`,
+		},
+		{
+			name: "nested config that merely contains a vars object",
+			src:  `{"generators": {"api": {"vars": {"old": 1}}}}`,
+		},
+		{
+			name: "requires nested deeper than the top level",
+			src:  `{"vars": {"other": {"requires": ["old"]}}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, n, err := renameJSONDeclarations([]byte(tt.src), "old", "new")
+			require.NoError(t, err)
+			assert.Equal(t, 0, n)
+			assert.Equal(t, tt.src, string(got))
+		})
+	}
+}
+
+func TestUT_RenameJSONDeclarations_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := renameJSONDeclarations([]byte(`{"vars": `), "old", "new")
+	require.Error(t, err)
+}
+
+func TestUT_RenameJSONDeclarations_NewNameIsEscapedSafely(t *testing.T) {
+	t.Parallel()
+
+	// The public command rejects names that are not identifiers, but the
+	// splicer itself must still emit a well-formed JSON string for any input —
+	// so feed it a name that genuinely needs escaping and confirm the quote and
+	// backslash survive as JSON escapes rather than corrupting the document.
+	src := `{"vars": {"old": 1}}`
+	got, n, err := renameJSONDeclarations([]byte(src), "old", `a"b\c`)
+	require.NoError(t, err)
+	assert.Equal(t, 1, n)
+	assert.JSONEq(t, `{"vars": {"a\"b\\c": 1}}`, string(got))
+}

--- a/internal/vars/rename.go
+++ b/internal/vars/rename.go
@@ -1,0 +1,546 @@
+package vars
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+
+	"github.com/go-git/go-git/v5/plumbing/format/gitignore"
+
+	"github.com/kaikenlabs/tag/internal/fileutil"
+	"github.com/kaikenlabs/tag/internal/types"
+)
+
+// varNamePattern is the set of names Gonja can reach through dot access, and so
+// the set this command is able to rename.
+var varNamePattern = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
+
+// Change is a single line-level edit within a file.
+type Change struct {
+	// Line is the 1-based line number, or 0 for a whole-path rename.
+	Line   int    `json:"line"`
+	Before string `json:"before"`
+	After  string `json:"after"`
+}
+
+// FileChange collects every edit for one file.
+type FileChange struct {
+	// Path is the file's location relative to the template root.
+	Path string `json:"path"`
+	// NewPath is set when the file or one of its parent directories carries a
+	// {{ vars.x }} placeholder and therefore moves on disk.
+	NewPath string `json:"new_path,omitempty"`
+	// Changes lists the content edits; empty for a pure path rename.
+	Changes []Change `json:"changes"`
+	// Replacements counts individual substitutions, which exceeds len(Changes)
+	// when a single line mentions the variable more than once.
+	Replacements int `json:"replacements"`
+
+	content  []byte
+	original []byte
+}
+
+// RenamePlan is the complete set of edits for one variable rename. Planning is
+// read-only, so a plan can be printed for --dry-run and discarded.
+type RenamePlan struct {
+	Root    string       `json:"root"`
+	OldName string       `json:"old_name"`
+	NewName string       `json:"new_name"`
+	Files   []FileChange `json:"files"`
+}
+
+// FileCount returns the number of files the plan touches.
+func (p *RenamePlan) FileCount() int {
+	return len(p.Files)
+}
+
+// ReplacementCount returns the total number of individual replacements, counting
+// a moved path as one.
+func (p *RenamePlan) ReplacementCount() int {
+	total := 0
+	for _, f := range p.Files {
+		total += f.Replacements
+		if f.NewPath != "" {
+			total++
+		}
+	}
+	return total
+}
+
+// PathRenameCount returns the number of files whose on-disk path changes.
+func (p *RenamePlan) PathRenameCount() int {
+	n := 0
+	for _, f := range p.Files {
+		if f.NewPath != "" {
+			n++
+		}
+	}
+	return n
+}
+
+// PlanRename computes every edit needed to rename oldName to newName across a
+// TAG template, without touching the filesystem.
+//
+// The rename covers the whole template tree, including _generators/ (generators
+// inherit root variables) and .tag/ (its bundle manifests reference scaffold
+// variables by name). Files excluded from scaffold output by .tagignore are left
+// alone, as are _dialects/, .git/ and binary files.
+func PlanRename(root, oldName, newName string) (*RenamePlan, error) {
+	absRoot, err := validateRenameRoot(root, oldName, newName)
+	if err != nil {
+		return nil, err
+	}
+
+	plan := &RenamePlan{Root: absRoot, OldName: oldName, NewName: newName}
+
+	ignoreMatcher, err := loadIgnorePatterns(absRoot)
+	if err != nil {
+		return nil, fmt.Errorf("load ignore patterns: %w", err)
+	}
+
+	walkErr := filepath.WalkDir(absRoot, func(srcPath string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		relPath, relErr := filepath.Rel(absRoot, srcPath)
+		if relErr != nil {
+			return fmt.Errorf("relative path: %w", relErr)
+		}
+		if skip, skipDir := shouldSkipRenameEntry(relPath, d, ignoreMatcher); skip {
+			if skipDir {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if d.IsDir() {
+			return nil
+		}
+		change, planErr := planFile(absRoot, relPath, oldName, newName)
+		if planErr != nil {
+			return planErr
+		}
+		if change != nil {
+			plan.Files = append(plan.Files, *change)
+		}
+		return nil
+	})
+	if walkErr != nil {
+		return nil, walkErr
+	}
+
+	slices.SortFunc(plan.Files, func(a, b FileChange) int {
+		return strings.Compare(a.Path, b.Path)
+	})
+
+	if err := checkPathCollisions(absRoot, plan); err != nil {
+		return nil, err
+	}
+
+	return plan, nil
+}
+
+// validateRenameRoot checks the arguments and the template root, returning the
+// absolute root path.
+func validateRenameRoot(root, oldName, newName string) (string, error) {
+	if oldName == newName {
+		return "", fmt.Errorf("old and new names are identical: %q", oldName)
+	}
+	for _, name := range []string{oldName, newName} {
+		if !varNamePattern.MatchString(name) {
+			return "", fmt.Errorf("%q is not a valid variable name "+
+				"(letters, digits and underscores, not starting with a digit)", name)
+		}
+	}
+
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return "", fmt.Errorf("resolve path: %w", err)
+	}
+	info, err := os.Stat(absRoot)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return "", fmt.Errorf("path does not exist: %s", root)
+		}
+		return "", fmt.Errorf("stat path: %w", err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("path is not a directory: %s", root)
+	}
+
+	config, err := loadConfig(absRoot)
+	if err != nil {
+		return "", err
+	}
+	if _, ok := config.Vars[oldName]; !ok {
+		return "", fmt.Errorf("variable %q is not declared in %s",
+			oldName, types.TemplateConfigFile)
+	}
+	if _, ok := config.Vars[newName]; ok {
+		return "", fmt.Errorf("variable %q is already declared in %s",
+			newName, types.TemplateConfigFile)
+	}
+
+	return absRoot, nil
+}
+
+// shouldSkipRenameEntry decides whether an entry is out of scope for the rename
+// and whether its whole subtree can be pruned.
+func shouldSkipRenameEntry(
+	relPath string, d fs.DirEntry, ignoreMatcher gitignore.Matcher,
+) (skip, skipDir bool) {
+	if relPath == "." {
+		return true, false
+	}
+	// Rewriting through a symlink would edit a file outside the template.
+	if d.Type()&os.ModeSymlink != 0 {
+		return true, false
+	}
+
+	name := d.Name()
+	if name == types.TagIgnoreFile || name == types.CacheMetaFile {
+		return true, false
+	}
+	// Dialects define type mappings, not variable references; .git is not
+	// template content at all.
+	if d.IsDir() && (name == types.DialectsDir || name == ".git") {
+		return true, true
+	}
+
+	if ignoreMatcher != nil {
+		components := strings.Split(relPath, string(filepath.Separator))
+		if ignoreMatcher.Match(components, d.IsDir()) {
+			return true, d.IsDir()
+		}
+	}
+
+	return false, false
+}
+
+// planFile computes the edits for a single file, returning nil when nothing
+// changes.
+func planFile(absRoot, relPath, oldName, newName string) (*FileChange, error) {
+	newRelPath, _ := renameInExpressions(relPath, oldName, newName)
+
+	// #nosec G304 -- relPath comes from walking absRoot, the template the user named
+	original, err := os.ReadFile(filepath.Join(absRoot, relPath))
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", relPath, err)
+	}
+
+	change := FileChange{Path: relPath, original: original}
+	if newRelPath != relPath {
+		change.NewPath = newRelPath
+	}
+
+	if fileutil.IsTextContent(original) {
+		updated, changes, count, cErr := planContent(relPath, original, oldName, newName)
+		if cErr != nil {
+			return nil, cErr
+		}
+		if len(changes) > 0 {
+			change.Changes = changes
+			change.Replacements = count
+			change.content = updated
+		}
+	}
+
+	if change.NewPath == "" && len(change.Changes) == 0 {
+		return nil, nil //nolint:nilnil // nil change means "file unaffected"
+	}
+	return &change, nil
+}
+
+// planContent rewrites one file's bytes and derives the per-line diff. Because
+// no rewrite step adds or removes newlines, old and new content always have the
+// same number of lines and can be compared index-wise.
+func planContent(
+	relPath string, original []byte, oldName, newName string,
+) (updated []byte, changes []Change, count int, err error) {
+	updated = original
+
+	// Config and bundle manifests record variable names as data (a `vars` key,
+	// a `requires` entry) as well as inside expressions.
+	if isDeclarationFile(relPath) {
+		spliced, n, splErr := renameDeclarations(relPath, updated, oldName, newName)
+		if splErr != nil {
+			return nil, nil, 0, splErr
+		}
+		updated, count = spliced, n
+	}
+
+	rewritten, exprCount := renameInExpressions(string(updated), oldName, newName)
+	updated = []byte(rewritten)
+	count += exprCount
+
+	return updated, diffLines(string(original), string(updated)), count, nil
+}
+
+// renameDeclarations rewrites the JSON declarations in one config or bundle
+// manifest, refusing to proceed when the file already declares the new name.
+// Splicing over an existing declaration would produce a duplicate JSON key, and
+// a map-based parse silently keeps only one of them.
+func renameDeclarations(relPath string, data []byte, oldName, newName string) ([]byte, int, error) {
+	oldSpans, err := findDeclarationSpans(data, oldName)
+	if err != nil {
+		return nil, 0, fmt.Errorf("rewrite %s: %w", relPath, err)
+	}
+	if len(oldSpans) == 0 {
+		return data, 0, nil
+	}
+
+	newSpans, err := findDeclarationSpans(data, newName)
+	if err != nil {
+		return nil, 0, fmt.Errorf("rewrite %s: %w", relPath, err)
+	}
+	if len(newSpans) > 0 {
+		return nil, 0, fmt.Errorf("%s: %q is already declared there", relPath, newName)
+	}
+
+	spliced, count, err := renameJSONDeclarations(data, oldName, newName)
+	if err != nil {
+		return nil, 0, fmt.Errorf("rewrite %s: %w", relPath, err)
+	}
+	return spliced, count, nil
+}
+
+// diffLines pairs up differing lines of two same-line-count strings.
+func diffLines(before, after string) []Change {
+	if before == after {
+		return nil
+	}
+	beforeLines := strings.Split(before, "\n")
+	afterLines := strings.Split(after, "\n")
+	if len(beforeLines) != len(afterLines) {
+		// Defensive: a rewrite that changed the line count would make line
+		// numbers meaningless, so report the file as a single change.
+		return []Change{{Line: 0, Before: before, After: after}}
+	}
+
+	var changes []Change
+	for i := range beforeLines {
+		if beforeLines[i] != afterLines[i] {
+			changes = append(changes, Change{
+				Line:   i + 1,
+				Before: beforeLines[i],
+				After:  afterLines[i],
+			})
+		}
+	}
+	return changes
+}
+
+// isDeclarationFile reports whether a file declares variables as JSON data:
+// any tag.template.json, or any JSON file inside a _bundles/ directory.
+func isDeclarationFile(relPath string) bool {
+	base := filepath.Base(relPath)
+	if base == types.TemplateConfigFile {
+		return true
+	}
+	if filepath.Ext(base) != ".json" {
+		return false
+	}
+	return slices.Contains(strings.Split(relPath, string(filepath.Separator)), types.BundlesDir)
+}
+
+// checkPathCollisions fails the plan when a renamed path would land on an
+// existing entry that the rename does not itself move away.
+func checkPathCollisions(absRoot string, plan *RenamePlan) error {
+	moving := make(map[string]struct{}, len(plan.Files))
+	for _, f := range plan.Files {
+		if f.NewPath != "" {
+			moving[f.Path] = struct{}{}
+		}
+	}
+
+	claimed := make(map[string]string, len(plan.Files))
+	for _, f := range plan.Files {
+		if f.NewPath == "" {
+			continue
+		}
+		// Two sources renaming onto one destination would silently overwrite
+		// each other during Apply, so refuse the whole plan.
+		if other, ok := claimed[f.NewPath]; ok {
+			return fmt.Errorf("cannot rename %s and %s to the same path %s",
+				other, f.Path, f.NewPath)
+		}
+		claimed[f.NewPath] = f.Path
+
+		if _, ok := moving[f.NewPath]; ok {
+			continue
+		}
+		if err := checkExistingTarget(absRoot, f.Path, f.NewPath); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// checkExistingTarget reports a collision when the destination is already taken.
+// A destination that resolves to the source itself is not a collision: that is
+// what a case-only rename looks like on a case-insensitive filesystem.
+func checkExistingTarget(absRoot, from, to string) error {
+	dstInfo, err := os.Lstat(filepath.Join(absRoot, to))
+	if err != nil {
+		return nil //nolint:nilerr // no readable entry at the destination means nothing to collide with
+	}
+	if srcInfo, srcErr := os.Lstat(filepath.Join(absRoot, from)); srcErr == nil &&
+		os.SameFile(srcInfo, dstInfo) {
+		return nil
+	}
+	return fmt.Errorf("cannot rename %s to %s: target already exists", from, to)
+}
+
+// Apply writes the planned edits. Content is written first, then paths are moved
+// deepest-first so parent directories stay valid while their children move.
+//
+// If any step fails, everything already done is rolled back from the originals
+// captured at plan time, so a partial rename never survives the call.
+func (p *RenamePlan) Apply() error {
+	var undo []func() error
+
+	fail := func(err error) error {
+		var rollbackErrs []error
+		for i := len(undo) - 1; i >= 0; i-- {
+			if undoErr := undo[i](); undoErr != nil {
+				rollbackErrs = append(rollbackErrs, undoErr)
+			}
+		}
+		if len(rollbackErrs) > 0 {
+			// The tree is now half-applied; make that loud rather than silent.
+			return errors.Join(
+				fmt.Errorf("%w (WARNING: rollback also failed; the template may be "+
+					"partially renamed — restore it from version control)", err),
+				errors.Join(rollbackErrs...))
+		}
+		return err
+	}
+
+	for i := range p.Files {
+		f := &p.Files[i]
+		if len(f.Changes) == 0 || f.content == nil {
+			continue
+		}
+		abs := filepath.Join(p.Root, f.Path)
+		info, err := os.Stat(abs)
+		if err != nil {
+			return fail(fmt.Errorf("stat %s: %w", f.Path, err))
+		}
+		if err := os.WriteFile(abs, f.content, info.Mode().Perm()); err != nil {
+			return fail(fmt.Errorf("write %s: %w", f.Path, err))
+		}
+		original, mode := f.original, info.Mode().Perm()
+		undo = append(undo, func() error { return os.WriteFile(abs, original, mode) })
+	}
+
+	for _, move := range p.pathMoves() {
+		from := filepath.Join(p.Root, move.from)
+		to := filepath.Join(p.Root, move.to)
+		// A renamed directory placeholder means the target's parent may not
+		// exist yet; recreate it with the permissions the original carried.
+		created, err := mirrorParentDir(from, to)
+		if err != nil {
+			return fail(fmt.Errorf("create directory for %s: %w", move.to, err))
+		}
+		if len(created) > 0 {
+			undo = append(undo, func() error {
+				// created is deepest-first, so each removal sees an empty dir.
+				for _, dir := range created {
+					_ = os.Remove(dir)
+				}
+				return nil
+			})
+		}
+		if err := os.Rename(from, to); err != nil {
+			return fail(fmt.Errorf("rename %s to %s: %w", move.from, move.to, err))
+		}
+		undo = append(undo, func() error { return os.Rename(to, from) })
+	}
+
+	p.pruneEmptyRenamedDirs()
+
+	return nil
+}
+
+// mirrorParentDir ensures the destination's parent directory exists, giving it
+// the same permissions as the source's parent rather than a fixed mode. It
+// returns the directories it created, deepest-first, so a failed Apply can
+// remove them again.
+func mirrorParentDir(from, to string) ([]string, error) {
+	dstParent := filepath.Dir(to)
+	if _, err := os.Stat(dstParent); err == nil {
+		return nil, nil
+	}
+
+	var created []string
+	for dir := dstParent; ; dir = filepath.Dir(dir) {
+		if _, err := os.Stat(dir); err == nil {
+			break
+		}
+		created = append(created, dir)
+		if parent := filepath.Dir(dir); parent == dir {
+			break
+		}
+	}
+
+	mode := fs.FileMode(0o750)
+	if info, err := os.Stat(filepath.Dir(from)); err == nil {
+		mode = info.Mode().Perm()
+	}
+	if err := os.MkdirAll(dstParent, mode); err != nil {
+		return nil, fmt.Errorf("create %s: %w", dstParent, err)
+	}
+	return created, nil
+}
+
+type pathMove struct{ from, to string }
+
+// pathMoves returns the file moves ordered deepest-first, so that renaming a
+// file never invalidates a path still queued behind it.
+func (p *RenamePlan) pathMoves() []pathMove {
+	var moves []pathMove
+	for _, f := range p.Files {
+		if f.NewPath != "" {
+			moves = append(moves, pathMove{from: f.Path, to: f.NewPath})
+		}
+	}
+	slices.SortFunc(moves, func(a, b pathMove) int {
+		return strings.Count(b.from, string(filepath.Separator)) -
+			strings.Count(a.from, string(filepath.Separator))
+	})
+	return moves
+}
+
+// pruneEmptyRenamedDirs removes directories left behind once their contents
+// moved to the renamed path. Only now-empty directories whose own name carried
+// the old placeholder are removed, so unrelated empty directories survive.
+func (p *RenamePlan) pruneEmptyRenamedDirs() {
+	seen := map[string]struct{}{}
+	var dirs []string
+	for _, f := range p.Files {
+		if f.NewPath == "" {
+			continue
+		}
+		for dir := filepath.Dir(f.Path); dir != "."; dir = filepath.Dir(dir) {
+			if _, ok := seen[dir]; ok {
+				continue
+			}
+			seen[dir] = struct{}{}
+			dirs = append(dirs, dir)
+		}
+	}
+	// Deepest first, so nested leftovers clear before their parents.
+	slices.SortFunc(dirs, func(a, b string) int { return len(b) - len(a) })
+
+	for _, dir := range dirs {
+		renamed, _ := renameInExpressions(dir, p.OldName, p.NewName)
+		if renamed == dir {
+			continue
+		}
+		_ = os.Remove(filepath.Join(p.Root, dir))
+	}
+}

--- a/internal/vars/rename_format.go
+++ b/internal/vars/rename_format.go
@@ -1,0 +1,74 @@
+package vars
+
+import (
+	"fmt"
+	"io"
+)
+
+// WriteRenamePlan renders a rename plan in human-readable form. When dryRun is
+// true it reads as a preview of pending edits; otherwise as a report of edits
+// already applied.
+func WriteRenamePlan(w io.Writer, plan *RenamePlan, dryRun bool) {
+	if plan.FileCount() == 0 {
+		fmt.Fprintf(w, "No references found for %q — nothing to rename.\n", plan.OldName)
+		return
+	}
+
+	verb := "Renamed"
+	if dryRun {
+		verb = "Renaming"
+	}
+	fmt.Fprintf(w, "%s %q → %q\n\n", verb, plan.OldName, plan.NewName)
+
+	if dryRun {
+		fmt.Fprintln(w, "Changes:")
+	}
+	for i := range plan.Files {
+		writeFileChange(w, &plan.Files[i], dryRun)
+	}
+
+	fmt.Fprintf(w, "\n  %s, %s total\n",
+		pluralize(plan.FileCount(), "file"),
+		pluralize(plan.ReplacementCount(), "replacement"))
+
+	if !dryRun {
+		fmt.Fprintf(w, "\n✓ All references updated. Run 'tag template lint' to verify.\n")
+	}
+}
+
+func writeFileChange(w io.Writer, f *FileChange, dryRun bool) {
+	if !dryRun {
+		writeAppliedFileChange(w, f)
+		return
+	}
+
+	for _, c := range f.Changes {
+		fmt.Fprintf(w, "\n  %s:%d\n", f.Path, c.Line)
+		fmt.Fprintf(w, "    - %s\n", c.Before)
+		fmt.Fprintf(w, "    + %s\n", c.After)
+	}
+	if f.NewPath != "" {
+		fmt.Fprintf(w, "\n  %s (path placeholder):\n", f.Path)
+		fmt.Fprintf(w, "    - %s\n", f.Path)
+		fmt.Fprintf(w, "    + %s\n", f.NewPath)
+	}
+}
+
+func writeAppliedFileChange(w io.Writer, f *FileChange) {
+	switch {
+	case f.NewPath != "" && f.Replacements > 0:
+		fmt.Fprintf(w, "  Updated %s → %s (%s)\n",
+			f.Path, f.NewPath, pluralize(f.Replacements, "change"))
+	case f.NewPath != "":
+		fmt.Fprintf(w, "  Renamed %s → %s\n", f.Path, f.NewPath)
+	default:
+		fmt.Fprintf(w, "  Updated %s (%s)\n", f.Path, pluralize(f.Replacements, "change"))
+	}
+}
+
+func pluralize(n int, noun string) string {
+	if n == 1 {
+		return fmt.Sprintf("%d %s", n, noun)
+	}
+	return fmt.Sprintf("%d %ss", n, noun)
+}

--- a/internal/vars/rename_format_test.go
+++ b/internal/vars/rename_format_test.go
@@ -1,0 +1,68 @@
+package vars
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUT_WriteRenamePlan_DryRunPreview(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeTree(t, root, map[string]string{
+		"tag.template.json":              `{"vars": {"old": 1}}`,
+		"README.md":                      "# {{ vars.old }}\n",
+		"{{ vars.old | snake }}/main.go": "package main\n",
+	})
+
+	plan, err := PlanRename(root, "old", "renamed")
+	require.NoError(t, err)
+
+	var sb strings.Builder
+	WriteRenamePlan(&sb, plan, true)
+	out := sb.String()
+
+	assert.Contains(t, out, `Renaming "old" → "renamed"`)
+	assert.Contains(t, out, "README.md:1")
+	assert.Contains(t, out, "- # {{ vars.old }}")
+	assert.Contains(t, out, "+ # {{ vars.renamed }}")
+	assert.Contains(t, out, "(path placeholder)")
+	// 1 README reference + 1 config key + 1 path move.
+	assert.Contains(t, out, "3 files, 3 replacements total")
+	assert.NotContains(t, out, "Renamed \"old\"", "dry-run must not claim the rename happened")
+}
+
+func TestUT_WriteRenamePlan_AppliedSummary(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeTree(t, root, map[string]string{
+		"tag.template.json": `{"vars": {"old": 1}}`,
+		"README.md":         "# {{ vars.old }}\n",
+	})
+
+	plan, err := PlanRename(root, "old", "renamed")
+	require.NoError(t, err)
+
+	var sb strings.Builder
+	WriteRenamePlan(&sb, plan, false)
+	out := sb.String()
+
+	assert.Contains(t, out, `Renamed "old" → "renamed"`)
+	assert.Contains(t, out, "tag.template.json")
+	assert.Contains(t, out, "tag template lint")
+}
+
+func TestUT_WriteRenamePlan_NoChanges(t *testing.T) {
+	t.Parallel()
+
+	plan := &RenamePlan{Root: "/tmp/x", OldName: "old", NewName: "renamed"}
+
+	var sb strings.Builder
+	WriteRenamePlan(&sb, plan, true)
+
+	assert.Contains(t, sb.String(), "No references found")
+}

--- a/internal/vars/rename_test.go
+++ b/internal/vars/rename_test.go
@@ -1,0 +1,430 @@
+package vars
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeTree materialises a map of relative path -> content under root.
+func writeTree(t *testing.T, root string, files map[string]string) {
+	t.Helper()
+	for rel, content := range files {
+		full := filepath.Join(root, filepath.FromSlash(rel))
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+		require.NoError(t, os.WriteFile(full, []byte(content), 0o644))
+	}
+}
+
+// snapshotTree reads every file under root into a map of relative path -> content.
+func snapshotTree(t *testing.T, root string) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	require.NoError(t, filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		require.NoError(t, err)
+		if info.IsDir() {
+			return nil
+		}
+		rel, relErr := filepath.Rel(root, path)
+		require.NoError(t, relErr)
+		content, readErr := os.ReadFile(path)
+		require.NoError(t, readErr)
+		out[filepath.ToSlash(rel)] = string(content)
+		return nil
+	}))
+	return out
+}
+
+// renameTree builds a template, plans a rename and applies it, returning the
+// plan and the resulting tree.
+func renameTree(t *testing.T, files map[string]string, oldName, newName string) (*RenamePlan, string) {
+	t.Helper()
+	root := t.TempDir()
+	writeTree(t, root, files)
+
+	plan, err := PlanRename(root, oldName, newName)
+	require.NoError(t, err)
+	require.NoError(t, plan.Apply())
+
+	return plan, root
+}
+
+const basicConfig = `{
+  "name": "demo",
+  "vars": {
+    "old": { "type": "string", "prompt": "Old" },
+    "module": { "default": "github.com/acme/{{ vars.old | kebab }}" }
+  }
+}`
+
+func TestUT_PlanRename_UpdatesConfigAndTemplates(t *testing.T) {
+	t.Parallel()
+
+	plan, root := renameTree(t, map[string]string{
+		"tag.template.json": basicConfig,
+		"README.md":         "# {{ vars.old }}\n\nThe old project.\n",
+		"go.mod":            "module {{ vars.old | kebab }}\n",
+	}, "old", "renamed")
+
+	tree := snapshotTree(t, root)
+
+	assert.Contains(t, tree["tag.template.json"], `"renamed": { "type": "string", "prompt": "Old" }`)
+	assert.Contains(t, tree["tag.template.json"], `github.com/acme/{{ vars.renamed | kebab }}`)
+	assert.Equal(t, "# {{ vars.renamed }}\n\nThe old project.\n", tree["README.md"])
+	assert.Equal(t, "module {{ vars.renamed | kebab }}\n", tree["go.mod"])
+
+	assert.Equal(t, "old", plan.OldName)
+	assert.Equal(t, "renamed", plan.NewName)
+}
+
+func TestUT_PlanRename_ReportsTotals(t *testing.T) {
+	t.Parallel()
+
+	plan, _ := renameTree(t, map[string]string{
+		"tag.template.json": `{"vars": {"old": 1}}`,
+		"a.txt":             "{{ vars.old }} {{ vars.old }}\n",
+		"b.txt":             "{% if vars.old %}x{% endif %}\n",
+		"c.txt":             "nothing here\n",
+	}, "old", "renamed")
+
+	assert.Equal(t, 3, plan.FileCount(), "only files that actually changed are counted")
+	assert.Equal(t, 4, plan.ReplacementCount(), "1 config key + 2 in a.txt + 1 in b.txt")
+
+	var paths []string
+	for _, f := range plan.Files {
+		paths = append(paths, f.Path)
+	}
+	assert.NotContains(t, paths, "c.txt")
+}
+
+func TestUT_PlanRename_ReportsLineNumbers(t *testing.T) {
+	t.Parallel()
+
+	plan, _ := renameTree(t, map[string]string{
+		"tag.template.json": `{"vars": {"old": 1}}`,
+		"README.md":         "line one\nline two\n# {{ vars.old }}\nline four\n",
+	}, "old", "renamed")
+
+	var readme *FileChange
+	for i := range plan.Files {
+		if plan.Files[i].Path == "README.md" {
+			readme = &plan.Files[i]
+		}
+	}
+	require.NotNil(t, readme)
+	require.Len(t, readme.Changes, 1)
+	assert.Equal(t, 3, readme.Changes[0].Line)
+	assert.Equal(t, "# {{ vars.old }}", readme.Changes[0].Before)
+	assert.Equal(t, "# {{ vars.renamed }}", readme.Changes[0].After)
+}
+
+func TestUT_PlanRename_UpdatesGeneratorScopes(t *testing.T) {
+	t.Parallel()
+
+	_, root := renameTree(t, map[string]string{
+		"tag.template.json":                         `{"vars": {"old": 1}}`,
+		"_generators/api/tag.template.json":         `{"vars": {"old": 2}, "requires": ["old"]}`,
+		"_generators/api/templates/handler.go.t":    "// {{ vars.old }}\n",
+		"_generators/_bundles/crud/crud.json":       `{"requires": ["old"], "generators": []}`,
+		".tag/_bundles/feature/feature.bundle.json": `{"requires": ["old"]}`,
+	}, "old", "renamed")
+
+	tree := snapshotTree(t, root)
+
+	assert.Contains(t, tree["_generators/api/tag.template.json"], `"renamed": 2`)
+	assert.Contains(t, tree["_generators/api/tag.template.json"], `"requires": ["renamed"]`)
+	assert.Equal(t, "// {{ vars.renamed }}\n", tree["_generators/api/templates/handler.go.t"])
+	assert.Contains(t, tree["_generators/_bundles/crud/crud.json"], `"requires": ["renamed"]`)
+	assert.Contains(t, tree[".tag/_bundles/feature/feature.bundle.json"], `"requires": ["renamed"]`)
+}
+
+func TestUT_PlanRename_RenamesPathPlaceholders(t *testing.T) {
+	t.Parallel()
+
+	plan, root := renameTree(t, map[string]string{
+		"tag.template.json":                             `{"vars": {"old": 1}}`,
+		"{{ vars.old | snake }}/main.go":                "package main\n",
+		"{{ vars.old | snake }}/{{ vars.old }}_test.go": "package main\n",
+	}, "old", "renamed")
+
+	assert.FileExists(t, filepath.Join(root, "{{ vars.renamed | snake }}", "main.go"))
+	assert.FileExists(t, filepath.Join(root, "{{ vars.renamed | snake }}", "{{ vars.renamed }}_test.go"))
+	assert.NoDirExists(t, filepath.Join(root, "{{ vars.old | snake }}"))
+	assert.Equal(t, 2, plan.PathRenameCount())
+}
+
+func TestUT_PlanRename_PruneKeepsDirsThatStillHoldContent(t *testing.T) {
+	t.Parallel()
+
+	// The placeholder directory also contains a .tagignore'd file, which the
+	// rename never moves. Pruning must not delete a directory that still has
+	// content — os.Remove (not RemoveAll) guarantees that.
+	root := t.TempDir()
+	writeTree(t, root, map[string]string{
+		"tag.template.json":         `{"vars": {"old": 1}}`,
+		".tagignore":                "keepme.txt\n",
+		"{{ vars.old }}/main.go":    "package main\n",
+		"{{ vars.old }}/keepme.txt": "not a template\n",
+	})
+
+	plan, err := PlanRename(root, "old", "renamed")
+	require.NoError(t, err)
+	require.NoError(t, plan.Apply())
+
+	// main.go moved to the renamed dir; the ignored file stays put, so the old
+	// directory must survive with its remaining content intact.
+	assert.FileExists(t, filepath.Join(root, "{{ vars.renamed }}", "main.go"))
+	assert.FileExists(t, filepath.Join(root, "{{ vars.old }}", "keepme.txt"))
+}
+
+func TestUT_PlanRename_DryRunLeavesTreeUntouched(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	files := map[string]string{
+		"tag.template.json":              `{"vars": {"old": 1}}`,
+		"README.md":                      "# {{ vars.old }}\n",
+		"{{ vars.old | snake }}/main.go": "package main\n",
+	}
+	writeTree(t, root, files)
+	before := snapshotTree(t, root)
+
+	plan, err := PlanRename(root, "old", "renamed")
+	require.NoError(t, err)
+
+	assert.Positive(t, plan.ReplacementCount())
+	assert.Equal(t, before, snapshotTree(t, root),
+		"planning must not write anything — --dry-run depends on it")
+}
+
+func TestUT_PlanRename_SkipsNonTemplateContent(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeTree(t, root, map[string]string{
+		"tag.template.json": `{"vars": {"old": 1}}`,
+		".tagignore":        "vendor/\nCLAUDE.md\n",
+		"vendor/lib.go":     "// {{ vars.old }}\n",
+		"CLAUDE.md":         "# {{ vars.old }}\n",
+		"_dialects/go.yaml": "name: {{ vars.old }}\n",
+		".git/config":       "{{ vars.old }}\n",
+		"keep.md":           "# {{ vars.old }}\n",
+	})
+	require.NoError(t, os.WriteFile(filepath.Join(root, "logo.png"),
+		[]byte{0x89, 0x50, 0x4e, 0x47, 0x00, 0x01, 0x02}, 0o644))
+
+	plan, err := PlanRename(root, "old", "renamed")
+	require.NoError(t, err)
+	require.NoError(t, plan.Apply())
+
+	tree := snapshotTree(t, root)
+	assert.Equal(t, "// {{ vars.old }}\n", tree["vendor/lib.go"], ".tagignore must be honoured")
+	assert.Equal(t, "# {{ vars.old }}\n", tree["CLAUDE.md"], ".tagignore must be honoured")
+	assert.Equal(t, "name: {{ vars.old }}\n", tree["_dialects/go.yaml"])
+	assert.Equal(t, "{{ vars.old }}\n", tree[".git/config"])
+	assert.Equal(t, "# {{ vars.renamed }}\n", tree["keep.md"])
+}
+
+func TestUT_PlanRename_Validation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		files   map[string]string
+		oldName string
+		newName string
+		wantErr string
+	}{
+		{
+			name:    "old name not declared",
+			files:   map[string]string{"tag.template.json": `{"vars": {"other": 1}}`},
+			oldName: "missing",
+			newName: "renamed",
+			wantErr: `not declared`,
+		},
+		{
+			name:    "new name already declared",
+			files:   map[string]string{"tag.template.json": `{"vars": {"old": 1, "taken": 2}}`},
+			oldName: "old",
+			newName: "taken",
+			wantErr: `already declared`,
+		},
+		{
+			name:    "identical names",
+			files:   map[string]string{"tag.template.json": `{"vars": {"old": 1}}`},
+			oldName: "old",
+			newName: "old",
+			wantErr: "identical",
+		},
+		{
+			name:    "invalid new identifier",
+			files:   map[string]string{"tag.template.json": `{"vars": {"old": 1}}`},
+			oldName: "old",
+			newName: "not-valid",
+			wantErr: "not a valid variable name",
+		},
+		{
+			name:    "invalid old identifier",
+			files:   map[string]string{"tag.template.json": `{"vars": {"old": 1}}`},
+			oldName: "1bad",
+			newName: "renamed",
+			wantErr: "not a valid variable name",
+		},
+		{
+			name:    "missing config",
+			files:   map[string]string{"README.md": "hi"},
+			oldName: "old",
+			newName: "renamed",
+			wantErr: "tag.template.json",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			writeTree(t, root, tt.files)
+
+			_, err := PlanRename(root, tt.oldName, tt.newName)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestUT_PlanRename_RejectsPathCollision(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeTree(t, root, map[string]string{
+		"tag.template.json":     `{"vars": {"old": 1}}`,
+		"{{ vars.old }}.go":     "a\n",
+		"{{ vars.renamed }}.go": "b\n",
+	})
+
+	_, err := PlanRename(root, "old", "renamed")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already exists")
+}
+
+func TestUT_PlanRename_RejectsTwoPathsRenamingOntoEachOther(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	// Both names rewrite to "{{ vars.renamed }}-{{ vars.renamed }}.go"; applying
+	// them in sequence would silently overwrite the first with the second.
+	writeTree(t, root, map[string]string{
+		"tag.template.json":                    `{"vars": {"old": 1}}`,
+		"{{ vars.old }}-{{ vars.renamed }}.go": "a\n",
+		"{{ vars.renamed }}-{{ vars.old }}.go": "b\n",
+	})
+
+	_, err := PlanRename(root, "old", "renamed")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "same path")
+}
+
+func TestUT_PlanRename_AllowsCaseOnlyRename(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeTree(t, root, map[string]string{
+		"tag.template.json": `{"vars": {"Old": 1}}`,
+		"{{ vars.Old }}.go": "package main\n",
+	})
+
+	// On a case-insensitive filesystem the destination Lstat resolves to the
+	// source itself; that must not be mistaken for a collision.
+	plan, err := PlanRename(root, "Old", "old")
+	require.NoError(t, err)
+	require.NoError(t, plan.Apply())
+
+	assert.FileExists(t, filepath.Join(root, "{{ vars.old }}.go"))
+}
+
+func TestUT_PlanRename_RejectsNewNameAlreadyDeclaredInGenerator(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeTree(t, root, map[string]string{
+		"tag.template.json": `{"vars": {"old": 1}}`,
+		// Renaming old -> taken here would produce a duplicate "taken" key,
+		// and a map-based parse would silently drop one declaration.
+		"_generators/api/tag.template.json": `{"vars": {"old": 1, "taken": 2}}`,
+	})
+
+	_, err := PlanRename(root, "old", "taken")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already declared")
+}
+
+func TestUT_RenamePlan_ApplyRestoresAfterPathMoveFailure(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeTree(t, root, map[string]string{
+		"tag.template.json":           `{"vars": {"old": 1}}`,
+		"README.md":                   "# {{ vars.old }}\n",
+		"{{ vars.old | snake }}/a.go": "package a\n",
+		"{{ vars.old | snake }}/b.go": "package b\n",
+	})
+	before := snapshotTree(t, root)
+
+	plan, err := PlanRename(root, "old", "renamed")
+	require.NoError(t, err)
+
+	// Break the last move so Apply fails after content writes AND after at
+	// least one rename has already succeeded.
+	moved := 0
+	for i := range plan.Files {
+		if plan.Files[i].NewPath != "" {
+			moved++
+			if moved == 2 {
+				plan.Files[i].Path = filepath.Join("gone", "missing.go")
+			}
+		}
+	}
+	require.Equal(t, 2, moved, "fixture must produce two path moves")
+
+	require.Error(t, plan.Apply())
+	assert.Equal(t, before, snapshotTree(t, root),
+		"a move-phase failure must roll back content writes and completed renames")
+	assert.NoDirExists(t, filepath.Join(root, "{{ vars.renamed | snake }}"),
+		"rollback must not leave the directory it created behind")
+}
+
+func TestUT_PlanRename_RejectsNonDirectory(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	file := filepath.Join(root, "afile")
+	require.NoError(t, os.WriteFile(file, []byte("x"), 0o644))
+
+	_, err := PlanRename(file, "old", "renamed")
+	require.Error(t, err)
+}
+
+func TestUT_RenamePlan_ApplyRestoresOnFailure(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeTree(t, root, map[string]string{
+		"tag.template.json": `{"vars": {"old": 1}}`,
+		"a.md":              "# {{ vars.old }}\n",
+		"b.md":              "# {{ vars.old }}\n",
+	})
+	before := snapshotTree(t, root)
+
+	plan, err := PlanRename(root, "old", "renamed")
+	require.NoError(t, err)
+
+	// Point one entry at an unwritable location so Apply fails partway.
+	plan.Files[len(plan.Files)-1].Path = filepath.Join("nope", "missing.md")
+
+	require.Error(t, plan.Apply())
+	assert.Equal(t, before, snapshotTree(t, root),
+		"a failed Apply must leave the template exactly as it was")
+}

--- a/internal/vars/rewrite.go
+++ b/internal/vars/rewrite.go
@@ -1,0 +1,245 @@
+package vars
+
+import (
+	"strings"
+)
+
+// Gonja block delimiters.
+const (
+	exprOpen   = "{{"
+	exprClose  = "}}"
+	stmtOpen   = "{%"
+	stmtClose  = "%}"
+	cmntOpen   = "{#"
+	cmntClose  = "#}"
+	rawTag     = "raw"
+	endRawTag  = "endraw"
+	varsPrefix = "vars."
+)
+
+// renameInExpressions rewrites `vars.<oldName>` to `vars.<newName>` inside Gonja
+// expression ({{ }}) and statement ({% %}) blocks, returning the rewritten source
+// and the number of replacements made.
+//
+// Plain text is never touched, which is what makes the rename safe on template
+// bodies that happen to mention the variable name in prose. Three regions are
+// deliberately left verbatim because their contents are not variable references:
+// comments ({# #}), {% raw %} blocks (emitted literally, so rewriting them would
+// change generated output), and string literals inside a block.
+//
+// The scan is byte-oriented and quote-aware, so a delimiter inside a string
+// literal — `{{ f("}}") ~ vars.x }}` — does not terminate the block early.
+// An unterminated block is copied verbatim rather than guessed at.
+//
+// Replacement never changes the number of newlines, so callers can derive line
+// numbers by comparing the input and output line-by-line.
+func renameInExpressions(src, oldName, newName string) (string, int) {
+	var (
+		b     strings.Builder
+		count int
+		i     int
+	)
+	b.Grow(len(src))
+
+	for i < len(src) {
+		switch {
+		case strings.HasPrefix(src[i:], cmntOpen):
+			i = copyComment(&b, src, i)
+
+		case strings.HasPrefix(src[i:], stmtOpen):
+			end := scanBlock(src, i+len(stmtOpen), stmtClose)
+			if end < 0 {
+				b.WriteString(src[i:])
+				return b.String(), count
+			}
+			block := src[i:end]
+			b.WriteString(rewriteBlock(block, oldName, newName, &count))
+			i = end
+			// A {% raw %} block emits its body literally; skip to {% endraw %}.
+			if blockTag(block) == rawTag {
+				i = skipRawBody(&b, src, i)
+			}
+
+		case strings.HasPrefix(src[i:], exprOpen):
+			end := scanBlock(src, i+len(exprOpen), exprClose)
+			if end < 0 {
+				b.WriteString(src[i:])
+				return b.String(), count
+			}
+			b.WriteString(rewriteBlock(src[i:end], oldName, newName, &count))
+			i = end
+
+		default:
+			b.WriteByte(src[i])
+			i++
+		}
+	}
+
+	return b.String(), count
+}
+
+// copyComment copies the {# ... #} comment starting at start verbatim and
+// returns the index just past it. An unterminated comment consumes the rest of
+// src, matching Gonja's own "everything after {# is comment" behaviour.
+func copyComment(b *strings.Builder, src string, start int) int {
+	idx := strings.Index(src[start+len(cmntOpen):], cmntClose)
+	if idx < 0 {
+		b.WriteString(src[start:])
+		return len(src)
+	}
+	end := start + len(cmntOpen) + idx + len(cmntClose)
+	b.WriteString(src[start:end])
+	return end
+}
+
+// skipRawBody copies everything from start up to and including the closing
+// {% endraw %} tag verbatim, returning the index just past it. Nested raw blocks
+// are not a thing in Gonja, so the first endraw wins.
+//
+// A raw body is literal text, so the search for the closing tag is literal too:
+// quote-aware scanning here would let an unbalanced quote in the body swallow
+// the real {% endraw %} and everything after it.
+func skipRawBody(b *strings.Builder, src string, start int) int {
+	i := start
+	for i < len(src) {
+		if !strings.HasPrefix(src[i:], stmtOpen) {
+			b.WriteByte(src[i])
+			i++
+			continue
+		}
+		idx := strings.Index(src[i+len(stmtOpen):], stmtClose)
+		if idx < 0 {
+			b.WriteString(src[i:])
+			return len(src)
+		}
+		end := i + len(stmtOpen) + idx + len(stmtClose)
+		block := src[i:end]
+		b.WriteString(block)
+		i = end
+		if blockTag(block) == endRawTag {
+			return i
+		}
+	}
+	return i
+}
+
+// blockTag returns the first word of a {% ... %} block, with whitespace-control
+// markers stripped. It returns "" for blocks that are not statement blocks.
+func blockTag(block string) string {
+	if !strings.HasPrefix(block, stmtOpen) || !strings.HasSuffix(block, stmtClose) {
+		return ""
+	}
+	inner := block[len(stmtOpen) : len(block)-len(stmtClose)]
+	inner = strings.TrimSpace(strings.Trim(strings.TrimSpace(inner), "-"))
+	tag, _, _ := strings.Cut(inner, " ")
+	return tag
+}
+
+// scanBlock returns the index just past the first close delimiter at or after
+// start, skipping over single- and double-quoted string literals so that a
+// delimiter inside a literal does not end the block. It returns -1 when the
+// block is unterminated.
+func scanBlock(src string, start int, closing string) int {
+	i := start
+	for i < len(src) {
+		if c := src[i]; c == '\'' || c == '"' {
+			i = skipQuoted(src, i)
+			continue
+		}
+		if strings.HasPrefix(src[i:], closing) {
+			return i + len(closing)
+		}
+		i++
+	}
+	return -1
+}
+
+// skipQuoted returns the index just past the string literal starting at src[i]
+// (which must be a quote character), honouring backslash escapes. An
+// unterminated literal consumes the remainder of src.
+func skipQuoted(src string, i int) int {
+	quote := src[i]
+	i++
+	for i < len(src) {
+		switch src[i] {
+		case '\\':
+			i += 2
+		case quote:
+			return i + 1
+		default:
+			i++
+		}
+	}
+	return len(src)
+}
+
+// rewriteBlock replaces vars.<oldName> with vars.<newName> inside a single
+// block, skipping string literals, and adds the number of replacements to count.
+func rewriteBlock(block, oldName, newName string, count *int) string {
+	needle := varsPrefix + oldName
+	replacement := varsPrefix + newName
+
+	var b strings.Builder
+	b.Grow(len(block))
+
+	i := 0
+	for i < len(block) {
+		if c := block[i]; c == '\'' || c == '"' {
+			end := skipQuoted(block, i)
+			b.WriteString(block[i:end])
+			i = end
+			continue
+		}
+		if strings.HasPrefix(block[i:], needle) && isWholeReference(block, i, len(needle)) {
+			b.WriteString(replacement)
+			i += len(needle)
+			*count++
+			continue
+		}
+		b.WriteByte(block[i])
+		i++
+	}
+
+	return b.String()
+}
+
+// isWholeReference reports whether the `vars.<name>` match at block[i:i+width] is
+// a complete reference rather than part of a longer identifier or a nested
+// attribute path. It rejects `myvars.old`, `cfg.vars.old`, `cfg . vars.old` and
+// `vars.old_suffix`, while allowing `vars.old.nested` and `vars.old[0]`.
+func isWholeReference(block string, i, width int) bool {
+	// Part of a longer identifier, e.g. myvars.old.
+	if i > 0 && isIdentByte(block[i-1]) {
+		return false
+	}
+	// An attribute of something else, e.g. cfg.vars.old. Gonja allows
+	// whitespace around the dot operator, so skip back over it before deciding.
+	// Only the dot check may skip whitespace: a preceding keyword such as the
+	// "if" in `{% if vars.old %}` must still count as a real reference.
+	if j := lastNonSpaceIndex(block, i); j >= 0 && block[j] == '.' {
+		return false
+	}
+	// A longer variable name that merely starts with this one, e.g. vars.old_x.
+	if next := i + width; next < len(block) && isIdentByte(block[next]) {
+		return false
+	}
+	return true
+}
+
+// lastNonSpaceIndex returns the index of the last non-space, non-tab byte before
+// i, or -1 when there is none.
+func lastNonSpaceIndex(block string, i int) int {
+	for j := i - 1; j >= 0; j-- {
+		if block[j] != ' ' && block[j] != '\t' {
+			return j
+		}
+	}
+	return -1
+}
+
+func isIdentByte(c byte) bool {
+	return c == '_' ||
+		(c >= 'a' && c <= 'z') ||
+		(c >= 'A' && c <= 'Z') ||
+		(c >= '0' && c <= '9')
+}

--- a/internal/vars/rewrite_test.go
+++ b/internal/vars/rewrite_test.go
@@ -1,0 +1,343 @@
+package vars
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUT_RenameInExpressions_ExpressionForms(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		src   string
+		want  string
+		count int
+	}{
+		{
+			name:  "bare reference",
+			src:   "# {{ vars.old }}",
+			want:  "# {{ vars.new }}",
+			count: 1,
+		},
+		{
+			name:  "single filter",
+			src:   "module {{ vars.old | kebab }}",
+			want:  "module {{ vars.new | kebab }}",
+			count: 1,
+		},
+		{
+			name:  "chained filters",
+			src:   "{{ vars.old | snake | upper }}",
+			want:  "{{ vars.new | snake | upper }}",
+			count: 1,
+		},
+		{
+			name:  "no surrounding whitespace",
+			src:   "{{vars.old}}",
+			want:  "{{vars.new}}",
+			count: 1,
+		},
+		{
+			name:  "whitespace control markers",
+			src:   "{{- vars.old -}}",
+			want:  "{{- vars.new -}}",
+			count: 1,
+		},
+		{
+			name:  "attribute access on the variable",
+			src:   "{{ vars.old.nested }}",
+			want:  "{{ vars.new.nested }}",
+			count: 1,
+		},
+		{
+			name:  "multiple references on one line",
+			src:   "{{ vars.old }}-{{ vars.old | upper }}",
+			want:  "{{ vars.new }}-{{ vars.new | upper }}",
+			count: 2,
+		},
+		{
+			name:  "string concatenation operand",
+			src:   `{{ vars.old ~ "-suffix" }}`,
+			want:  `{{ vars.new ~ "-suffix" }}`,
+			count: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, n := renameInExpressions(tt.src, "old", "new")
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.count, n)
+		})
+	}
+}
+
+func TestUT_RenameInExpressions_StatementForms(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		src   string
+		want  string
+		count int
+	}{
+		{
+			name:  "if conditional",
+			src:   "{% if vars.old %}x{% endif %}",
+			want:  "{% if vars.new %}x{% endif %}",
+			count: 1,
+		},
+		{
+			// Guards the whitespace-before-dot check against over-rejecting:
+			// a keyword preceding the reference is not an attribute path.
+			name:  "keyword directly before the reference",
+			src:   "{% if not vars.old %}x{% endif %}",
+			want:  "{% if not vars.new %}x{% endif %}",
+			count: 1,
+		},
+		{
+			name:  "for loop",
+			src:   "{% for item in vars.old %}{{ item }}{% endfor %}",
+			want:  "{% for item in vars.new %}{{ item }}{% endfor %}",
+			count: 1,
+		},
+		{
+			name:  "set statement",
+			src:   "{% set x = vars.old %}",
+			want:  "{% set x = vars.new %}",
+			count: 1,
+		},
+		{
+			name:  "whitespace control on statement",
+			src:   "{%- if vars.old -%}",
+			want:  "{%- if vars.new -%}",
+			count: 1,
+		},
+		{
+			name: "multi-line statement tag",
+			src: `{% if vars.old
+      and vars.old != "" %}ok{% endif %}`,
+			want: `{% if vars.new
+      and vars.new != "" %}ok{% endif %}`,
+			count: 2,
+		},
+		{
+			name:  "elif branch",
+			src:   "{% if a %}{% elif vars.old %}{% endif %}",
+			want:  "{% if a %}{% elif vars.new %}{% endif %}",
+			count: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, n := renameInExpressions(tt.src, "old", "new")
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.count, n)
+		})
+	}
+}
+
+func TestUT_RenameInExpressions_LeavesNonExpressionsAlone(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{
+			name: "plain prose containing the name",
+			src:  "The old variable and vars.old outside a tag stay put.",
+		},
+		{
+			name: "longer name with the old name as a prefix",
+			src:  "{{ vars.old_suffix }}",
+		},
+		{
+			name: "different variable ending with the old name",
+			src:  "{{ vars.very_old }}",
+		},
+		{
+			name: "another namespace",
+			src:  "{{ myvars.old }}",
+		},
+		{
+			name: "nested attribute that merely ends in vars",
+			src:  "{{ cfg.vars.old }}",
+		},
+		{
+			// Gonja accepts whitespace around the dot operator, so this is an
+			// attribute of cfg — not the global vars namespace.
+			name: "nested attribute with whitespace around the dot",
+			src:  "{{ cfg . vars.old }}",
+		},
+		{
+			name: "nested attribute with a tab around the dot",
+			src:  "{{ cfg\t.\tvars.old }}",
+		},
+		{
+			name: "gonja comment",
+			src:  "{# {{ vars.old }} is deprecated #}",
+		},
+		{
+			name: "multi-line gonja comment",
+			src:  "{#\n  {{ vars.old }}\n#}",
+		},
+		{
+			name: "raw block",
+			src:  "{% raw %}{{ vars.old }}{% endraw %}",
+		},
+		{
+			name: "raw block with whitespace control",
+			src:  "{%- raw -%}\n{{ vars.old | kebab }}\n{%- endraw -%}",
+		},
+		{
+			name: "string literal inside an expression",
+			src:  `{{ "vars.old" }}`,
+		},
+		{
+			name: "string literal comparison inside a statement",
+			src:  `{% if x == "vars.old" %}y{% endif %}`,
+		},
+		{
+			name: "single-quoted string literal",
+			src:  `{{ f('vars.old') }}`,
+		},
+		{
+			name: "unterminated expression is left verbatim",
+			src:  "{{ vars.old",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, n := renameInExpressions(tt.src, "old", "new")
+			assert.Equal(t, tt.src, got)
+			assert.Equal(t, 0, n)
+		})
+	}
+}
+
+func TestUT_RenameInExpressions_DelimitersInsideStringLiterals(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		src   string
+		want  string
+		count int
+	}{
+		{
+			name:  "closing expression delimiter inside a string",
+			src:   `{{ f("}}") ~ vars.old }}`,
+			want:  `{{ f("}}") ~ vars.new }}`,
+			count: 1,
+		},
+		{
+			name:  "closing statement delimiter inside a string",
+			src:   `{% set s = "%}" %}{{ vars.old }}`,
+			want:  `{% set s = "%}" %}{{ vars.new }}`,
+			count: 1,
+		},
+		{
+			name:  "escaped quote inside a string",
+			src:   `{{ f("a\"}}b") ~ vars.old }}`,
+			want:  `{{ f("a\"}}b") ~ vars.new }}`,
+			count: 1,
+		},
+		{
+			name:  "expression after a raw block still renamed",
+			src:   "{% raw %}{{ vars.old }}{% endraw %}{{ vars.old }}",
+			want:  "{% raw %}{{ vars.old }}{% endraw %}{{ vars.new }}",
+			count: 1,
+		},
+		{
+			name:  "expression after a comment still renamed",
+			src:   "{# vars.old #}{{ vars.old }}",
+			want:  "{# vars.old #}{{ vars.new }}",
+			count: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, n := renameInExpressions(tt.src, "old", "new")
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.count, n)
+		})
+	}
+}
+
+func TestUT_RenameInExpressions_RawBodyIsScannedLiterally(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		src   string
+		want  string
+		count int
+	}{
+		{
+			name: "unbalanced quote inside a raw body does not swallow the rest of the file",
+			src: `{% raw %}{% set x = "oops %}{% endraw %}` +
+				`{{ vars.old }}`,
+			want: `{% raw %}{% set x = "oops %}{% endraw %}` +
+				`{{ vars.new }}`,
+			count: 1,
+		},
+		{
+			name:  "raw tag separated by tabs is still recognised",
+			src:   "{%\traw\t%}{{ vars.old }}{%\tendraw\t%}{{ vars.old }}",
+			want:  "{%\traw\t%}{{ vars.old }}{%\tendraw\t%}{{ vars.new }}",
+			count: 1,
+		},
+		{
+			name:  "raw tag with no surrounding whitespace",
+			src:   "{%raw%}{{ vars.old }}{%endraw%}{{ vars.old }}",
+			want:  "{%raw%}{{ vars.old }}{%endraw%}{{ vars.new }}",
+			count: 1,
+		},
+		{
+			name:  "unterminated raw block leaves the remainder verbatim",
+			src:   "{% raw %}{{ vars.old }} forever",
+			want:  "{% raw %}{{ vars.old }} forever",
+			count: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, n := renameInExpressions(tt.src, "old", "new")
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.count, n)
+		})
+	}
+}
+
+func TestUT_RenameInExpressions_PreservesLineCount(t *testing.T) {
+	t.Parallel()
+
+	src := "a\n{{ vars.old }}\nb\n{% if vars.old %}\nc\n{% endif %}\n"
+	got, n := renameInExpressions(src, "old", "renamed")
+
+	assert.Equal(t, 2, n)
+	assert.Equal(t, countNewlines(src), countNewlines(got),
+		"rewrite must not add or remove newlines so line numbers stay stable")
+}
+
+func countNewlines(s string) int {
+	n := 0
+	for i := range len(s) {
+		if s[i] == '\n' {
+			n++
+		}
+	}
+	return n
+}


### PR DESCRIPTION
## Intent

Renaming a variable in a TAG template today means manual find-and-replace across the declaration, every `{{ vars.x }}` reference, frontmatter `to:` paths, directory placeholders, conditionals, hook commands and bundle `requires` — miss one and you get a silently empty value at render time. This adds a single command that does it atomically.

```bash
tag template rename-var --dry-run project_name service_name   # preview
tag template rename-var project_name service_name             # apply
```

## What changed

**New command** `tag template rename-var <old> <new> [path]` (`--dry-run`), registered under `tag template`.

Rewrites, everywhere a template refers to the variable:
- `tag.template.json` declaration, derived defaults, hook commands
- Bundle and generator `requires` entries
- All Gonja expressions: `{{ vars.x }}`, chained filters, `{% if %}`, `{% for %}`, `{% set %}`
- Frontmatter `to:` paths and file/directory name placeholders (renamed on disk)

Leaves alone: plain prose, comments, `{% raw %}` blocks, string literals inside expressions, `.tagignore`d files, `_dialects/`, `.git/`, symlinks, binaries. Includes `_generators/` and `.tag/` (they reference root-level variables).

**Design**
- `internal/vars/rewrite.go` — quote/comment/raw-aware expression rewriter; never changes newline count, so line numbers stay valid for the diff preview.
- `internal/vars/jsonedit.go` — byte-span JSON splice that preserves key order and formatting; a backward quote-scan makes `\uXXXX`-escaped keys splice safely.
- `internal/vars/rename.go` — read-only `PlanRename` + transactional `Apply` with full rollback (content writes + completed renames + created dirs all revert on failure); collision checks reject two placeholders resolving to one path and are case-only-rename aware.

## Testing

- Unit tests for the rewriter, JSON splicer, planner, formatter and CLI (`internal/vars`, `internal/commands`).
- Integration tests (`internal/integration/renamevar_test.go`) proving a renamed template lints clean, every documented location is rewritten, and `--dry-run` is inert.
- Reviewed adversarially with Codex and Antigravity; their data-loss and silent-wrong-rename findings (duplicate destinations, raw-body quote-swallow, whitespace-around-dot, nested-config duplicate keys) are fixed and regression-tested.
- `make lint` clean; `make scan` clean on new files; full `go test ./...` green.

## Notes / deviations from the ticket

- Flags precede positionals (`--dry-run` first) — urfave/cli v2 stops flag parsing at the first positional, repo-wide; the ticket's trailing-flag example was adjusted in docs/help.
- Only dot access (`vars.old`) is rewritten; `vars["old"]` is not — matching the existing `lint`/`variables` limitation. Documented.
- `--format json`, auto-running lint, and `.tagconfig.json` updates were intentionally left out (ticket said "consider"; the last is a downstream project file, not template source).

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01APpwARzUG8cziQSDGwYWS3