### PR TITLE
fix: template lint/variables skip {% raw %} blocks (#332)

### DIFF
--- a/.skills/reference.md
+++ b/.skills/reference.md
@@ -528,6 +528,8 @@ Validates:
 - Gonja template syntax (parse-only, no execution)
 - `{{ vars.* }}` references against declared variables
 
+Comments (`{# ... #}`) and `{% raw %}...{% endraw %}` blocks are masked out before variable scanning, so a `{{ vars.* }}` written inside either is treated as literal text, not a reference.
+
 Exit codes: `0` = pass, `1` = lint errors, `2` = usage error.
 
 ### Variable Auditing
@@ -544,6 +546,7 @@ Cross-references declared variables in `tag.template.json` with usage in templat
 - Detects undeclared variables used in templates
 - Detects declared but unused variables
 - Scans generator-level configs inside `_generators/`
+- Comments and `{% raw %}...{% endraw %}` blocks are masked out before scanning — a variable referenced only inside one of them counts as unused, not used
 
 Exit codes: `0` = no issues (or non-strict), `1` = issues found (`--strict`), `2` = usage error.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `tag template lint` and `tag template variables` no longer scan the contents of `{% raw %}...{% endraw %}` blocks as live template expressions: a literal `{{ vars.* }}` inside a raw block is no longer reported as an undefined variable, and a variable referenced only inside a raw block is now correctly reported as unused (#332)
+
 ## [0.13.0] - 2026-03-03
 
 ### Changed

--- a/docs/commands/template.md
+++ b/docs/commands/template.md
@@ -206,7 +206,7 @@ tag template lint --format json
 - **Path placeholders** — Directory and file names containing `{{ vars.* }}` are checked.
 - **Binary files** — Automatically skipped.
 - **`.tagignore` patterns** — Ignored files are excluded from linting.
-- **Comments** — Template comments (`{# ... #}`) are stripped before variable scanning.
+- **Comments and raw blocks** — Template comments (`{# ... #}`) and `{% raw %}...{% endraw %}` blocks are masked out before variable scanning, so `{{ vars.* }}` written inside either is treated as literal text, not a reference.
 
 ---
 
@@ -275,7 +275,7 @@ Summary: 5 declared, 0 undeclared, 0 unused
 - `{% for item in vars.x %}` iteration references
 - Derived variable default expressions (`"default": "{{ vars.other }}"`)
 - Generator-level `tag.template.json` configs
-- Template comments (`{# ... #}`) are stripped before scanning
+- Template comments (`{# ... #}`) and `{% raw %}...{% endraw %}` blocks are masked out before scanning — a variable referenced only inside one of them counts as unused, not used
 - Binary files and `.tagignore` patterns are honored
 
 ---
@@ -373,7 +373,6 @@ Changes:
 **Limitations:**
 
 - Only dot access (`vars.old_name`) is rewritten. Subscript access (`vars["old_name"]`) is not recognised — the same limitation `tag template lint` and `tag template variables` have.
-- A `{% raw %}` block containing a literal `{{ vars.old_name }}` is correctly left alone, but `tag template lint` does not model raw blocks and will report it as an undefined variable afterwards.
 
 ---
 

--- a/internal/integration/renamevar_test.go
+++ b/internal/integration/renamevar_test.go
@@ -140,11 +140,10 @@ func TestIT_TemplateRenameVar_RewritesEveryLocation(t *testing.T) {
 	assert.Contains(t, main, "// {{ vars.service_name }}")
 }
 
-// Raw blocks and comments live in their own fixture because `tag template lint`
-// does not model either construct: its variable scan treats their contents as
-// real references, so a template that keeps a literal {{ vars.old }} inside
-// {% raw %} lints as an undefined variable after a rename. Leaving the literal
-// alone is still correct — rewriting it would change the generated output.
+// Raw blocks and comments live in their own fixture because the rewriter leaves
+// both verbatim — rewriting them would change the generated output. The linter
+// masks the same two constructs, so a template that deliberately keeps a literal
+// {{ vars.old }} inside {% raw %} still lints clean after a rename.
 func TestIT_TemplateRenameVar_LeavesRawBlocksAndCommentsLiteral(t *testing.T) {
 	t.Parallel()
 
@@ -165,6 +164,18 @@ func TestIT_TemplateRenameVar_LeavesRawBlocksAndCommentsLiteral(t *testing.T) {
 	assert.Contains(t, doc, "# {{ vars.service_name }}")
 	assert.Contains(t, doc, "{% raw %}Literal {{ vars.project_name }} stays literal.{% endraw %}")
 	assert.Contains(t, doc, "{# {{ vars.project_name }} in a comment #}")
+
+	// The old name survives only where it is literal output, so neither linter
+	// may report it: not undefined for lint, not a use for the variable report.
+	linter, err := lint.NewLinter(root)
+	require.NoError(t, err)
+	result, err := linter.Run()
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.ErrorCount(), "issues: %+v", result.Issues)
+
+	report, err := vars.Analyze(root)
+	require.NoError(t, err)
+	assert.Empty(t, report.Root.Undeclared)
 }
 
 func TestIT_TemplateRenameVar_DryRunIsAPreview(t *testing.T) {

--- a/internal/lint/checks.go
+++ b/internal/lint/checks.go
@@ -21,6 +21,7 @@ import (
 	"github.com/kaikenlabs/tag/internal/tmplconfig"
 	"github.com/kaikenlabs/tag/internal/types"
 	"github.com/kaikenlabs/tag/internal/validate"
+	"github.com/kaikenlabs/tag/internal/vars"
 )
 
 // varExprRegex matches {{ vars.NAME ... }} expressions, capturing the variable name.
@@ -28,9 +29,6 @@ var varExprRegex = regexp.MustCompile(`\{\{[^}]*\bvars\.([a-zA-Z_][a-zA-Z0-9_]*)
 
 // varStmtRegex matches {% ... vars.NAME ... %} statements (if, for, set, etc.).
 var varStmtRegex = regexp.MustCompile(`\{%[^%]*\bvars\.([a-zA-Z_][a-zA-Z0-9_]*)\b[^%]*%\}`)
-
-// commentRegex matches Gonja comments {# ... #}, including multi-line.
-var commentRegex = regexp.MustCompile(`(?s)\{#.*?#\}`)
 
 // VarRef holds a variable reference found in template content.
 type VarRef struct {
@@ -233,10 +231,10 @@ func (l *Linter) lintFileContent(absPath, relPath string) {
 
 // lintVariableRefs scans content for {{ vars.* }} references and checks against declared vars.
 func (l *Linter) lintVariableRefs(content, relPath string) {
-	// Strip comments before scanning, preserving newlines to keep line numbers accurate.
-	cleaned := commentRegex.ReplaceAllStringFunc(content, func(match string) string {
-		return strings.Repeat("\n", strings.Count(match, "\n"))
-	})
+	// Mask comments and {% raw %} blocks before scanning: their contents are
+	// emitted literally, not evaluated, so they are not variable references.
+	// Masking preserves newlines, so reported line numbers stay accurate.
+	cleaned := vars.MaskLiterals(content)
 
 	scanner := bufio.NewScanner(strings.NewReader(cleaned))
 	lineNum := 0

--- a/internal/lint/lint_test.go
+++ b/internal/lint/lint_test.go
@@ -405,6 +405,32 @@ func TestUT_CrossReference_MultilineComment_Ignored(t *testing.T) {
 	}
 }
 
+func TestUT_CrossReference_VarInRawBlock_Ignored(t *testing.T) {
+	dir := t.TempDir()
+	createTemplate(t, dir, validConfig, map[string]string{
+		"test.txt": "{% raw %}legendFormat: {{ vars.pod }}\nspans {{ vars.also_undefined }}\nlines{% endraw %}\n{{ vars.nonexistent }}",
+	})
+
+	linter, err := NewLinter(dir)
+	require.NoError(t, err)
+
+	result, err := linter.Run()
+	require.NoError(t, err)
+
+	var found []Issue
+	for _, issue := range result.Issues {
+		if issue.Rule == "undefined-variable" {
+			found = append(found, issue)
+		}
+	}
+
+	// Only the reference outside the raw block is a real reference, and masking
+	// the raw body must not shift the line it is reported on.
+	require.Len(t, found, 1, "issues: %+v", found)
+	assert.Contains(t, found[0].Message, "nonexistent")
+	assert.Equal(t, 4, found[0].Line)
+}
+
 // --- Multiple Errors Tests ---
 
 func TestUT_MultipleErrorsReported(t *testing.T) {

--- a/internal/vars/analyzer.go
+++ b/internal/vars/analyzer.go
@@ -25,9 +25,6 @@ var varExprRegex = regexp.MustCompile(`\{\{[^}]*\bvars\.([a-zA-Z_][a-zA-Z0-9_]*)
 // varStmtRegex matches {% ... vars.NAME ... %} statements (if, for, set, etc.).
 var varStmtRegex = regexp.MustCompile(`\{%[^%]*\bvars\.([a-zA-Z_][a-zA-Z0-9_]*)\b[^%]*%\}`)
 
-// commentRegex matches Gonja comments {# ... #}, including multi-line.
-var commentRegex = regexp.MustCompile(`(?s)\{#.*?#\}`)
-
 // Analyze scans a template directory and returns a Report of declared vs
 // referenced variables, including undeclared and unused findings.
 func Analyze(root string) (*Report, error) {
@@ -312,10 +309,9 @@ func scanFileContent(absPath, relPath string) map[string][]Reference {
 
 	refs := make(map[string][]Reference)
 
-	// Strip comments before scanning, preserving newlines for line numbers.
-	cleaned := commentRegex.ReplaceAllStringFunc(string(content), func(match string) string {
-		return strings.Repeat("\n", strings.Count(match, "\n"))
-	})
+	// Mask comments and {% raw %} blocks before scanning: their contents are not
+	// variable references. Masking preserves newlines, so line numbers hold.
+	cleaned := MaskLiterals(string(content))
 
 	scanner := bufio.NewScanner(strings.NewReader(cleaned))
 	lineNum := 0

--- a/internal/vars/analyzer_test.go
+++ b/internal/vars/analyzer_test.go
@@ -90,6 +90,37 @@ func TestUT_AnalyzeUnusedVariable(t *testing.T) {
 	assert.Equal(t, "unused_var", report.Root.Unused[0])
 }
 
+func TestUT_AnalyzeRawBlockNotCounted(t *testing.T) {
+	t.Parallel()
+
+	root := setupTemplate(t,
+		`{"vars": {"project_name": "myapp", "pod": {"type": "string", "prompt": "Pod"}}}`,
+		map[string]string{
+			"grafana.json": "{% raw %}legendFormat: {{ vars.pod }}{% endraw %}\n" +
+				"{% raw %}{{ vars.undeclared_in_raw }}\nspanning two lines{% endraw %}\n" +
+				"# {{ vars.project_name }}",
+		},
+	)
+
+	report, err := Analyze(root)
+	require.NoError(t, err)
+
+	// A raw-block mention is literal output, not a reference: it neither declares
+	// usage nor introduces an undeclared variable.
+	assert.Equal(t, []string{"pod"}, report.Root.Unused)
+	assert.Empty(t, report.Root.Undeclared)
+
+	// Masking is newline-preserving, so the one real reference keeps its line.
+	var refs []Reference
+	for _, dv := range report.Root.Declared {
+		if dv.Name == "project_name" {
+			refs = dv.References
+		}
+	}
+	require.Len(t, refs, 1)
+	assert.Equal(t, 4, refs[0].Line)
+}
+
 func TestUT_AnalyzeDerivedVariable(t *testing.T) {
 	t.Parallel()
 

--- a/internal/vars/mask.go
+++ b/internal/vars/mask.go
@@ -1,0 +1,106 @@
+package vars
+
+import (
+	"strings"
+)
+
+// MaskLiterals blanks the regions of a Gonja template whose contents are emitted
+// literally instead of evaluated — comments ({# #}) and {% raw %} blocks — so a
+// variable scan does not mistake their contents for references. A literal
+// {{ vars.pod }} kept inside a raw block is output, not a reference to `pod`.
+//
+// A masked span is replaced by the newlines it contains and nothing else, so
+// every line that survives keeps its original line number.
+//
+// Expression and statement blocks are copied verbatim and scanned quote-aware,
+// which stops a delimiter inside a string literal — {{ f("{# ") }} — from opening
+// a comment that was never there. An unterminated comment or raw block masks to
+// the end of input, matching Gonja's own "everything after the opener belongs to
+// it" behaviour.
+func MaskLiterals(src string) string {
+	var b strings.Builder
+	b.Grow(len(src))
+
+	i := 0
+	for i < len(src) {
+		switch {
+		case strings.HasPrefix(src[i:], cmntOpen):
+			i = maskComment(&b, src, i)
+
+		case strings.HasPrefix(src[i:], stmtOpen):
+			end := scanBlock(src, i+len(stmtOpen), stmtClose)
+			if end < 0 {
+				b.WriteString(src[i:])
+				return b.String()
+			}
+			if blockTag(src[i:end]) == rawTag {
+				i = maskRawBlock(&b, src, i)
+				continue
+			}
+			b.WriteString(src[i:end])
+			i = end
+
+		case strings.HasPrefix(src[i:], exprOpen):
+			end := scanBlock(src, i+len(exprOpen), exprClose)
+			if end < 0 {
+				b.WriteString(src[i:])
+				return b.String()
+			}
+			b.WriteString(src[i:end])
+			i = end
+
+		default:
+			b.WriteByte(src[i])
+			i++
+		}
+	}
+
+	return b.String()
+}
+
+// maskComment blanks the {# ... #} comment starting at start and returns the
+// index just past it.
+func maskComment(b *strings.Builder, src string, start int) int {
+	idx := strings.Index(src[start+len(cmntOpen):], cmntClose)
+	if idx < 0 {
+		blank(b, src[start:])
+		return len(src)
+	}
+	end := start + len(cmntOpen) + idx + len(cmntClose)
+	blank(b, src[start:end])
+	return end
+}
+
+// maskRawBlock blanks the {% raw %} tag starting at start, its literal body and
+// the closing {% endraw %}, returning the index just past the closing tag.
+//
+// As in skipRawBody, the search for the close tag is literal rather than
+// quote-aware: a raw body is plain text, so an unbalanced quote inside it must
+// not swallow the real {% endraw %} and everything after it.
+func maskRawBlock(b *strings.Builder, src string, start int) int {
+	i := start
+	for i < len(src) {
+		if !strings.HasPrefix(src[i:], stmtOpen) {
+			i++
+			continue
+		}
+		idx := strings.Index(src[i+len(stmtOpen):], stmtClose)
+		if idx < 0 {
+			break
+		}
+		end := i + len(stmtOpen) + idx + len(stmtClose)
+		if blockTag(src[i:end]) == endRawTag {
+			blank(b, src[start:end])
+			return end
+		}
+		i = end
+	}
+
+	blank(b, src[start:])
+	return len(src)
+}
+
+// blank writes only the newlines contained in span, discarding everything else.
+func blank(b *strings.Builder, span string) {
+	b.WriteString(strings.Repeat("\n", strings.Count(span, "\n")))
+}

--- a/internal/vars/mask_test.go
+++ b/internal/vars/mask_test.go
@@ -40,6 +40,11 @@ func TestUT_MaskLiterals_BlanksLiteralSpans(t *testing.T) {
 			want: "ab",
 		},
 		{
+			name: "endraw closed with a tab still terminates the block",
+			src:  "a{% raw %}{{ vars.x }}{% endraw\t%}{{ vars.later }}",
+			want: "a{{ vars.later }}",
+		},
+		{
 			name: "raw tag separated by newlines",
 			src:  "a{%\nraw\n%}{{ vars.x }}{%\nendraw\n%}b",
 			want: "a\n\n\n\nb",
@@ -175,5 +180,13 @@ func TestUT_MaskLiterals_PreservesLineCount(t *testing.T) {
 		"{% raw %}literal {{ vars.pod }}\nand more\n{% endraw %}\n" +
 		"{{ vars.tail }}\n"
 
-	assert.Equal(t, countNewlines(src), countNewlines(MaskLiterals(src)))
+	masked := MaskLiterals(src)
+
+	assert.Equal(t, countNewlines(src), countNewlines(masked))
+
+	// Line count alone would hold for a function that masked nothing, so pin that
+	// the spans really were removed while their newlines stayed behind.
+	assert.NotContains(t, masked, "vars.x")
+	assert.NotContains(t, masked, "vars.pod")
+	assert.Contains(t, masked, "{{ vars.tail }}")
 }

--- a/internal/vars/mask_test.go
+++ b/internal/vars/mask_test.go
@@ -1,0 +1,179 @@
+package vars
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUT_MaskLiterals_BlanksLiteralSpans(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "gonja comment",
+			src:  "a{# {{ vars.x }} #}b",
+			want: "ab",
+		},
+		{
+			name: "multi-line gonja comment",
+			src:  "a{# {{ vars.x }}\nstill a comment #}b",
+			want: "a\nb",
+		},
+		{
+			name: "raw block",
+			src:  "a{% raw %}{{ vars.x }}{% endraw %}b",
+			want: "ab",
+		},
+		{
+			name: "raw tag with no surrounding whitespace",
+			src:  "a{%raw%}{{ vars.x }}{%endraw%}b",
+			want: "ab",
+		},
+		{
+			name: "raw tag separated by tabs",
+			src:  "a{%\traw\t%}{{ vars.x }}{%\tendraw\t%}b",
+			want: "ab",
+		},
+		{
+			name: "raw tag separated by newlines",
+			src:  "a{%\nraw\n%}{{ vars.x }}{%\nendraw\n%}b",
+			want: "a\n\n\n\nb",
+		},
+		{
+			name: "raw block with whitespace control",
+			src:  "a{%- raw -%}{{ vars.x }}{%- endraw -%}b",
+			want: "ab",
+		},
+		{
+			name: "multi-line raw block keeps its newlines",
+			src:  "a{% raw %}{{ vars.x }}\n{{ vars.y }}\n{% endraw %}b",
+			want: "a\n\nb",
+		},
+		{
+			name: "comment nested inside a raw body is part of the raw span",
+			src:  "a{% raw %}{# {{ vars.x }} #}{% endraw %}b",
+			want: "ab",
+		},
+		{
+			name: "empty raw block",
+			src:  "a{% raw %}{% endraw %}b",
+			want: "ab",
+		},
+		{
+			name: "adjacent raw blocks",
+			src:  "a{% raw %}{{ vars.x }}{% endraw %}{% raw %}{{ vars.y }}{% endraw %}b",
+			want: "ab",
+		},
+		{
+			name: "raw block spanning the whole input",
+			src:  "{% raw %}{{ vars.x }}{% endraw %}",
+			want: "",
+		},
+		{
+			name: "CRLF inside a masked span keeps only the newline",
+			src:  "a{# {{ vars.x }}\r\nstill a comment #}b",
+			want: "a\nb",
+		},
+		{
+			name: "unterminated raw block masks to end of input",
+			src:  "a{% raw %}{{ vars.x }}\ntrailing",
+			want: "a\n",
+		},
+		{
+			name: "unterminated comment masks to end of input",
+			src:  "a{# {{ vars.x }}\ntrailing",
+			want: "a\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, MaskLiterals(tt.src))
+		})
+	}
+}
+
+func TestUT_MaskLiterals_LeavesRealReferencesIntact(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "expression outside any block",
+			src:  "{{ vars.x }}",
+			want: "{{ vars.x }}",
+		},
+		{
+			name: "expression after a closed raw block",
+			src:  "{% raw %}{{ vars.x }}{% endraw %}{{ vars.later }}",
+			want: "{{ vars.later }}",
+		},
+		{
+			name: "expression after a closed comment",
+			src:  "{# {{ vars.x }} #}{{ vars.later }}",
+			want: "{{ vars.later }}",
+		},
+		{
+			name: "unbalanced quote inside a raw body does not swallow the rest of the file",
+			src:  `{% raw %}{% set x = "oops %}{% endraw %}{{ vars.later }}`,
+			want: "{{ vars.later }}",
+		},
+		{
+			name: "raw tag inside a string literal does not open a raw block",
+			src:  `{{ f("{% raw %}") ~ vars.x }}{{ vars.later }}`,
+			want: `{{ f("{% raw %}") ~ vars.x }}{{ vars.later }}`,
+		},
+		{
+			name: "comment delimiter inside a string literal does not open a comment",
+			src:  `{{ f("{#") ~ vars.x }}{{ vars.later }}`,
+			want: `{{ f("{#") ~ vars.x }}{{ vars.later }}`,
+		},
+		{
+			name: "references on the same line either side of a raw block",
+			src:  "{{ vars.a }}{% raw %}{{ vars.b }}{% endraw %}{{ vars.c }}",
+			want: "{{ vars.a }}{{ vars.c }}",
+		},
+		{
+			name: "endraw without an opener is an ordinary statement block",
+			src:  "{% endraw %}{{ vars.later }}",
+			want: "{% endraw %}{{ vars.later }}",
+		},
+		{
+			name: "statement blocks are left alone",
+			src:  "{% if vars.x %}yes{% endif %}",
+			want: "{% if vars.x %}yes{% endif %}",
+		},
+		{
+			name: "plain text is untouched",
+			src:  "raw endraw {# not a comment",
+			want: "raw endraw ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, MaskLiterals(tt.src))
+		})
+	}
+}
+
+func TestUT_MaskLiterals_PreservesLineCount(t *testing.T) {
+	t.Parallel()
+
+	src := "# {{ vars.project_name }}\n" +
+		"{# a comment\nspanning {{ vars.x }}\nthree lines #}\n" +
+		"{% raw %}literal {{ vars.pod }}\nand more\n{% endraw %}\n" +
+		"{{ vars.tail }}\n"
+
+	assert.Equal(t, countNewlines(src), countNewlines(MaskLiterals(src)))
+}


### PR DESCRIPTION
## Intent

`tag template lint` and `tag template variables` scanned the contents of `{% raw %}...{% endraw %}` blocks as if they were live template expressions. A literal `{{ vars.pod }}` kept inside a raw block is emitted verbatim at render time — it is not a variable reference — but the linter reported it as an undefined variable, and a declared variable referenced *only* inside raw blocks was still counted as "used".

This was the visible seam left by #240 / #330: `rename-var` correctly skips raw blocks, so a template that intentionally keeps a literal `{{ vars.old_name }}` inside one would lint as an undefined variable right after a correct rename. The rename was right; the linter was wrong.

## What changed

- **`internal/vars/mask.go` (new)** — `MaskLiterals` blanks `{# comments #}` and `{% raw %}...{% endraw %}` spans, emitting only the newlines they contain so surviving findings keep their line numbers. It reuses the quote-aware `scanBlock` / `blockTag` that already back `rename-var`; the close-tag search stays deliberately **not** quote-aware, so a stray quote in a raw body cannot swallow the real `{% endraw %}`.
- **`internal/vars/analyzer.go` + `internal/lint/checks.go`** — both call it in place of the `commentRegex` each carried, so `lint`, `variables` and `rename-var` now agree on what is literal.
- **Docs** — retires the known-limitation note added by #330; `lint` / `variables` now document raw blocks alongside comments.

## Verification

All six acceptance criteria exercised through the built binary, not just unit tests. An unterminated `{% raw %}` or `{#` masks to EOF (matching Gonja), but never hides findings silently — the syntax check fails the file first and `lint` exits 1.

Reviewed adversarially by Codex and Antigravity plus quality-engineer and refactoring-expert agents. Every Blocker/Major claim was refuted against the built binary, shown pre-existing on `main`, or fixed; one upheld test-quality finding (a line-count assertion that passed against a no-op) is addressed in the second commit.

## Known limitation, deliberately out of scope

The variable scan is not quote-aware: `{{ replace("{{ vars.ghost }}") }}` reports `ghost` as undefined on `main` today and still does here. The old comment regex *accidentally* masked the `{# ... #}`-wrapped variant of this; that accident is gone, so the pre-existing false positive is now visible in one more shape. Fixing it properly means teaching the scan to skip string literals — which changes which variables count as used across every existing template. Follow-up ticket to come.

Closes #332

🤖 Generated with [Claude Code](https://claude.com/claude-code)