### PR TITLE
docs: soften Serena rule to "prefer" for symbol-level ops

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,11 +3,11 @@
 ## Mandatory Rules
 
 1. Before pushing: `make lint` then `make test`
-2. Use **Serena MCP** for code operations:
-   - `get_symbols_overview` / `find_symbol` over full file reads
-   - `replace_symbol_body` / `insert_after_symbol` / `insert_before_symbol` over Edit/Write
+2. Prefer **Serena MCP** for symbol-level code operations:
+   - `get_symbols_overview` / `find_symbol` over full file reads when navigating
+   - `replace_symbol_body` / `insert_after_symbol` / `insert_before_symbol` for symbol edits
    - `find_referencing_symbols` for impact analysis before changes
-   - Reserve Write/Edit for new files or non-code files
+   - Edit/Write are fine for new files, non-code files, and non-symbol edits (imports, comments, formatting)
 3. Use **sequential thinking MCP** for complex reasoning
 4. Use **ref MCP** for library documentation lookups
 5. After code changes, update `.skills/` files if CLI commands, flags, behavior, or workflows changed


### PR DESCRIPTION
## Intent

Rule 2 in `CLAUDE.md` read as an absolute mandate — "Use **Serena MCP** for code operations ... over Edit/Write" — which misrepresents actual practice. Edit/Write are legitimate for new files, non-code files, and non-symbol changes (imports, comments, formatting). This rewords the rule so it matches how the tools are actually used.

## What changed

`CLAUDE.md` rule 2 only:
- "Use **Serena MCP** for code operations" → "Prefer **Serena MCP** for symbol-level code operations"
- Scoped the symbol-tool guidance to navigation and symbol edits
- Replaced "Reserve Write/Edit for new files or non-code files" with an explicit note that Edit/Write are fine for new files, non-code files, and non-symbol edits

Docs-only; no code or behavior change.