### PR TITLE
fix: recognise subscript var access vars["name"] in lint/variables/rename-var (#339)

### DIFF
--- a/.skills/reference.md
+++ b/.skills/reference.md
@@ -528,7 +528,7 @@ Validates:
 - Gonja template syntax (parse-only, no execution)
 - `{{ vars.* }}` references against declared variables
 
-Comments (`{# ... #}`), `{% raw %}...{% endraw %}` bodies, and string literals inside a `{{ }}` / `{% %}` block are never scanned for references — `{{ replace("{{ vars.ghost }}") }}` does not reference `ghost`. A `{% raw %}` tag's opening tag is scanned normally; only its body is skipped. Same reference rules as `rename-var` below, including the `vars["name"]` subscript limitation and `vars.0` being index access, not a variable named `0`.
+Comments (`{# ... #}`), `{% raw %}...{% endraw %}` bodies, and string literals inside a `{{ }}` / `{% %}` block are never scanned for references — `{{ replace("{{ vars.ghost }}") }}` does not reference `ghost`. A `{% raw %}` tag's opening tag is scanned normally; only its body is skipped. Same reference rules as `rename-var` below: dot access (`vars.name`) and literal subscript access (`vars["name"]` / `vars['name']`) both count as references, a non-literal subscript (`vars[expr]`) does not, and `vars.0` is index access, not a variable named `0`.
 
 Exit codes: `0` = pass, `1` = lint errors, `2` = usage error.
 
@@ -566,7 +566,7 @@ Left untouched: plain text, comments (`{# ... #}`), the body of `{% raw %}` bloc
 
 Planning is read-only, so `--dry-run` cannot write. A failed apply rolls back every file and path already changed.
 
-Only dot access is rewritten — `vars["old_name"]` is not recognised. A name must start with a letter or underscore: `vars.0` is index access, not a variable named `0`, and is never renamed.
+Dot access (`vars.old_name`) and literal subscript access (`vars["old_name"]` / `vars['old_name']`, whitespace-tolerant) are both rewritten; a non-literal subscript (`vars[expr]`) is left alone since its key is not statically known. A name must start with a letter or underscore: `vars.0` is index access, not a variable named `0`, and is never renamed.
 
 Exit codes: `0` = applied or previewed, `1` = rename error (undeclared, name taken, path collision), `2` = usage error.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `tag template lint`, `tag template variables` and `tag template rename-var` now recognise literal **subscript** variable access — `{{ vars["name"] }}` and `{{ vars['name'] }}` (whitespace-tolerant) — in addition to dot access. Subscript is the only way to reach a variable whose name collides with a Gonja keyword (e.g. `param.in`). Non-literal subscripts (`vars[expr]`) remain out of scope, since the key is not statically known (#339)
+
 ### Changed
+
+- **Potentially breaking**: because subscript access is now recognised (#339), templates that reference variables only through `vars["name"]` will produce findings they did not before — `tag template lint` can newly report an undeclared variable, and `tag template variables --strict` can flip a variable from unused to used. As with #337 this can change CI verdicts on templates whose source did not otherwise change; re-run once after upgrading. `tag template rename-var` now also rewrites subscript references, fixing a case where it renamed a declaration but left a live `vars["old"]` reference behind, silently corrupting the template (#339)
+
 
 - **Potentially breaking**: `tag template lint` and `tag template variables` now share the same quote-aware variable scanner as `tag template rename-var`, so all three commands agree on what counts as a `vars.*` reference. Because this scanner finds real references the old regex missed and stops treating string-literal lookalikes as references, both `tag template lint` and `tag template variables --strict` can change verdict — in either direction — on templates whose source did not otherwise change. Downstream template repos relying on either command in CI should re-run once after upgrading (#337)
 

--- a/docs/commands/template.md
+++ b/docs/commands/template.md
@@ -206,7 +206,7 @@ tag template lint --format json
 - **Path placeholders** — Directory and file names containing `{{ vars.* }}` are checked.
 - **Binary files** — Automatically skipped.
 - **`.tagignore` patterns** — Ignored files are excluded from linting.
-- **Comments, raw blocks, and string literals** — Template comments (`{# ... #}`), the body of `{% raw %}...{% endraw %}` blocks, and string literals inside a `{{ }}` / `{% %}` block are never scanned for references, so `{{ replace("{{ vars.ghost }}") }}` does not reference `ghost`. A `{% raw %}` tag's own opening tag is scanned like any other block — only its body is skipped. `tag template lint`, `tag template variables`, and `tag template rename-var` share this exact definition of a reference, including the `vars["name"]` subscript limitation (see `rename-var`'s "What is left alone" list below) and reading `vars.0` as index access, not a variable named `0`.
+- **Comments, raw blocks, and string literals** — Template comments (`{# ... #}`), the body of `{% raw %}...{% endraw %}` blocks, and string literals inside a `{{ }}` / `{% %}` block are never scanned for references, so `{{ replace("{{ vars.ghost }}") }}` does not reference `ghost`. A `{% raw %}` tag's own opening tag is scanned like any other block — only its body is skipped. `tag template lint`, `tag template variables`, and `tag template rename-var` share this exact definition of a reference. Both dot access (`vars.name`) and literal subscript access (`vars["name"]` / `vars['name']`, whitespace-tolerant) count as references; a non-literal subscript (`vars[expr]`) does not, because the key is not statically known. `vars.0` is read as index access, not a variable named `0`.
 
 ---
 
@@ -275,7 +275,7 @@ Summary: 5 declared, 0 undeclared, 0 unused
 - `{% for item in vars.x %}` iteration references
 - Derived variable default expressions (`"default": "{{ vars.other }}"`)
 - Generator-level `tag.template.json` configs
-- Template comments (`{# ... #}`), the body of `{% raw %}...{% endraw %}` blocks, and string literals inside a `{{ }}` / `{% %}` block are never scanned — a variable referenced only inside one of them counts as unused, not used. A `{% raw %}` tag's own opening tag is scanned like any other block — only its body is skipped. `tag template variables` shares this exact definition of a reference with `tag template lint` and `tag template rename-var`, including the `vars["name"]` subscript limitation (see `rename-var`'s "What is left alone" list below) and reading `vars.0` as index access, not a variable named `0`.
+- Template comments (`{# ... #}`), the body of `{% raw %}...{% endraw %}` blocks, and string literals inside a `{{ }}` / `{% %}` block are never scanned — a variable referenced only inside one of them counts as unused, not used. A `{% raw %}` tag's own opening tag is scanned like any other block — only its body is skipped. `tag template variables` shares this exact definition of a reference with `tag template lint` and `tag template rename-var`: dot access (`vars.name`) and literal subscript access (`vars["name"]` / `vars['name']`) both count, a non-literal subscript (`vars[expr]`) does not, and `vars.0` is read as index access, not a variable named `0`.
 - Binary files and `.tagignore` patterns are honored
 
 ---
@@ -372,7 +372,7 @@ Changes:
 
 **Limitations:**
 
-- Only dot access (`vars.old_name`) is rewritten. Subscript access (`vars["old_name"]`) is not recognised — the same limitation `tag template lint` and `tag template variables` have.
+- Dot access (`vars.old_name`) and literal subscript access (`vars["old_name"]` / `vars['old_name']`, whitespace-tolerant) are both rewritten — the same references `tag template lint` and `tag template variables` recognise. A non-literal subscript (`vars[expr]`) is left alone, because its key is not statically known.
 - A name must start with a letter or underscore. `vars.0` is read as index access, not a variable named `0`, and is never renamed.
 
 ---

--- a/internal/integration/renamevar_test.go
+++ b/internal/integration/renamevar_test.go
@@ -178,6 +178,47 @@ func TestIT_TemplateRenameVar_LeavesRawBlocksAndCommentsLiteral(t *testing.T) {
 	assert.Empty(t, report.Root.Undeclared)
 }
 
+// TestIT_TemplateRenameVar_RewritesSubscriptAccess is the regression for issue
+// #339: before the fix, rename-var renamed the declaration but left a live
+// {{ vars["old"] }} subscript reference pointing at a variable that no longer
+// existed — a successful apply that silently corrupted the template. Renaming a
+// declaration reached only through subscript access (single and double quotes)
+// must rewrite those references too, so the template still lints clean after.
+func TestIT_TemplateRenameVar_RewritesSubscriptAccess(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeFixture(t, root, map[string]string{
+		"tag.template.json": `{"name": "sub", "vars": {"declared": {"type": "string", "default": "d"}}}`,
+		"body.txt":          `{{ vars["declared"] }} and {{ vars['declared'] }}`,
+	})
+
+	// The fixture must start clean, otherwise the post-rename assertion is vacuous.
+	before, err := vars.Analyze(root)
+	require.NoError(t, err)
+	require.False(t, before.HasIssues(), "fixture should start with no variable issues")
+
+	plan, err := vars.PlanRename(root, "declared", "renamed")
+	require.NoError(t, err)
+	require.NoError(t, plan.Apply())
+
+	body := readFile(t, root, "body.txt")
+	assert.Equal(t, `{{ vars["renamed"] }} and {{ vars['renamed'] }}`, body,
+		"both single- and double-quoted subscript keys must be rewritten")
+
+	// The declaration and every reference moved together: nothing dangling.
+	after, err := vars.Analyze(root)
+	require.NoError(t, err)
+	assert.False(t, after.HasIssues(),
+		"rename must not leave a live subscript reference behind")
+
+	linter, err := lint.NewLinter(root)
+	require.NoError(t, err)
+	result, err := linter.Run()
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.ErrorCount(), "issues: %+v", result.Issues)
+}
+
 func TestIT_TemplateRenameVar_DryRunIsAPreview(t *testing.T) {
 	t.Parallel()
 

--- a/internal/integration/varscan_test.go
+++ b/internal/integration/varscan_test.go
@@ -27,16 +27,22 @@ Defect 2 (greedy regex): {{ vars.alpha ~ vars.beta }}
 Defect 3 (attribute path): {{ cfg.vars.attrname }}
 Defect 4 (multi-line block): {{ vars.spans
     ~ vars.lines }}
+Subscript (issue #339): {{ vars["subbed"] }} and {{ vars['single'] }}
+Subscript lookalike: {{ myvars["notref"] }}
 `
 
 // varScanFixtureCandidates is every name mentioned in varScanFixtureBody,
 // real reference or lookalike.
-var varScanFixtureCandidates = []string{"ghost", "alpha", "beta", "attrname", "spans", "lines"}
+var varScanFixtureCandidates = []string{
+	"ghost", "alpha", "beta", "attrname", "spans", "lines",
+	"subbed", "single", "notref",
+}
 
 // varScanFixtureRealRefs is the subset of varScanFixtureCandidates that are
-// true vars.* references. "ghost" and "attrname" are deliberately excluded:
-// they are lookalikes, not references.
-var varScanFixtureRealRefs = []string{"alpha", "beta", "lines", "spans"}
+// true vars.* references. "ghost", "attrname" and "notref" are deliberately
+// excluded: they are lookalikes, not references. "subbed" and "single" are
+// subscript references, real since issue #339.
+var varScanFixtureRealRefs = []string{"alpha", "beta", "lines", "single", "spans", "subbed"}
 
 // TestIT_TemplateVarScan_ThreeCommandsAgree proves lint, the variables report
 // and rename-var agree on exactly the real references in one fixture built

--- a/internal/vars/rewrite.go
+++ b/internal/vars/rewrite.go
@@ -15,6 +15,7 @@ const (
 	rawTag     = "raw"
 	endRawTag  = "endraw"
 	varsPrefix = "vars."
+	varsToken  = "vars"
 )
 
 // renameInExpressions rewrites `vars.<oldName>` to `vars.<newName>` inside Gonja
@@ -191,6 +192,82 @@ func skipQuoted(src string, i int) int {
 	return len(src)
 }
 
+// subscriptRef describes a `vars["name"]` subscript reference located inside a
+// block. name is the key's bytes; keyOpen and keyClose index the opening and
+// closing quote of the key; end is the index just past the closing `]`.
+type subscriptRef struct {
+	name     string
+	keyOpen  int
+	keyClose int
+	end      int
+}
+
+// matchSubscript reports whether block[i:] begins a `vars["name"]` subscript
+// reference and, if so, describes it. i must point at the candidate `vars`
+// token. It accepts single or double quotes and tolerates whitespace around the
+// token, the brackets and the key, matching Gonja's subscript grammar so
+// `vars [ "x" ]` is recognised. The key bytes are taken literally, so the name
+// is not restricted to a bare identifier beyond its first byte — subscript
+// access exists precisely to reach names like "param.in".
+//
+// Two forms are deliberately not matched: a non-literal subscript (`vars[expr]`,
+// whose key is not statically known) and a key whose first byte is not a letter
+// or underscore (`vars["0bad"]`, index access — the same letter/underscore-start
+// rule dot access applies). Both keep the scanner and the rename walker
+// enumerating the same names.
+//
+// The left-context guard (isWholeReference) is the caller's job, so
+// `cfg.vars["x"]` and `myvars["x"]` are rejected exactly as their dot-access
+// equivalents are.
+func matchSubscript(block string, i int) (subscriptRef, bool) {
+	if !strings.HasPrefix(block[i:], varsToken) {
+		return subscriptRef{}, false
+	}
+	j := skipSpace(block, i+len(varsToken))
+	if j >= len(block) || block[j] != '[' {
+		return subscriptRef{}, false
+	}
+	j = skipSpace(block, j+1)
+	if j >= len(block) || (block[j] != '\'' && block[j] != '"') {
+		return subscriptRef{}, false
+	}
+	keyOpen := j
+	if keyOpen+1 >= len(block) || !isIdentStartByte(block[keyOpen+1]) {
+		return subscriptRef{}, false
+	}
+	keyEnd := skipQuoted(block, keyOpen) // index just past the closing quote
+	// skipQuoted consumes the rest of the block on an unterminated literal; a
+	// real subscript must have a matching closing quote.
+	if keyEnd <= keyOpen+1 || block[keyEnd-1] != block[keyOpen] {
+		return subscriptRef{}, false
+	}
+	j = skipSpace(block, keyEnd)
+	if j >= len(block) || block[j] != ']' {
+		return subscriptRef{}, false
+	}
+	return subscriptRef{
+		name:     block[keyOpen+1 : keyEnd-1],
+		keyOpen:  keyOpen,
+		keyClose: keyEnd - 1,
+		end:      j + 1,
+	}, true
+}
+
+// skipSpace returns the index of the first non-whitespace byte at or after i,
+// skipping the spaces, tabs, carriage returns and newlines Gonja tolerates
+// inside an expression.
+func skipSpace(block string, i int) int {
+	for i < len(block) {
+		switch block[i] {
+		case ' ', '\t', '\r', '\n':
+			i++
+		default:
+			return i
+		}
+	}
+	return i
+}
+
 // rewriteBlock replaces vars.<oldName> with vars.<newName> inside a single
 // block, skipping string literals, and adds the number of replacements to count.
 func rewriteBlock(block, oldName, newName string, count *int) string {
@@ -206,6 +283,22 @@ func rewriteBlock(block, oldName, newName string, count *int) string {
 			end := skipQuoted(block, i)
 			b.WriteString(block[i:end])
 			i = end
+			continue
+		}
+		// Subscript access: vars["oldName"]. The key is a quoted run, so it must
+		// be recognised here before the quote branch above would consume it
+		// verbatim. Rewriting swaps only the key's bytes, preserving quote style
+		// and surrounding whitespace.
+		if m, ok := matchSubscript(block, i); ok && isWholeReference(block, i, len(varsToken)) {
+			if m.name == oldName {
+				b.WriteString(block[i : m.keyOpen+1])
+				b.WriteString(newName)
+				b.WriteString(block[m.keyClose:m.end])
+				*count++
+			} else {
+				b.WriteString(block[i:m.end])
+			}
+			i = m.end
 			continue
 		}
 		if strings.HasPrefix(block[i:], needle) && isWholeReference(block, i, len(needle)) {

--- a/internal/vars/rewrite_test.go
+++ b/internal/vars/rewrite_test.go
@@ -341,3 +341,81 @@ func countNewlines(s string) int {
 	}
 	return n
 }
+
+// TestUT_RenameInExpressions_SubscriptAccess covers issue #339: rename-var
+// rewrites the key of a vars["old"] / vars['old'] subscript reference,
+// preserving quote style and whitespace, and leaves lookalikes alone.
+func TestUT_RenameInExpressions_SubscriptAccess(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		src   string
+		want  string
+		count int
+	}{
+		{
+			name:  "double-quoted subscript",
+			src:   `{{ vars["old"] }}`,
+			want:  `{{ vars["new"] }}`,
+			count: 1,
+		},
+		{
+			name:  "single-quoted subscript",
+			src:   `{{ vars['old'] }}`,
+			want:  `{{ vars['new'] }}`,
+			count: 1,
+		},
+		{
+			name:  "whitespace around brackets is preserved",
+			src:   `{{ vars [ "old" ] }}`,
+			want:  `{{ vars [ "new" ] }}`,
+			count: 1,
+		},
+		{
+			name:  "subscript and dot access in one block",
+			src:   `{{ vars["old"] ~ vars.old }}`,
+			want:  `{{ vars["new"] ~ vars.new }}`,
+			count: 2,
+		},
+		{
+			name:  "subscript in a statement block",
+			src:   `{% if vars["old"] %}x{% endif %}`,
+			want:  `{% if vars["new"] %}x{% endif %}`,
+			count: 1,
+		},
+		{
+			name:  "attribute path is left alone",
+			src:   `{{ cfg.vars["old"] }}`,
+			want:  `{{ cfg.vars["old"] }}`,
+			count: 0,
+		},
+		{
+			name:  "longer identifier is left alone",
+			src:   `{{ myvars["old"] }}`,
+			want:  `{{ myvars["old"] }}`,
+			count: 0,
+		},
+		{
+			name:  "a different subscript key is left alone",
+			src:   `{{ vars["other"] }}`,
+			want:  `{{ vars["other"] }}`,
+			count: 0,
+		},
+		{
+			name:  "non-literal subscript is left alone",
+			src:   `{{ vars[old] }}`,
+			want:  `{{ vars[old] }}`,
+			count: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, n := renameInExpressions(tt.src, "old", "new")
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.count, n)
+		})
+	}
+}

--- a/internal/vars/scan.go
+++ b/internal/vars/scan.go
@@ -110,6 +110,17 @@ func scanBlockRefs(refs []ScannedRef, block string, startLine int) []ScannedRef 
 			continue
 		}
 
+		// Subscript access: vars["name"]. Recognised before the dot form and
+		// before the quote branch above would consume the key, using the same
+		// shared matcher as rewriteBlock so the scanner and the rename walker
+		// agree on it by construction.
+		if m, ok := matchSubscript(block, i); ok && isWholeReference(block, i, len(varsToken)) {
+			refs = append(refs, ScannedRef{Name: m.name, Line: line})
+			line += strings.Count(block[i:m.end], "\n")
+			i = m.end
+			continue
+		}
+
 		if strings.HasPrefix(block[i:], varsPrefix) {
 			nameStart := i + len(varsPrefix)
 			// A name must begin with a letter or underscore. Gonja reads the

--- a/internal/vars/scan_fuzz_test.go
+++ b/internal/vars/scan_fuzz_test.go
@@ -13,6 +13,15 @@ import (
 // as well as the "both sides should" one.
 var candidateNamePattern = regexp.MustCompile(`vars\.([a-zA-Z_][a-zA-Z0-9_]*)`)
 
+// subscriptNamePattern is the subscript-access counterpart of
+// candidateNamePattern, added for issue #339: it enumerates the names reachable
+// through vars["name"] / vars['name'] so the differential check below actually
+// exercises the subscript form. Like candidateNamePattern it is a deliberately
+// naive superset (it ignores context and mismatched quotes); over-matching is
+// safe because ScanRefs and renameInExpressions share matchSubscript and so
+// agree on any name — a spurious candidate simply yields 0 == 0.
+var subscriptNamePattern = regexp.MustCompile(`vars\s*\[\s*["']([a-zA-Z_][a-zA-Z0-9_.]*)["']\s*\]`)
+
 // FuzzScanRefsAgreesWithRenameWalker is the structural guard behind issue #337:
 // `tag template lint`, `tag template variables` (via ScanRefs) and
 // `tag template rename-var` (via renameInExpressions) must agree on what counts
@@ -41,6 +50,16 @@ func FuzzScanRefsAgreesWithRenameWalker(f *testing.F) {
 		"vars.plaintext",
 		"{{ vars. }}",
 		"{{ vars.a.b[0] }}",
+		`{{ vars["sub"] }}`,
+		`{{ vars['single'] }}`,
+		`{{ vars [ "spaced" ] }}`,
+		`{{ vars["dotted.name"] }}`,
+		`{{ vars["mix"] ~ vars.mix }}`,
+		`{{ cfg.vars["attr"] }}`,
+		`{{ myvars["look"] }}`,
+		`{{ vars[dynamic] }}`,
+		`{{ vars["0bad"] }}`,
+		`{{ replace("vars[\"ghost\"]") }}`,
 	}
 	for _, s := range seeds {
 		f.Add(s)
@@ -60,8 +79,12 @@ func FuzzScanRefsAgreesWithRenameWalker(f *testing.F) {
 			}
 		}
 
+		var candidates [][]string
+		candidates = append(candidates, candidateNamePattern.FindAllStringSubmatch(src, -1)...)
+		candidates = append(candidates, subscriptNamePattern.FindAllStringSubmatch(src, -1)...)
+
 		seen := make(map[string]struct{})
-		for _, m := range candidateNamePattern.FindAllStringSubmatch(src, -1) {
+		for _, m := range candidates {
 			name := m[1]
 			if _, ok := seen[name]; ok {
 				continue

--- a/internal/vars/scan_test.go
+++ b/internal/vars/scan_test.go
@@ -540,3 +540,90 @@ func TestUT_ScanRefs_DeliberateEdgeCases(t *testing.T) {
 		})
 	}
 }
+
+// TestUT_ScanRefs_SubscriptAccess covers issue #339: the scanner recognises
+// vars["name"] / vars['name'] subscript references, with the same left-context
+// guard and letter/underscore-start rule as dot access.
+func TestUT_ScanRefs_SubscriptAccess(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		src  string
+		want []ScannedRef
+	}{
+		{
+			name: "double-quoted subscript",
+			src:  `{{ vars["declared"] }}`,
+			want: []ScannedRef{{Name: "declared", Line: 1}},
+		},
+		{
+			name: "single-quoted subscript",
+			src:  `{{ vars['declared'] }}`,
+			want: []ScannedRef{{Name: "declared", Line: 1}},
+		},
+		{
+			name: "subscript and dot access mixed in one block",
+			src:  `{{ vars["a"] ~ vars.b }}`,
+			want: []ScannedRef{{Name: "a", Line: 1}, {Name: "b", Line: 1}},
+		},
+		{
+			name: "whitespace around brackets and key",
+			src:  `{{ vars [ "spaced" ] }}`,
+			want: []ScannedRef{{Name: "spaced", Line: 1}},
+		},
+		{
+			name: "keyword-collision key with a dot",
+			src:  `{{ vars["param.in"] }}`,
+			want: []ScannedRef{{Name: "param.in", Line: 1}},
+		},
+		{
+			name: "subscript inside a statement block",
+			src:  `{% if vars["flag"] %}x{% endif %}`,
+			want: []ScannedRef{{Name: "flag", Line: 1}},
+		},
+		{
+			// Attribute path and longer identifier must be rejected, exactly as
+			// for dot access (cfg.vars.x / myvars.x).
+			name: "attribute path is not a reference",
+			src:  `{{ cfg.vars["x"] }}`,
+			want: nil,
+		},
+		{
+			name: "longer identifier is not a reference",
+			src:  `{{ myvars["y"] }}`,
+			want: nil,
+		},
+		{
+			// A non-literal subscript key is not statically known, so no command
+			// can act on it: deliberately not a reference (documented limitation).
+			name: "non-literal subscript is not a reference",
+			src:  `{{ vars[some_expr] }}`,
+			want: nil,
+		},
+		{
+			// Consistent with dot access: a name must start with a letter or
+			// underscore, so a digit-leading key is index access, not a variable.
+			name: "digit-leading key is not a reference",
+			src:  `{{ vars["0bad"] }}`,
+			want: nil,
+		},
+		{
+			name: "subscript key mentioned in a string literal is not a reference",
+			src:  `{{ replace("vars[\"ghost\"]") }}`,
+			want: nil,
+		},
+		{
+			name: "line number of a subscript inside a multi-line block",
+			src:  "{{ vars.first\n    ~ vars[\"second\"] }}",
+			want: []ScannedRef{{Name: "first", Line: 1}, {Name: "second", Line: 2}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, ScanRefs(tt.src))
+		})
+	}
+}


### PR DESCRIPTION
## Intent

Make the three variable-aware template commands — `tag template lint`, `tag template variables`, `tag template rename-var` — recognise **literal subscript access** (`{{ vars["name"] }}` / `{{ vars['name'] }}`) in addition to dot access. Subscript is the only way to reach a variable whose name collides with a Gonja keyword (e.g. `param.in`), which `.skills/reference.md` already tells authors to use.

Before this, the blind spot was not merely cosmetic:
- `lint` reported templates referencing an **undeclared** variable via subscript as valid (false negative in its one check).
- `variables` reported a **used** variable as unused (failing `--strict` CI on a correct template).
- `rename-var` renamed the declaration but left a live `{{ vars["old"] }}` reference dangling — a **successful apply that silently corrupted the template**.

## What changed

Per #337, reference recognition lives in one place, so this is a single-site fix:

- **`internal/vars/rewrite.go`** — new shared `matchSubscript` helper (+ `skipSpace`). Whitespace-tolerant, requires a letter/underscore-start key (consistent with dot access), rejects non-literal `vars[expr]`. `rewriteBlock` swaps only the key bytes, preserving quote style and whitespace.
- **`internal/vars/scan.go`** — `scanBlockRefs` uses the same `matchSubscript` + `isWholeReference` guard, so the scanner and rename walker agree by construction (`cfg.vars["x"]` / `myvars["x"]` rejected exactly as their dot equivalents).
- **Tests** — subscript unit tests for both scan and rewrite; fuzz oracle extended to enumerate subscript names (+ seeds); `TestIT_TemplateVarScan_ThreeCommandsAgree` fixture extended; new rename-then-lint-clean IT (`TestIT_TemplateRenameVar_RewritesSubscriptAccess`).
- **Docs** — `docs/commands/template.md` (3 spots), `.skills/reference.md` (2 spots), `CHANGELOG.md`.

## Design decisions (per ticket)

- **Non-literal subscript `vars[expr]`** is out of scope — the key is not statically known, so no command can act on it. Documented and tested as the remaining limitation.
- **Whitespace variants** `vars [ "x" ]` are recognised (matches Gonja's subscript grammar), consistently across all three commands.
- **Potentially breaking**: templates using subscript access will now produce findings they never did before (newly-detected undeclared vars; unused→used flips), so CI verdicts can change on unchanged templates. Called out in the CHANGELOG.

## Verification

- Real-CLI smoke test of the ticket's exact reproduction: `lint` flags `undeclared_one`, `variables` counts `declared` as used, `rename-var` rewrites both quote styles.
- `make lint` clean, `make test` green, `FuzzScanRefsAgreesWithRenameWalker` clean for 30s.
- Independent peer review (Codex) of the byte-index logic and scan/rewrite agreement — no correctness bugs found.

Closes #339