### PR TITLE
fix: strip quotes from inject after:/before: matchers

### DIFF
--- a/.skills/SKILL.md
+++ b/.skills/SKILL.md
@@ -46,6 +46,10 @@ Rename a template variable everywhere?
   → tag template rename-var --dry-run <old> <new>   (preview first)
   → tag template rename-var <old> <new>
 
+Which generator creates what, and in what order?
+  → tag template graph                              (creates, injects, markers, bundle order)
+  → tag template graph --format dot | dot -Tpng -o graph.png
+
 Test all boolean combinations?
   → tag test [template-dir]
 
@@ -262,6 +266,7 @@ my-project/
 | `tag template lint [path]` | Validate template (schema, syntax, vars) |
 | `tag template variables [path]` | Audit variable declarations vs usage (`--format json`, `--strict`) |
 | `tag template rename-var <old> <new> [path]` | Rename a variable across config and templates (`--dry-run`) |
+| `tag template graph [path]` | Visualize generator dependencies (`--format text\|json\|dot`) |
 | `tag convert cookiecutter <src> -o <dst>` | Convert Cookiecutter template |
 | `tag dialect list` | List available type-mapping dialects |
 | `tag dialect show <name>` | Show type mappings for a dialect |

--- a/.skills/reference.md
+++ b/.skills/reference.md
@@ -567,6 +567,36 @@ Only dot access is rewritten — `vars["old_name"]` is not recognised.
 
 Exit codes: `0` = applied or previewed, `1` = rename error (undeclared, name taken, path collision), `2` = usage error.
 
+### Dependency Graph
+
+```bash
+tag template graph                     # Analyze current directory
+tag template graph ./path/to/template  # Analyze a specific template
+tag template graph --format json       # Machine-readable output
+tag template graph --format dot | dot -Tpng -o graph.png
+```
+
+Flags must precede the positional argument.
+
+Builds the implicit dependency graph between generators by reading each template's frontmatter:
+
+- **Generators** — every generator with its actions (`create`, `inject`, `append`) and target paths. Inject actions also show the marker and clause, e.g. `[inject after "// ROUTES"]`.
+- **Bundles** — each bundle's generator execution order, flagged `valid` or `INVALID ORDER`. Order is invalid when a generator injects into a file that a *later* generator in the same bundle creates.
+- **Injection markers** — the marker strings actually found in the project's source files, with line numbers and the generators that reference them. Skips `.tag/`, `_generators/`, dotfiles, and binary files.
+
+Warnings (`code` in JSON output):
+
+| Code | Meaning |
+|------|---------|
+| `file_conflict` | Two or more generators create the same target file |
+| `missing_target` | A generator injects into a file no generator creates (often fine — the file may come from the scaffold) |
+| `order_violation` | A bundle injects into a file before the generator that creates it |
+| `malformed_metadata` | A template's frontmatter could not be extracted or parsed |
+
+Targets containing `{{ ... }}` are skipped by `missing_target`, since they cannot be resolved statically.
+
+Exit code is `0` even when warnings are present — `graph` reports, it does not gate. Use `2` for usage errors (unknown `--format`, more than one path argument).
+
 ### Cache Management
 
 ```bash

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -273,6 +273,27 @@ func TestIT_GenerateInjectAfter(t *testing.T) {
 	compareDirectories(t, expectedDir, workDir)
 }
 
+// TestIT_GenerateInjectAfterQuotedMarker verifies that a quoted `after:` marker
+// injects at the same place as an unquoted one. The quoted form is what the
+// tutorials, command docs, and shipped examples use, so it must resolve to the
+// bare marker text rather than being matched literally with its quotes.
+func TestIT_GenerateInjectAfterQuotedMarker(t *testing.T) {
+	testdataDir := getTestdataDir()
+	generatorDir := filepath.Join(testdataDir, "generators", "inject-after-quoted")
+	preExistingDir := filepath.Join(testdataDir, "pre-existing", "inject-after")
+	expectedDir := filepath.Join(testdataDir, "expected-generate-inject-after")
+
+	workDir := setupWorkDir(t, preExistingDir)
+
+	gen, err := engine.NewGenerator(false, generatorDir, "", io.Discard)
+	require.NoError(t, err)
+
+	_, err = gen.Generate(engine.Data{Name: "users"})
+	require.NoError(t, err)
+
+	compareDirectories(t, expectedDir, workDir)
+}
+
 // TestIT_GenerateInjectBefore tests the inject-before action.
 // It verifies that content is injected before a marker string in a pre-existing file.
 func TestIT_GenerateInjectBefore(t *testing.T) {

--- a/internal/integration/testdata/generators/inject-after-quoted/inject_after_quoted.tmpl
+++ b/internal/integration/testdata/generators/inject-after-quoted/inject_after_quoted.tmpl
@@ -1,0 +1,6 @@
+---
+to: app/router.go
+inject: true
+after: "// routes"
+---
+	mux.HandleFunc("/{{ name }}", {{ name }}Handler)

--- a/internal/template/metadata.go
+++ b/internal/template/metadata.go
@@ -176,11 +176,11 @@ func ParseMetadata(rendered string) (*Metadata, error) {
 
 		case fieldAfter:
 			meta.InjectClause = types.InjectAfter
-			meta.InjectMatcher = value
+			meta.InjectMatcher = unquote(value)
 
 		case fieldBefore:
 			meta.InjectClause = types.InjectBefore
-			meta.InjectMatcher = value
+			meta.InjectMatcher = unquote(value)
 
 		case fieldNotes:
 			meta.Notes = unquote(value)

--- a/internal/template/metadata_test.go
+++ b/internal/template/metadata_test.go
@@ -443,6 +443,82 @@ func TestUT_ParseMetadata_EmptyInjectMatcher(t *testing.T) {
 	assert.ErrorIs(t, err, ErrEmptyInjectMatcher)
 }
 
+func TestUT_ParseMetadata_QuotedInjectMatcher(t *testing.T) {
+	// Quoted after:/before: values are the form used throughout the docs and
+	// shipped examples; the surrounding quotes must not leak into the matcher,
+	// or injection fails at runtime with "no matching expression".
+	tests := []struct {
+		name     string
+		rendered string
+		clause   types.InjectClause
+		want     string
+	}{
+		{
+			name:     "double-quoted after",
+			rendered: "to: output/file.go\ninject: true\nafter: \"// ROUTES\"",
+			clause:   types.InjectAfter,
+			want:     "// ROUTES",
+		},
+		{
+			name:     "single-quoted after",
+			rendered: "to: output/file.go\ninject: true\nafter: '// ROUTES'",
+			clause:   types.InjectAfter,
+			want:     "// ROUTES",
+		},
+		{
+			name:     "double-quoted before",
+			rendered: "to: output/file.go\ninject: true\nbefore: \"// END routes\"",
+			clause:   types.InjectBefore,
+			want:     "// END routes",
+		},
+		{
+			name:     "quoted matcher containing an unbalanced paren",
+			rendered: "to: output/file.go\ninject: true\nafter: \"import (\"",
+			clause:   types.InjectAfter,
+			want:     "import (",
+		},
+		{
+			name:     "unquoted matcher is untouched",
+			rendered: "to: output/file.go\ninject: true\nafter: // ROUTES",
+			clause:   types.InjectAfter,
+			want:     "// ROUTES",
+		},
+		{
+			name:     "inner quotes are preserved",
+			rendered: "to: output/file.go\ninject: true\nafter: \"// tag:\"routes\"\"",
+			clause:   types.InjectAfter,
+			want:     "// tag:\"routes\"",
+		},
+		{
+			name:     "lone quote character is not stripped",
+			rendered: "to: output/file.go\ninject: true\nafter: \"",
+			clause:   types.InjectAfter,
+			want:     "\"",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			meta, err := ParseMetadata(tt.rendered)
+
+			require.NoError(t, err)
+			assert.Equal(t, ActionInject, meta.Action)
+			assert.Equal(t, tt.clause, meta.InjectClause)
+			assert.Equal(t, tt.want, meta.InjectMatcher)
+		})
+	}
+}
+
+func TestUT_ParseMetadata_EmptyQuotedInjectMatcher(t *testing.T) {
+	// `after: ""` unquotes to the empty string, which cannot match anything —
+	// reject it the same way a bare `after:` is rejected.
+	rendered := "to: output/file.go\ninject: true\nafter: \"\""
+
+	_, err := ParseMetadata(rendered)
+
+	assert.ErrorIs(t, err, ErrEmptyInjectMatcher)
+}
+
 func TestUT_ParseMetadata_OrphanInjectClause(t *testing.T) {
 	// after: without inject: true should be silently cleared
 	rendered := "to: output/file.go\nafter: // marker"


### PR DESCRIPTION
## Intent

Following TAG's own documentation produced a generator that could not run. Every tutorial, command doc, and shipped example writes the injection marker in quoted form:

```yaml
after: "// ROUTES"
```

That form fails at runtime:

```
tag error: cannot inject via matcher matcher="\"// ROUTES\"" clause=After
tag error: error when generating template: no matching expression
```

`ParseMetadata` assigned the raw value to `InjectMatcher` for `after:`/`before:`, while the adjacent `notes:`/`description:` cases already called `unquote()`. The writer then matches with a literal `strings.Index`, so the quotes were searched for as part of the marker text.

Only the Go test fixtures (`internal/engine/testdata/`, `internal/integration/testdata/`) used the unquoted form, which is why the suite stayed green while the docs were broken.

## What changed

- `internal/template/metadata.go` — `after:`/`before:` now call `unquote(value)`, matching how `notes:` and `description:` already behave. Two lines.
- `internal/template/metadata_test.go` — table test over double/single quoted, unquoted, a matcher containing an unbalanced paren (`"import ("`, straight from `.skills/recipes.md`), inner quotes preserved, and a lone quote character left alone. Plus `after: ""` now returns `ErrEmptyInjectMatcher` rather than silently producing a matcher that can never match.
- `internal/integration/testdata/generators/inject-after-quoted/` + `TestIT_GenerateInjectAfterQuotedMarker` — end-to-end guard reusing the existing pre-existing/expected fixtures, since the bug was only visible through the full parse → write chain. Confirmed non-vacuous: it fails when the fix is reverted.
- `.skills/SKILL.md`, `.skills/reference.md` — document `tag template graph`, which had no `.skills/` coverage (per CLAUDE.md rule 5). Documented exit codes and flag ordering were verified against the real binary.

## Verification

Real `tag generate` runs, both forms, before and after:

| Form | Before | After |
|---|---|---|
| `after: "// ROUTES"` | `no matching expression` | injects |
| `after: // ROUTES` | injects | injects |

Also scaffolded `examples/weather-api-go` and ran its `endpoint` generator — the quoted injection into `main.go` now lands correctly.

`make lint` → 0 issues. `make test` → green.

## Not addressed

Scaffolding `examples/weather-api-go` and running `tag generate endpoint` also hits a **separate pre-existing bug**: the generator ships a stub `_generators/endpoint/tag.template.json` (`{"vars": {}}`) and the generate engine treats it as a template file, failing with `missing required 'to' field`. Removing that file makes the example work. `internal/graph` already skips `tag.template.json` explicitly; the engine does not. Left out of scope — happy to file it separately.

Refs #236